### PR TITLE
Changing JMS Inbound timeouts

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
@@ -108,7 +108,7 @@ public class JMSPollingConsumer {
             session = jmsConnectionFactory.getSession(connection);
             destination = jmsConnectionFactory.getDestination(connection);
             messageConsumer = jmsConnectionFactory.getMessageConsumer(session, destination);
-            Message msg = messageConsumer.receive(1);
+            Message msg = messageConsumer.receive();
             if (msg == null) {
                 logger.debug("Inbound JMS Endpoint. No JMS message received.");
                 return null;
@@ -179,7 +179,7 @@ public class JMSPollingConsumer {
                 } else {
                     return msg;
                 }
-                msg = messageConsumer.receive(1);
+                msg = messageConsumer.receive();
             }
 
         } catch (JMSException e) {


### PR DESCRIPTION
Some MBs like WSO2 MB cannot read within a millisecond.
this is to fix that issue by removing timeout : http://docs.oracle.com/javaee/1.4/api/javax/jms/MessageConsumer.html#receive(long)

Credit goes to @sandamal for figuring out this.