### PR TITLE
Removing_destroyCurrentContext_in_WSO2Registry

### DIFF
--- a/components/mediation-registry/org.wso2.carbon.mediation.registry/src/main/java/org/wso2/carbon/mediation/registry/WSO2Registry.java
+++ b/components/mediation-registry/org.wso2.carbon.mediation.registry/src/main/java/org/wso2/carbon/mediation/registry/WSO2Registry.java
@@ -718,7 +718,6 @@ public class WSO2Registry extends AbstractRegistry {
      *  Carbon Kernel mandates to set Threadlocal before calling anything in kernel
      */
     private void setTenantInfo() {
-    	PrivilegedCarbonContext.destroyCurrentContext();
         PrivilegedCarbonContext cc = PrivilegedCarbonContext.getThreadLocalCarbonContext();
         cc.setTenantDomain(domain);
         cc.setTenantId(tenantId);


### PR DESCRIPTION
`PrivilegedCarbonContext.destroyCurrentContext();`
Caused issue with eager loading tenants. 
This fix is to remove it.

