### PR TITLE
Backend changes to return boolean instead of void

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.mediation.library/src/main/java/org/wso2/carbon/mediation/library/service/MediationLibraryAdminService.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.library/src/main/java/org/wso2/carbon/mediation/library/service/MediationLibraryAdminService.java
@@ -421,7 +421,7 @@ public class MediationLibraryAdminService extends AbstractServiceBusAdmin {
 	 * @param status
 	 * @throws AxisFault
 	 */
-	public void updateStatus(String libQName, String libName, String packageName, String status)
+	public boolean updateStatus(String libQName, String libName, String packageName, String status)
 	                                                                                            throws AxisFault {
 		try {
 			SynapseConfiguration configuration = getSynapseConfiguration();
@@ -453,6 +453,7 @@ public class MediationLibraryAdminService extends AbstractServiceBusAdmin {
 			String message = "Unable to update status for :  " + libQName;
 			handleException(log, message, e);
 		}
+        return true;
 	}
     
 	/**

--- a/components/mediation-admin/org.wso2.carbon.task/src/main/java/org/wso2/carbon/task/CarbonTaskManagementService.java
+++ b/components/mediation-admin/org.wso2.carbon.task/src/main/java/org/wso2/carbon/task/CarbonTaskManagementService.java
@@ -48,7 +48,7 @@ public class CarbonTaskManagementService extends AbstractAdmin {
     public CarbonTaskManagementService() {
     }
 
-    public void addTaskDescription(OMElement taskElement) throws TaskManagementException {
+    public boolean addTaskDescription(OMElement taskElement) throws TaskManagementException {
 
         if (log.isDebugEnabled()) {
             log.debug("Add TaskDescription - Get a Task configuration  :" + taskElement);
@@ -68,9 +68,10 @@ public class CarbonTaskManagementService extends AbstractAdmin {
             }
             handleException("Error creating a task : " + e.getMessage(), e);            
         }
+        return true;
     }
 
-    public void deleteTaskDescription(String s, String group) throws TaskManagementException {
+    public boolean deleteTaskDescription(String s, String group) throws TaskManagementException {
 
         validateName(s);
         if (log.isDebugEnabled()) {
@@ -83,6 +84,7 @@ public class CarbonTaskManagementService extends AbstractAdmin {
             handleException("Error deleting a task with name : " + s + " : " +
                     e.getMessage(), e);
         }
+        return true;
     }
 
     public void editTaskDescription(OMElement taskElement) throws TaskManagementException {


### PR DESCRIPTION
Many important operations in ```MediationLibraryAdminService``` and ```CarbonTaskManagementService``` had returned void as the final result. That caused problems with external applications with exceptions such as 'Input Stream null'. 
This changes some of those to return boolean values instead void.