### PR TITLE
ESBJAVA-3761 - SynapseXPath error

### DIFF
--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.validate.ui/src/main/resources/web/validate-mediator/edit-mediator.jsp
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.validate.ui/src/main/resources/web/validate-mediator/edit-mediator.jsp
@@ -99,7 +99,7 @@
 
                                         if (schemaKey != null) {
                                             showValue = schemaKey.getKeyValue();
-                                            synapseXPath = schemaKey.getExpression();
+                                            synapseXPath = (SynapseXPath) schemaKey.getExpression();
 
                                             isStaticKey = showValue != null && !"".equals(showValue);
 


### PR DESCRIPTION
SynaspsePath cast to SynapseXPath since schemaKey.getExpression() method changed.