### PR TITLE
Fixing https://wso2.org/jira/browse/ESBJAVA-3950

### DIFF
--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.enqueue.ui/pom.xml
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.enqueue.ui/pom.xml
@@ -57,6 +57,8 @@
                             org.jaxen,
                             org.wso2.carbon.priority.executors.stub.*,
                             org.apache.axiom.om; version="${axiom.osgi.version.range}",
+                            javax.servlet.http;version="${imp.pkg.version.javax.servlet}",
+                            javax.servlet;version="${imp.pkg.version.javax.servlet}",
                             *;resolution:=optional
                         </Import-Package>
                     </instructions>


### PR DESCRIPTION
Imported the servlet api related packages explicitly. The issue occurred due to implicit import of non existing version.