### PR TITLE
Removed the full zookeeper exception log

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/kafka/KAFKAMessageListener.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/kafka/KAFKAMessageListener.java
@@ -57,10 +57,9 @@ public class KAFKAMessageListener extends AbstractKafkaMessageListener {
             isCreated = true;
         } catch (ZkTimeoutException toe) {
             logger.error(" Error in Creating Kafka Consumer Connector | ZkTimeout"
-                    + toe.getMessage(),toe);
+                    + toe.getMessage());
             throw new SynapseException(
-                    " Error in Creating Kafka Consumer Connector| ZkTimeout",
-                    toe);
+                    " Error in Creating Kafka Consumer Connector| ZkTimeout");
 
         } catch (Exception e) {
             logger.error(" Error in Creating Kafka Consumer Connector."

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/kafka/KAFKAPollingConsumer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/kafka/KAFKAPollingConsumer.java
@@ -144,7 +144,7 @@ public class KAFKAPollingConsumer {
                 return null;
             }
         } catch (Exception e) {
-            logger.error(e.getMessage(),e);
+            logger.error(e.getMessage());
             return null;
         }
         //Inject the messages to the sequence


### PR DESCRIPTION
Between every time interval,the zookeeper exception is printed in the ESB. The PR is for removing that.

Before this fix
------------------
[2015-07-28 15:40:07,298] ERROR - KAFKAMessageListener  Error in Creating Kafka Consumer Connector | ZkTimeoutUnable to connect to zookeeper server within timeout: 6000
org.I0Itec.zkclient.exception.ZkTimeoutException: Unable to connect to zookeeper server within timeout: 6000
	at org.I0Itec.zkclient.ZkClient.connect(ZkClient.java:880)
	at org.I0Itec.zkclient.ZkClient.<init>(ZkClient.java:98)
	at org.I0Itec.zkclient.ZkClient.<init>(ZkClient.java:84)
	at kafka.consumer.ZookeeperConsumerConnector.connectZk(ZookeeperConsumerConnector.scala:156)
	at kafka.consumer.ZookeeperConsumerConnector.<init>(ZookeeperConsumerConnector.scala:114)
	at kafka.javaapi.consumer.ZookeeperConsumerConnector.<init>(ZookeeperConsumerConnector.scala:65)
	at kafka.javaapi.consumer.ZookeeperConsumerConnector.<init>(ZookeeperConsumerConnector.scala:67)
	at kafka.consumer.Consumer$.createJavaConsumerConnector(ConsumerConnector.scala:100)
	at kafka.consumer.Consumer.createJavaConsumerConnector(ConsumerConnector.scala)
	at org.wso2.carbon.inbound.endpoint.protocol.kafka.KAFKAMessageListener.createKafkaConsumerConnector(KAFKAMessageListener.java:50)
	at org.wso2.carbon.inbound.endpoint.protocol.kafka.KAFKAPollingConsumer.poll(KAFKAPollingConsumer.java:143)
	at org.wso2.carbon.inbound.endpoint.protocol.kafka.KAFKAPollingConsumer.execute(KAFKAPollingConsumer.java:114)
	at org.wso2.carbon.inbound.endpoint.protocol.kafka.KAFKATask.taskExecute(KAFKATask.java:46)
	at org.wso2.carbon.inbound.endpoint.common.InboundRunner.run(InboundRunner.java:96)
	at java.lang.Thread.run(Thread.java:745)


After this Fix
------------------
[2015-07-28 15:41:55,157]  INFO - KAFKAMessageListener Creating Kafka Consumer Connector...
[2015-07-28 15:42:01,372] ERROR - KAFKAMessageListener  Error in Creating Kafka Consumer Connector | ZkTimeoutUnable to connect to zookeeper server within timeout: 6000
[2015-07-28 15:42:01,373] ERROR - KAFKAPollingConsumer  Error in Creating Kafka Consumer Connector| ZkTimeout

