### PR TITLE
Fixing inalid XHTML due to missing LI closing tag

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/docs/userguide.html
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/docs/userguide.html
@@ -154,7 +154,7 @@
     The following fields are specific to the HTTP Endpoint.
     <ul>
       <li>Name: The unique name for the endpoint </li>
-      <li>URI Template: The URL Template of the endpoint where template variables are placed inside curly braces with the prefix 'uri.var'. Example: http://wso2.com/{uri.var.pageId}/{uri.var.docId}.
+      <li>URI Template: The URL Template of the endpoint where template variables are placed inside curly braces with the prefix 'uri.var'. Example: http://wso2.com/{uri.var.pageId}/{uri.var.docId}.</li>
       <li>Method: The HTTP Method to use. The available values
         are:
         <ul>


### PR DESCRIPTION
This causes build failure in AppM. It might cause build failure in other products too.