### PR TITLE
ESBJAVA-4061 Error messages are not printed when a worker node in a c…

### DIFF
--- a/components/mediation-ntask/src/main/java/org/wso2/carbon/mediation/ntask/NTaskTaskManager.java
+++ b/components/mediation-ntask/src/main/java/org/wso2/carbon/mediation/ntask/NTaskTaskManager.java
@@ -584,12 +584,12 @@ public class NTaskTaskManager implements TaskManager, TaskServiceObserver, Serve
                                   .equals(org.wso2.carbon.ntask.core.TaskManager.TaskState.PAUSED);
             } catch (Exception e) {
                 /*
-                 * This ugly fix was given to avoid error messages printing
+                 * This fix was given to avoid error messages printing
                  * while server shutdowns in cluster mode when MP is running.
                  * This is related to the issue ESBJAVA-4061.
                  */
                 if (logger.isDebugEnabled()) {
-                    logger.error("Cannot return task status [" + taskName + "]. Error: " +
+                    logger.debug("Cannot return task status [" + taskName + "]. Error: " +
                             e.getLocalizedMessage(), e);
                 }
             }

--- a/components/mediation-ntask/src/main/java/org/wso2/carbon/mediation/ntask/NTaskTaskManager.java
+++ b/components/mediation-ntask/src/main/java/org/wso2/carbon/mediation/ntask/NTaskTaskManager.java
@@ -583,8 +583,15 @@ public class NTaskTaskManager implements TaskManager, TaskServiceObserver, Serve
                 return taskManager.getTaskState(taskName)
                                   .equals(org.wso2.carbon.ntask.core.TaskManager.TaskState.PAUSED);
             } catch (Exception e) {
-                logger.error("Cannot return task status [" + taskName + "]. Error: " +
-                                     e.getLocalizedMessage(), e);
+                /*
+                 * This ugly fix was given to avoid error messages printing
+                 * while server shutdowns in cluster mode when MP is running.
+                 * This is related to the issue ESBJAVA-4061.
+                 */
+                if (logger.isDebugEnabled()) {
+                    logger.error("Cannot return task status [" + taskName + "]. Error: " +
+                            e.getLocalizedMessage(), e);
+                }
             }
         }
         return false;


### PR DESCRIPTION
…luster shutdowns while MP is running.