### PR TITLE
HL7 version 3 support for inbound-endpoint

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/codec/HL7Codec.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/codec/HL7Codec.java
@@ -95,7 +95,7 @@ public class HL7Codec {
                     context.setHl7Message(HL7MessageUtils.parse(context.getRequestBuffer().toString(),
                             context.getPreProcessParser()));
                 } else {
-                    context.setHl7Message(HL7MessageUtils.parse(context.getRequestBuffer().toString(), context.isValidateMessage()));
+                    context.setHl7Message(HL7MessageUtils.parse(context.getRequestBuffer().toString(), context.isValidateMessage(), context.getHl7Version()));
                 }
                 context.getRequestBuffer().setLength(0);
             } catch (HL7Exception e) {

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/context/MLLPContext.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/context/MLLPContext.java
@@ -54,12 +54,15 @@ public class MLLPContext {
     private Parser preProcessorParser = null;
     private BufferFactory bufferFactory;
 
+    private int hl7Version = 2;
+
     public MLLPContext(IOSession session,
                        CharsetDecoder decoder,
                        boolean autoAck,
                        boolean validateMessage,
                        Parser preProcessorParser,
-                       BufferFactory bufferFactory) {
+                       BufferFactory bufferFactory,
+                       int hl7Version) {
         this.session = session;
         this.codec = new HL7Codec(decoder);
         this.autoAck = autoAck;
@@ -69,6 +72,7 @@ public class MLLPContext {
         this.expiry = MLLPConstants.DEFAULT_HL7_TIMEOUT;
         this.requestBuffer = new StringBuffer();
         this.responseBuffer = new StringBuffer();
+        this.hl7Version = hl7Version;
 
         if (preProcessorParser == null) {
             preProcess = false;
@@ -188,6 +192,14 @@ public class MLLPContext {
 
     public void setMessageId(String messageId) {
         this.messageId = messageId;
+    }
+
+    public int getHl7Version() {
+        return hl7Version;
+    }
+
+    public void setHl7Version(int hl7Version) {
+        this.hl7Version = hl7Version;
     }
 
     public void reset() {

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/context/MLLPContextFactory.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/context/MLLPContextFactory.java
@@ -38,8 +38,9 @@ public class MLLPContextFactory {
         boolean validate = Boolean.valueOf(inboundParams.getProperties().getProperty(MLLPConstants.PARAM_HL7_VALIDATE));
         Parser preParser = (Parser) processor.getInboundParameterMap().get(MLLPConstants.HL7_PRE_PROC_PARSER_CLASS);
         BufferFactory bufferFactory = (BufferFactory) processor.getInboundParameterMap().get(MLLPConstants.INBOUND_HL7_BUFFER_FACTORY);
+        int version = Integer.valueOf(inboundParams.getProperties().getProperty(MLLPConstants.PARAM_HL7_VERSION));
 
-        return new MLLPContext(session, decoder, autoAck, validate, preParser, bufferFactory);
+        return new MLLPContext(session, decoder, autoAck, validate, preParser, bufferFactory, version);
     }
 
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/core/MLLPConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/core/MLLPConstants.java
@@ -65,6 +65,8 @@ public class MLLPConstants {
 
     public final static String HL7_INBOUND_TENANT_DOMAIN = "HL7_INBOUND_TENANT_DOMAIN";
 
+    public final static String PARAM_HL7_VERSION = "inbound.hl7.Version";
+
     public static class TCPConstants {
 
         public final static String IO_THREAD_COUNT = "io_thread_count";

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/management/HL7EndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/management/HL7EndpointManager.java
@@ -187,5 +187,14 @@ public class HL7EndpointManager extends AbstractInboundEndpointManager {
                 params.getProperties().setProperty(MLLPConstants.PARAM_HL7_PASS_THROUGH_INVALID_MESSAGES, "false");
             }
         }
+
+        if (params.getProperties().getProperty(MLLPConstants.PARAM_HL7_VERSION) == null) {
+            params.getProperties().setProperty(MLLPConstants.PARAM_HL7_VERSION, "2");
+        } else {
+            if (!params.getProperties().getProperty(MLLPConstants.PARAM_HL7_VERSION).equalsIgnoreCase("3") &&
+                !params.getProperties().getProperty(MLLPConstants.PARAM_HL7_VERSION).equalsIgnoreCase("2")) {
+                params.getProperties().setProperty(MLLPConstants.PARAM_HL7_VERSION, "2");
+            }
+        }
     }
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/util/HL7MessageUtils.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/hl7/util/HL7MessageUtils.java
@@ -88,11 +88,44 @@ public class HL7MessageUtils {
         }
     }
 
+    /**
+     * @deprecated : Use method <i> parse(String msg, boolean validate, int version) </i> instead
+     */
     public static Message parse(String msg, boolean validate) throws HL7Exception {
         if (validate) {
             return pipeParser.parse(msg);
         } else {
             return noValidationPipeParser.parse(msg);
+        }
+    }
+
+    /**
+     * Parse incoming HL7 string message to build a Message object
+     *
+     * @param msg       String value of HL7 message
+     * @param validate  Whether message should be validated
+     * @param version   HL7 version (Supporting v2 & v3)
+     * @return Parsed HL7 Message
+     * @throws HL7Exception
+     */
+    public static Message parse(String msg, boolean validate, int version) throws HL7Exception {
+        switch (version) {
+            case 3:
+            {
+                if (validate) {
+                    return xmlParser.parse(msg);
+                } else {
+                    return noValidationXmlParser.parse(msg);
+                }
+            }
+            default:
+            {
+                if (validate) {
+                    return pipeParser.parse(msg);
+                } else {
+                    return noValidationPipeParser.parse(msg);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This is to give HL7 v3 support for HL7 inbound endpoint.

Sample configuration:
```
<inboundEndpoint xmlns="http://ws.apache.org/ns/synapse"
                 name="Sample1"
                 sequence="SimpleSeq"
                 onError="fault"
                 protocol="hl7"
                 suspend="false">
   <parameters>
      <parameter name="inbound.hl7.AutoAck">true</parameter>
      <parameter name="inbound.hl7.Port">20000</parameter>
      <parameter name="inbound.hl7.TimeOut">3000</parameter>
      <parameter name="inbound.hl7.CharSet">UTF-8</parameter>
      <parameter name="inbound.hl7.ValidateMessage">false</parameter>
      <parameter name="inbound.hl7.Version">3</parameter>
      <parameter name="transport.hl7.BuildInvalidMessages">false</parameter>
   </parameters>
</inboundEndpoint>
```