### PR TITLE
Adding debug logs when publishing data to analytic server, Using Jackson for JSON, Async. publishing

### DIFF
--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/pom.xml
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/pom.xml
@@ -90,6 +90,14 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.orbit.com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/internal/MediationStatisticsComponent.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/internal/MediationStatisticsComponent.java
@@ -295,7 +295,7 @@ public class MediationStatisticsComponent {
         PublisherUtils.setTraceDataCollectingEnabled(flowStatisticsEnabled);
 
         if (!flowStatisticsEnabled) {
-            log.info("Statistic Reporter is Disabled");
+            log.info("Global Message-Flow Statistic Reporting is Disabled");
         }
 
     }

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/internal/MediationStatisticsComponent.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/internal/MediationStatisticsComponent.java
@@ -126,7 +126,7 @@ public class MediationStatisticsComponent {
         MessageFlowObserverStore observerStore = new MessageFlowObserverStore();
 
         MessageFlowReporterThread reporterThread = new MessageFlowReporterThread(synEnvService, observerStore);
-        reporterThread.setName("mediation-flow-tracer-" + tenantId);
+        reporterThread.setName("message-flow-reporter-" + tenantId);
         reporterThread.start();
         if (log.isDebugEnabled()) {
             log.debug("Registering the new mediation flow tracer service");

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/publish/ConfigurationPublisher.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/publish/ConfigurationPublisher.java
@@ -57,7 +57,23 @@ public class ConfigurationPublisher {
 
                 addEventData(eventData, structuringArtifact);
                 StreamDefinition streamDef = getComponentStreamDefinition(metaDataKeyList.toArray());
+
+                if(log.isDebugEnabled()) {
+                    log.debug("Before sending to analytic server ------");
+
+                    /*
+                     Logs to print data sending to analytics server. Use log4j.properties to enable this logs
+                      */
+                    for (int i = 0; i < eventData.size(); i++) {
+                        log.debug(streamDef.getPayloadData().get(i).getName() + " -> " + eventData.get(i));
+                    }
+                }
+
                 publishToAgent(eventData, metaDataValueList, PublisherConfig, streamDef);
+
+                if(log.isDebugEnabled()) {
+                    log.debug("------ After sending to analytic server");
+                }
             }
 
         } catch (MalformedStreamDefinitionException e) {

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/publish/StatisticsPublisher.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/publish/StatisticsPublisher.java
@@ -59,7 +59,23 @@ public class StatisticsPublisher {
 			if (PublisherConfig.isMessageFlowPublishingEnabled()) {
 				addEventData(eventData, publishingFlow);
 				StreamDefinition streamDef = getComponentStreamDefinition(metaDataKeyList.toArray());
+
+				if(log.isDebugEnabled()) {
+					log.debug("Before sending to analytic server ------");
+
+                    /*
+                     Logs to print data sending to analytics server. Use log4j.properties to enable this logs
+                      */
+					for (int i = 0; i < eventData.size(); i++) {
+						log.debug(streamDef.getPayloadData().get(i).getName() + " -> " + eventData.get(i));
+					}
+				}
+
 				publishToAgent(eventData, metaDataValueList, PublisherConfig, streamDef);
+
+				if(log.isDebugEnabled()) {
+					log.debug("------ After sending to analytic server");
+				}
 			}
 		} catch (MalformedStreamDefinitionException e) {
 			log.error("Error while creating stream definition object", e);
@@ -92,7 +108,11 @@ public class StatisticsPublisher {
 		String jsonString = JSONObject.toJSONString(mapping);
 
 		eventData.add(compress(jsonString));
-		//        eventData.add((jsonString));
+
+		if (log.isDebugEnabled()){
+			log.debug("Uncompressed data :");
+			log.debug(jsonString);
+		}
 	}
 
 	private static void publishToAgent(List<Object> eventData, List<Object> metaDataValueList,

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/publish/StatisticsPublisher.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/publish/StatisticsPublisher.java
@@ -15,7 +15,6 @@
  */
 package org.wso2.carbon.das.messageflow.data.publisher.publish;
 
-import net.minidev.json.JSONObject;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.aspects.flow.statistics.publishing.PublishingFlow;
@@ -36,6 +35,7 @@ import org.wso2.carbon.databridge.commons.StreamDefinition;
 import org.wso2.carbon.databridge.commons.exception.MalformedStreamDefinitionException;
 import org.wso2.carbon.databridge.commons.exception.TransportException;
 import org.wso2.carbon.databridge.commons.utils.DataBridgeCommonsUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayOutputStream;
@@ -47,6 +47,7 @@ import java.util.zip.GZIPOutputStream;
 
 public class StatisticsPublisher {
 	private static Log log = LogFactory.getLog(StatisticsPublisher.class);
+	private static ObjectMapper mapper = new ObjectMapper();
 
 	public static void process(PublishingFlow publishingFlow, PublisherConfig PublisherConfig) {
 		List<String> metaDataKeyList = new ArrayList<String>();
@@ -100,18 +101,24 @@ public class StatisticsPublisher {
 	}
 
 	private static void addEventData(List<Object> eventData, PublishingFlow publishingFlow) {
+
 		eventData.add(publishingFlow.getMessageFlowId());
 
 		Map<String, Object> mapping = publishingFlow.getObjectAsMap();
 		mapping.put("host", PublisherUtil.getHostAddress()); // Adding host
 
-		String jsonString = JSONObject.toJSONString(mapping);
+		String jsonString;
+		try {
+			jsonString = mapper.writeValueAsString(mapping);
 
-		eventData.add(compress(jsonString));
+			eventData.add(compress(jsonString));
 
-		if (log.isDebugEnabled()){
-			log.debug("Uncompressed data :");
-			log.debug(jsonString);
+			if (log.isDebugEnabled()){
+				log.debug("Uncompressed data :");
+				log.debug(jsonString);
+			}
+		} catch (IOException e) {
+			log.error("Error while reading input stream. " + e.getMessage());
 		}
 	}
 
@@ -142,7 +149,7 @@ public class StatisticsPublisher {
 				}
 			}
 			dataPublisher = eventPublisherConfig.getDataPublisher();
-			dataPublisher.publish(DataBridgeCommonsUtils.generateStreamId(streamDef.getName(), streamDef.getVersion()),
+			dataPublisher.tryPublish(DataBridgeCommonsUtils.generateStreamId(streamDef.getName(), streamDef.getVersion()),
 			                      metaDataValueList.toArray(), null, eventData.toArray());
 		} else {
 			DataPublisher dataPublisher = null;
@@ -164,7 +171,7 @@ public class StatisticsPublisher {
 			}
 			dataPublisher = eventPublisherConfig.getLoadBalancingDataPublisher();
 
-			dataPublisher.publish(DataBridgeCommonsUtils.generateStreamId(streamDef.getName(), streamDef.getVersion()),
+			dataPublisher.tryPublish(DataBridgeCommonsUtils.generateStreamId(streamDef.getName(), streamDef.getVersion()),
 			                      metaDataValueList.toArray(), null, eventData.toArray());
 		}
 	}

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/services/MessageFlowReporterThread.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/services/MessageFlowReporterThread.java
@@ -67,6 +67,9 @@ public class MessageFlowReporterThread extends Thread {
     public void run() {
         while (!shutdownRequested) {
             try {
+                if(log.isDebugEnabled()) {
+                    log.debug("Executing reporter thread - " + this.getName());
+                }
                 collectDataAndReport();
                 delay();
             } catch (Throwable t) {

--- a/features/synapse-features/org.apache.synapse.wso2.feature/pom.xml
+++ b/features/synapse-features/org.apache.synapse.wso2.feature/pom.xml
@@ -67,14 +67,10 @@
             <groupId>org.wso2.orbit.com.jayway.jsonpath</groupId>
             <artifactId>com.jayway.jsonpath</artifactId>
         </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-        </dependency>
       	<dependency>
-	    <groupId>com.damnhandy.wso2</groupId>
-	    <artifactId>handy-uri-templates</artifactId>
-	</dependency>        
+            <groupId>com.damnhandy.wso2</groupId>
+            <artifactId>handy-uri-templates</artifactId>
+	    </dependency>
     </dependencies>
 
     <build>
@@ -110,7 +106,6 @@
                                 <bundleDef>org.wso2.caching:wso2caching-core</bundleDef>
                                 <bundleDef>com.damnhandy.wso2:handy-uri-templates</bundleDef>
                                 <bundleDef>org.wso2.orbit.com.jayway.jsonpath:com.jayway.jsonpath</bundleDef>
-                                <bundleDef>net.minidev:json-smart</bundleDef>
                             </bundles>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This is to make it more convenient to debug messages publishing to Analytic Server.

Need to add following entry to log4j.properties to enable : 
```
log4j.logger.org.wso2.carbon.das.messageflow.data.publisher=DEBUG
```

Using Jackson library for JSON processing

Use async. method for publishing statistics