### PR TITLE
Adding null for empty authenticationUrlSet

### DIFF
--- a/components/event-sink/org.wso2.carbon.event.sink/src/main/java/org/wso2/carbon/event/sink/EventSink.java
+++ b/components/event-sink/org.wso2.carbon.event.sink/src/main/java/org/wso2/carbon/event/sink/EventSink.java
@@ -147,10 +147,15 @@ public class EventSink {
 			throw new EventSinkException("Failed to decrypt password");
 		}
 		eventSink.setName(name);
+
+		String authenticationUrlSet = null;
+		if(eventSink.getAuthenticationUrlSet().trim().length() > 0){
+			authenticationUrlSet = eventSink.getAuthenticationUrlSet();
+		}
 		try {
 			eventSink.setDataPublisher(
 					new DataPublisher(DataEndpointConstants.THRIFT_DATA_AGENT_TYPE, eventSink.getReceiverUrlSet(),
-					                  eventSink.getAuthenticationUrlSet(), eventSink.getUsername(),
+					                  authenticationUrlSet, eventSink.getUsername(),
 					                  eventSink.getPassword()));
 		} catch (DataEndpointAgentConfigurationException | DataEndpointException | DataEndpointConfigurationException
 				| DataEndpointAuthenticationException | TransportException e) {


### PR DESCRIPTION
With migration to analytics-common, if there's no value for authenticationUrlSet, data bridge expects a null value.