### PR TITLE
Fix task issue with PublishEvent mediator

### DIFF
--- a/components/mediation-ntask/src/main/java/org/wso2/carbon/mediation/ntask/Constants.java
+++ b/components/mediation-ntask/src/main/java/org/wso2/carbon/mediation/ntask/Constants.java
@@ -2,4 +2,5 @@ package org.wso2.carbon.mediation.ntask;
 
 public class Constants {
     public static final String TASK_TYPE_ESB = "ESB_TASK";
+    public static final String TASK_EXECUTING_TENANT_ID = "CURRENT_TASK_EXECUTING_TENANT_IDENTIFIER";
 }

--- a/components/mediation-ntask/src/main/java/org/wso2/carbon/mediation/ntask/NTaskAdapter.java
+++ b/components/mediation-ntask/src/main/java/org/wso2/carbon/mediation/ntask/NTaskAdapter.java
@@ -4,6 +4,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.task.Task;
 import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.mediation.ntask.internal.NtaskService;
 import org.wso2.carbon.ntask.core.AbstractTask;
 import org.wso2.carbon.ntask.core.TaskInfo;
@@ -63,6 +64,13 @@ public class NTaskAdapter extends AbstractTask {
         if (!(taskInstance instanceof Task)) {
             return;
         }
+
+        // Add runtimeProperties
+        if(taskInstance instanceof org.apache.synapse.startup.tasks.MessageInjector){
+            org.apache.synapse.startup.tasks.MessageInjector messageInjectorTask = (org.apache.synapse.startup.tasks.MessageInjector) taskInstance;
+            messageInjectorTask.addRuntimeProperty(Constants.TASK_EXECUTING_TENANT_ID, PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+        }
+
         synapseTask = (Task) taskInstance;
         initialized = true;
     }

--- a/components/mediators/publishEvent/org.wso2.carbon.mediator.publishevent/src/main/java/org/wso2/carbon/mediator/publishevent/ActivityIDSetter.java
+++ b/components/mediators/publishEvent/org.wso2.carbon.mediator.publishevent/src/main/java/org/wso2/carbon/mediator/publishevent/ActivityIDSetter.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.mediator.publishevent;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 
@@ -46,7 +47,7 @@ public class ActivityIDSetter {
 	 * @param messageContext message context of message
 	 * @throws SynapseException
 	 */
-	public static void setActivityIdInTransportHeader(Axis2MessageContext messageContext) throws SynapseException {
+	public static void setActivityIdInTransportHeader(MessageContext messageContext) throws SynapseException {
 		try {
 			//get the unique ID used for correlating messages for BAM activity monitoring
 			String idString = getUniqueId();
@@ -54,7 +55,8 @@ public class ActivityIDSetter {
 			//Get activity ID form message context, if available.
 			Object idFromContext = messageContext.getProperty(MSG_CONTEXT_ACTIVITY_ID);
 
-			org.apache.axis2.context.MessageContext axis2MessageContext = messageContext.getAxis2MessageContext();
+			Axis2MessageContext axis2smc = (Axis2MessageContext) messageContext;
+			org.apache.axis2.context.MessageContext axis2MessageContext = axis2smc.getAxis2MessageContext();
 
 			Map headers = (Map) axis2MessageContext
 					.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);


### PR DESCRIPTION
This will enables event publish mediator to work with scheduled tasks. Since schedule tasks uses separate threads, event publish mediator failed to find a tenant id.
This fix is only applicable for synapse Message Injector type tasks.

Ref: https://github.com/wso2/wso2-synapse/pull/552