### PR TITLE
JMX publishing capability for statistics implementation

### DIFF
--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.data.publisher.util/src/main/java/org/wso2/carbon/das/data/publisher/util/DASDataPublisherConstants.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.data.publisher.util/src/main/java/org/wso2/carbon/das/data/publisher/util/DASDataPublisherConstants.java
@@ -70,6 +70,6 @@ public class DASDataPublisherConstants {
 
     // Carbon XML properties
     public static final String STAT_CONFIG_ELEMENT = "MediationFlowStatisticConfig";
-    public static final String FLOW_STATISTIC_REPORTING_INTERVAL = STAT_CONFIG_ELEMENT + ".ReportingInterval";
+    public static final String FLOW_STATISTIC_REPORTING_INTERVAL = STAT_CONFIG_ELEMENT + ".AnalyticsServerPublishingInterval";
     public static final String FLOW_STATISTIC_JMX_PUBLISHING = STAT_CONFIG_ELEMENT + ".JmxPublishingDisable";
 }

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.data.publisher.util/src/main/java/org/wso2/carbon/das/data/publisher/util/DASDataPublisherConstants.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.data.publisher.util/src/main/java/org/wso2/carbon/das/data/publisher/util/DASDataPublisherConstants.java
@@ -69,5 +69,7 @@ public class DASDataPublisherConstants {
     public static final String DAS_PUBLISHING_ENABLED = "publishing-enabled";
 
     // Carbon XML properties
-    public static final String FLOW_STATISTIC_REPORTING_INTERVAL = "MediationFlowStatisticsReportingInterval";
+    public static final String STAT_CONFIG_ELEMENT = "MediationFlowStatisticConfig";
+    public static final String FLOW_STATISTIC_REPORTING_INTERVAL = STAT_CONFIG_ELEMENT + ".ReportingInterval";
+    public static final String FLOW_STATISTIC_JMX_PUBLISHING = STAT_CONFIG_ELEMENT + ".JmxPublishingDisable";
 }

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/jmx/JMXMediationFlowObserver.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/jmx/JMXMediationFlowObserver.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p/>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.das.messageflow.data.publisher.observer.jmx;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.aspects.flow.statistics.publishing.PublishingEvent;
+import org.apache.synapse.aspects.flow.statistics.publishing.PublishingFlow;
+import org.apache.synapse.commons.jmx.MBeanRegistrar;
+import org.wso2.carbon.das.messageflow.data.publisher.observer.MessageFlowObserver;
+import org.wso2.carbon.das.messageflow.data.publisher.observer.jmx.data.StatisticCollectionViewMXBean;
+import org.wso2.carbon.das.messageflow.data.publisher.observer.jmx.data.StatisticsCompositeObject;
+import org.apache.synapse.aspects.flow.statistics.util.StatisticsConstants;
+import org.wso2.carbon.das.messageflow.data.publisher.observer.jmx.data.SummeryStatisticObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Publish statistics data for JMX monitoring.
+ */
+public class JMXMediationFlowObserver implements StatisticCollectionViewMXBean, MessageFlowObserver {
+
+    private static final Log log = LogFactory.getLog(JMXMediationFlowObserver.class);
+
+    public static final String MBEAN_CATEGORY = "Mediation Flow Statistic View";
+
+    public static final String MBEAN_ID = "MediationFlowStatisticView";
+
+    private final Map<String, SummeryStatisticObject> proxyStatistics = new HashMap<>();
+
+    private final Map<String, SummeryStatisticObject> apiStatistics = new HashMap<>();
+
+    private final Map<String, SummeryStatisticObject> sequenceStatistics = new HashMap<>();
+
+    private final Map<String, SummeryStatisticObject> inboundEndpointStatistics = new HashMap<>();
+
+    private final Map<String, SummeryStatisticObject> endpointStatistics = new HashMap<>();
+
+    public JMXMediationFlowObserver() {
+        MBeanRegistrar.getInstance().registerMBean(this, MBEAN_CATEGORY, MBEAN_ID);
+    }
+
+    @Override
+    public void resetAPIStatistics() {
+        apiStatistics.clear();
+    }
+
+    @Override
+    public void resetProxyStatistics() {
+        proxyStatistics.clear();
+    }
+
+    @Override
+    public void resetSequenceStatistics() {
+        sequenceStatistics.clear();
+    }
+
+    @Override
+    public void resetInboundEndpointStatistics() {
+        inboundEndpointStatistics.clear();
+    }
+
+    @Override
+    public void resetEndpointStatistics() {
+        endpointStatistics.clear();
+    }
+
+    @Override
+    public void resetAllStatistics() {
+        resetAPIStatistics();
+        resetProxyStatistics();
+        resetSequenceStatistics();
+        resetInboundEndpointStatistics();
+        resetEndpointStatistics();
+    }
+
+    @Override
+    public StatisticsCompositeObject getProxyServiceJmxStatistics(String proxyName) {
+        SummeryStatisticObject statisticsObject = proxyStatistics.get(proxyName);
+        if (statisticsObject != null) {
+            return statisticsObject.getJmxObject();
+        }
+        return new StatisticsCompositeObject();
+    }
+
+    @Override
+    public StatisticsCompositeObject getSequenceJmxStatistics(String sequenceName) {
+        SummeryStatisticObject statisticsObject = sequenceStatistics.get(sequenceName);
+        if (statisticsObject != null) {
+            return statisticsObject.getJmxObject();
+        }
+        return new StatisticsCompositeObject();
+    }
+
+    @Override
+    public StatisticsCompositeObject getApiJmxStatistics(String apiName) {
+        SummeryStatisticObject statisticsObject = apiStatistics.get(apiName);
+        if (statisticsObject != null) {
+            return statisticsObject.getJmxObject();
+        }
+        return new StatisticsCompositeObject();
+    }
+
+    @Override
+    public StatisticsCompositeObject getInboundEndpointJmxStatistics(String inboundEndpointName) {
+        SummeryStatisticObject statisticsObject = inboundEndpointStatistics.get(inboundEndpointName);
+        if (statisticsObject != null) {
+            return statisticsObject.getJmxObject();
+        }
+        return new StatisticsCompositeObject();
+    }
+
+    @Override
+    public StatisticsCompositeObject getEndpointJmxStatistics(String endpointName) {
+        SummeryStatisticObject statisticsObject = endpointStatistics.get(endpointName);
+        if (statisticsObject != null) {
+            return statisticsObject.getJmxObject();
+        }
+        return new StatisticsCompositeObject();
+    }
+
+    @Override
+    public void destroy() {
+        MBeanRegistrar.getInstance().unRegisterMBean("Mediation Flow Statistic View", "MediationFlowStatisticView");
+    }
+
+    @Override
+    public void updateStatistics(PublishingFlow snapshot) {
+        for (PublishingEvent event : snapshot.getEvents()) {
+            String componentType = event.getComponentType();
+            //Mediator is the most common component type, therefore checking it first and ignoring will save time
+            if (!StatisticsConstants.FLOW_STATISTICS_MEDIATOR.equals(componentType)) {
+                if (StatisticsConstants.FLOW_STATISTICS_ENDPOINT.equals(componentType)) {
+                    SummeryStatisticObject statisticObject = endpointStatistics.get(event.getComponentName());
+                    if (statisticObject == null) {
+                        endpointStatistics.put(event.getComponentName(), new SummeryStatisticObject(event));
+                    } else {
+                        statisticObject.updateStatistics(event);
+                    }
+                } else if (StatisticsConstants.FLOW_STATISTICS_SEQUENCE.equals(componentType)) {
+                    SummeryStatisticObject statisticObject = sequenceStatistics.get(event.getComponentName());
+                    if (statisticObject == null) {
+                        sequenceStatistics.put(event.getComponentName(), new SummeryStatisticObject(event));
+                    } else {
+                        statisticObject.updateStatistics(event);
+                    }
+                } else if (StatisticsConstants.FLOW_STATISTICS_PROXYSERVICE.equals(componentType)) {
+                    SummeryStatisticObject statisticObject = proxyStatistics.get(event.getComponentName());
+                    if (statisticObject == null) {
+                        proxyStatistics.put(event.getComponentName(), new SummeryStatisticObject(event));
+                    } else {
+                        statisticObject.updateStatistics(event);
+                    }
+                } else if (StatisticsConstants.FLOW_STATISTICS_API.equals(componentType)) {
+                    SummeryStatisticObject statisticObject = apiStatistics.get(event.getComponentName());
+                    if (statisticObject == null) {
+                        apiStatistics.put(event.getComponentName(), new SummeryStatisticObject(event));
+                    } else {
+                        statisticObject.updateStatistics(event);
+                    }
+                } else if (StatisticsConstants.FLOW_STATISTICS_INBOUNDENDPOINT.equals(componentType)) {
+                    SummeryStatisticObject statisticObject = inboundEndpointStatistics.get(event.getComponentName());
+                    if (statisticObject == null) {
+                        inboundEndpointStatistics.put(event.getComponentName(), new SummeryStatisticObject(event));
+                    } else {
+                        statisticObject.updateStatistics(event);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/jmx/data/StatisticCollectionViewMXBean.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/jmx/data/StatisticCollectionViewMXBean.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p/>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.das.messageflow.data.publisher.observer.jmx.data;
+
+
+/**
+ * MBean interface to expose collected statistic data using JMX.
+ */
+public interface StatisticCollectionViewMXBean {
+
+    /**
+     * Reset JMX API statistic collection.
+     */
+    void resetAPIStatistics();
+
+    /**
+     * Reset JMX Proxy statistic collection.
+     */
+    void resetProxyStatistics();
+
+    /**
+     * Reset JMX Sequence statistic collection.
+     */
+    void resetSequenceStatistics();
+
+    /**
+     * Reset JMX Inbound Endpoint statistic collection.
+     */
+    void resetInboundEndpointStatistics();
+
+    /**
+     * Reset JMX Endpoint statistic collection.
+     */
+    void resetEndpointStatistics();
+
+    /**
+     * Reset all JMX statistics.
+     */
+    void resetAllStatistics();
+
+    /**
+     * Returns statistics related to a Proxy Service.
+     *
+     * @param proxyName Name of the proxy service.
+     * @return Composite Data Object that contains Proxy Statistics.
+     */
+    StatisticsCompositeObject getProxyServiceJmxStatistics(String proxyName);
+
+    /**
+     * Returns statistics related to a Sequence.
+     *
+     * @param sequenceName Name of the Sequence.
+     * @return Composite Data Object that contains Sequence Statistics.
+     */
+    StatisticsCompositeObject getSequenceJmxStatistics(String sequenceName);
+
+    /**
+     * Returns statistics related to a API.
+     *
+     * @param apiName Name of the API.
+     * @return Composite Data Object that contains API Statistics.
+     */
+    StatisticsCompositeObject getApiJmxStatistics(String apiName);
+
+    /**
+     * Returns statistics related to a Inbound Endpoint.
+     *
+     * @param inboundEndpointName Name of the Inbound Endpoint.
+     * @return Composite Data Object that contains Inbound Endpoint Statistics.
+     */
+    StatisticsCompositeObject getInboundEndpointJmxStatistics(String inboundEndpointName);
+
+    /**
+     * Returns statistics related to a Endpoint.
+     *
+     * @param endpointName Name of the Endpoint.
+     * @return Composite Data Object that contains Endpoint Statistics.
+     */
+    StatisticsCompositeObject getEndpointJmxStatistics(String endpointName);
+}

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/jmx/data/StatisticsCompositeObject.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/jmx/data/StatisticsCompositeObject.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p/>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.das.messageflow.data.publisher.observer.jmx.data;
+
+
+import java.beans.ConstructorProperties;
+
+/**
+ * Composite data object which is passed to the JMX Agent.
+ */
+public class StatisticsCompositeObject {
+
+    public static final String STATISTIC_DATA_NOT_FOUND = "Not Found";
+    private final String name;
+
+    private long maxProcessingTime = 0;
+
+    private long minProcessingTime = 0;
+
+    private long avgProcessingTime = 0;
+
+    private long numberOfInvocations = 0;
+
+    private long faultCount = 0;
+
+    @ConstructorProperties({"name", "maxProcessingTime", "minProcessingTime", "avgProcessingTime", "numberOfInvocations",
+            "faultCount"})
+    public StatisticsCompositeObject(String name, long maxProcessingTime, long minProcessingTime,
+                                     long avgProcessingTime, long numberOfInvocations, long faultCount) {
+        this.name = name;
+        this.faultCount = faultCount;
+        this.maxProcessingTime = maxProcessingTime;
+        this.minProcessingTime = minProcessingTime;
+        this.avgProcessingTime = avgProcessingTime;
+        this.numberOfInvocations = numberOfInvocations;
+    }
+
+    public StatisticsCompositeObject() {
+        name = STATISTIC_DATA_NOT_FOUND;
+    }
+
+    public long getFaultCount() {
+        return faultCount;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public long getMaxProcessingTime() {
+        return maxProcessingTime;
+    }
+
+    public long getMinProcessingTime() {
+        return minProcessingTime;
+    }
+
+    public long getAvgProcessingTime() {
+        return avgProcessingTime;
+    }
+
+    public long getNumberOfInvocations() {
+        return numberOfInvocations;
+    }
+
+
+}
+

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/jmx/data/SummeryStatisticObject.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/jmx/data/SummeryStatisticObject.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p/>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.das.messageflow.data.publisher.observer.jmx.data;
+
+import org.apache.synapse.aspects.flow.statistics.publishing.PublishingEvent;
+
+/**
+ * Summery data object to summery data for JMX publisher.
+ */
+public class SummeryStatisticObject {
+
+    private final String name;
+
+    private long maxTime = 0;
+
+    private long minTime = 0;
+
+    private long avgTime = 0;
+
+    private long count = 0;
+
+    private long faultCount;
+
+    public SummeryStatisticObject(PublishingEvent publishingEvent) {
+        name = publishingEvent.getComponentName();
+        minTime = maxTime = avgTime = publishingEvent.getDuration();
+        count++;
+        if (publishingEvent.getFaultCount() > 0) {
+            faultCount++;
+        }
+    }
+
+    public void updateStatistics(PublishingEvent publishingEvent) {
+        long duration = publishingEvent.getDuration();
+        avgTime = (avgTime * count + duration) / (count + 1);
+        if (minTime > duration) {
+            minTime = duration;
+        } else if (maxTime < duration) {
+            maxTime = duration;
+        }
+        count++;
+        if (publishingEvent.getFaultCount() > 0) {
+            faultCount++;
+        }
+    }
+
+    public StatisticsCompositeObject getJmxObject() {
+        return new StatisticsCompositeObject(name, maxTime, minTime, avgTime, count, faultCount);
+    }
+}


### PR DESCRIPTION
JMX functionality and statistic reporting collection thread default values can be configured in carbon.xml by using the following configuration.
   ` <MediationFlowStatisticConfig>
        <AnalyticsServerPublishingInterval>2000</AnalyticsServerPublishingInterval>
        <JmxPublishingDisable>true</JmxPublishingDisable>
    </MediationFlowStatisticConfig>`