### PR TITLE
Adding functionality to register custom statistic observers

### DIFF
--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.data.publisher.util/src/main/java/org/wso2/carbon/das/data/publisher/util/DASDataPublisherConstants.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.data.publisher.util/src/main/java/org/wso2/carbon/das/data/publisher/util/DASDataPublisherConstants.java
@@ -72,4 +72,5 @@ public class DASDataPublisherConstants {
     public static final String STAT_CONFIG_ELEMENT = "MediationFlowStatisticConfig";
     public static final String FLOW_STATISTIC_REPORTING_INTERVAL = STAT_CONFIG_ELEMENT + ".AnalyticsServerPublishingInterval";
     public static final String FLOW_STATISTIC_JMX_PUBLISHING = STAT_CONFIG_ELEMENT + ".JmxPublishingDisable";
+    public static final String STAT_OBSERVERS = STAT_CONFIG_ELEMENT + ".Observers";
 }

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/DASMediationFlowObserver.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/DASMediationFlowObserver.java
@@ -25,7 +25,6 @@ import org.wso2.carbon.das.messageflow.data.publisher.conf.PublisherProfile;
 import org.wso2.carbon.das.messageflow.data.publisher.conf.PublisherProfileManager;
 import org.wso2.carbon.das.messageflow.data.publisher.publish.StatisticsPublisher;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.mediation.statistics.*;
 
 import java.util.List;
 

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/TenantInformation.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/TenantInformation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p/>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.das.messageflow.data.publisher.observer;
+
+/**
+ * This interface has to be implemented by the tenant aware observers.
+ */
+public interface TenantInformation {
+    /**
+     * Get the tenant id for the observer
+     * @return tenantId
+     */
+    int getTenantId();
+
+    /**
+     * Set the tenantId for the observer
+     * @param id tenantId of the observer
+     */
+    void setTenantId(int id);
+}

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/jmx/JMXMediationFlowObserver.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/observer/jmx/JMXMediationFlowObserver.java
@@ -24,6 +24,7 @@ import org.apache.synapse.aspects.flow.statistics.publishing.PublishingEvent;
 import org.apache.synapse.aspects.flow.statistics.publishing.PublishingFlow;
 import org.apache.synapse.commons.jmx.MBeanRegistrar;
 import org.wso2.carbon.das.messageflow.data.publisher.observer.MessageFlowObserver;
+import org.wso2.carbon.das.messageflow.data.publisher.observer.TenantInformation;
 import org.wso2.carbon.das.messageflow.data.publisher.observer.jmx.data.StatisticCollectionViewMXBean;
 import org.wso2.carbon.das.messageflow.data.publisher.observer.jmx.data.StatisticsCompositeObject;
 import org.apache.synapse.aspects.flow.statistics.util.StatisticsConstants;
@@ -35,13 +36,15 @@ import java.util.Map;
 /**
  * Publish statistics data for JMX monitoring.
  */
-public class JMXMediationFlowObserver implements StatisticCollectionViewMXBean, MessageFlowObserver {
+public class JMXMediationFlowObserver implements StatisticCollectionViewMXBean, MessageFlowObserver, TenantInformation {
 
     private static final Log log = LogFactory.getLog(JMXMediationFlowObserver.class);
 
     public static final String MBEAN_CATEGORY = "Mediation Flow Statistic View";
 
     public static final String MBEAN_ID = "MediationFlowStatisticView";
+
+    private int tenantId = -1234;
 
     private final Map<String, SummeryStatisticObject> proxyStatistics = new HashMap<>();
 
@@ -185,5 +188,15 @@ public class JMXMediationFlowObserver implements StatisticCollectionViewMXBean, 
                 }
             }
         }
+    }
+
+    @Override
+    public int getTenantId() {
+        return tenantId;
+    }
+
+    @Override
+    public void setTenantId(int i) {
+        tenantId = i;
     }
 }


### PR DESCRIPTION
You can register custom observers by copying jar file which contains observer implementation.

- It should implement org.wso2.carbon.das.messageflow.data.publisher.observer.MessageFlowObserver Interface 
- If observer is tenant aware, it should implement org.wso2.carbon.das.messageflow.data.publisher.observer.TenantInformation

_**Steps to follow**_

- [Copy jar file to repository/components/lib directory of the ESB

- Add all the custom observers separated with commas in carbon.xml like follows 

`<MediationFlowStatisticConfig> <Observers>org.wso2.custom.Observer1,org.wso2.custom.Observer1r</Observers> </MediationFlowStatisticConfig>`



