### PR TITLE
OAuth 2 scope check

### DIFF
--- a/components/mediators/oauth/org.wso2.carbon.identity.oauth.mediator/src/main/java/org/wso2/carbon/identity/oauth/mediator/OAuthConstants.java
+++ b/components/mediators/oauth/org.wso2.carbon.identity.oauth.mediator/src/main/java/org/wso2/carbon/identity/oauth/mediator/OAuthConstants.java
@@ -23,11 +23,11 @@ public final class OAuthConstants {
 	
 	public static final String ASSOCIATION_OAUTH_CONSUMER_TOKEN = "ASSOCIATION_OAUTH_CONSUMER_TOKEN";
 	public static final String OAUTHORIZED_USER = "OAUTHORIZED_USER";
-	public static final String OAUTH2_SCOPE_VALIDATION_ENABLED = "oauth2_scope_validation_enabled";
 
 	// OAuth 2.0 parameters
 	public static final String BEARER = "Bearer ";
 	public static final String ACCESS_TOKEN = "access_token";
 	public static final String BEARER_TOKEN_TYPE="bearer";
+	public static final String OAUTH2_SCOPE_VALIDATION_ENABLED = "oauth2_scope_validation_enabled";
 
 }

--- a/components/mediators/oauth/org.wso2.carbon.identity.oauth.mediator/src/main/java/org/wso2/carbon/identity/oauth/mediator/OAuthConstants.java
+++ b/components/mediators/oauth/org.wso2.carbon.identity.oauth.mediator/src/main/java/org/wso2/carbon/identity/oauth/mediator/OAuthConstants.java
@@ -23,7 +23,7 @@ public final class OAuthConstants {
 	
 	public static final String ASSOCIATION_OAUTH_CONSUMER_TOKEN = "ASSOCIATION_OAUTH_CONSUMER_TOKEN";
 	public static final String OAUTHORIZED_USER = "OAUTHORIZED_USER";
-	public static final String OAUTH2_SCOPE_VALIDATION_ENABLED = "OAUTH2_SCOPE_VALIDATION_ENABLED";
+	public static final String OAUTH2_SCOPE_VALIDATION_ENABLED = "oauth2_scope_validation_enabled";
 
 	// OAuth 2.0 parameters
 	public static final String BEARER = "Bearer ";

--- a/components/mediators/oauth/org.wso2.carbon.identity.oauth.mediator/src/main/java/org/wso2/carbon/identity/oauth/mediator/OAuthConstants.java
+++ b/components/mediators/oauth/org.wso2.carbon.identity.oauth.mediator/src/main/java/org/wso2/carbon/identity/oauth/mediator/OAuthConstants.java
@@ -23,6 +23,7 @@ public final class OAuthConstants {
 	
 	public static final String ASSOCIATION_OAUTH_CONSUMER_TOKEN = "ASSOCIATION_OAUTH_CONSUMER_TOKEN";
 	public static final String OAUTHORIZED_USER = "OAUTHORIZED_USER";
+	public static final String OAUTH2_SCOPE_VALIDATION_ENABLED = "OAUTH2_SCOPE_VALIDATION_ENABLED";
 
 	// OAuth 2.0 parameters
 	public static final String BEARER = "Bearer ";


### PR DESCRIPTION
Initially client needs to obtain an access_token with providing the scope. (valid for OAuth2 only)

This improvement verifies the scope getting from the OAuth mediator is exactly the same as what it should be.

# Sample for testing. 

## Prerequisites:
Start WSO2 IS (port offset=0) and WSO2 ESB (port offset=1) 

## Step 1:
Generate a token by passing scope:
```
curl --user  {client_id} :{client_secret} -k -d "grant_type=password&username={username}&password={password}&scope=API_A" -H  "Content-Type: application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
```
will get a response as follows
```
{"scope":"API_A","token_type":"bearer","expires_in":3299,"refresh_token":"9d8b7ae18693554afd99bd5be6","access_token":"1ce493a9bec3da0349145bb44"}
```
thereafter in token verification process, WSO2 ESB gets scope for this access_token.

## Step 2:
Add following ESB configuration
```
<proxy xmlns="http://ws.apache.org/ns/synapse"
       name="OAuthProxy"
       transports="https,http"
       statistics="disable"
       trace="disable"
       startOnLoad="true">
   <target>
      <inSequence>
         <property name="oauth2_scope_validation_enabled" value="true" scope="default" type="STRING"/>
         <property name="scope" value="API_A" scope="default" type="STRING"/>

         <oauthService remoteServiceUrl="https://localhost:9443/services/" username="admin" password="admin"/>
         <log level="custom">
            <property name="state" value="after OAuth"/>
         </log>
         <send>
            <endpoint>
               <address uri="http://localhost:8281/services/echo" format="rest"/>
            </endpoint>
         </send>
      </inSequence>
      <outSequence>
         <send/>
      </outSequence>
   </target>
</proxy>
```
Please note the 2 properties used.
oauth2_scope_validation_enabled : must be true to start validation
scope : scope to validate (if not provided proxy-service name/ API name is used)

## Step 3:
Invoke the proxy through a curl command
```
curl -v -k -H "Authorization: Bearer 1ce493a9bec3da0349145bb44" http://127.0.0.1:8281/services/OAuthProxy/echoString?in=wso2
```
You should get the expected response.

## Further Testing:
* If you use something other than API_A for Step 1 scope variable, you won't get the response
* If you use "OAuthProxy" as the scope (proxy name), you no need to specify "scope" property in the ESB config. (will be detecting automatically).