### PR TITLE
fix#5045 : resolve NumberFormatException thrown for elements with xsi…

### DIFF
--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/input/readers/XMLInputReader.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/input/readers/XMLInputReader.java
@@ -200,33 +200,35 @@ public class XMLInputReader implements InputReader {
                 elementType = getObjectTextElementType(jsonSchemaMap, nameSpaceLocalName);
             }
         }
-        /* If there is text in the OMElement */
-        if (DataMapperEngineConstants.STRING_ELEMENT_TYPE.equals(elementType)
+        /* If an object/element(String/boolean/integer/number) property contains xis:nil=true
+           need  to avoid writing those fields */
+        if (!isXsiNil(omElement)) {
+            /* If there is text in the OMElement */
+            if (DataMapperEngineConstants.STRING_ELEMENT_TYPE.equals(elementType)
                 || DataMapperEngineConstants.BOOLEAN_ELEMENT_TYPE.equals(elementType)
                 || DataMapperEngineConstants.INTEGER_ELEMENT_TYPE.equals(elementType)
                 || DataMapperEngineConstants.NUMBER_ELEMENT_TYPE.equals(elementType)) {
-            if (isObject) { // if it is a normal object or an array element object
-                writeFieldElement(SCHEMA_XML_ELEMENT_TEXT_VALUE_FIELD, omElement.getText(), elementType);
-            } else if (!isArrayElement) { // if it is a normal XML element (not a object or part of an array)
-                writeFieldElement(nameSpaceLocalName, omElement.getText(), elementType);
-            } else { // primitive array elements
-                writePrimitiveElement(omElement.getText(), elementType);
+                if (isObject) { // if it is a normal object or an array element object
+                    writeFieldElement(SCHEMA_XML_ELEMENT_TEXT_VALUE_FIELD, omElement.getText(), elementType);
+                } else if (!isArrayElement) { // if it is a normal XML element (not a object or part of an array)
+                    writeFieldElement(nameSpaceLocalName, omElement.getText(), elementType);
+                } else { // primitive array elements
+                    writePrimitiveElement(omElement.getText(), elementType);
+                }
             }
-        }
 
-        /* writing attributes to the JSON message */
-        it_attr = omElement.getAllAttributes();
-        if (it_attr.hasNext()) {
-            writeAttributes(nextJSONSchemaMap);
-        }
+            /* writing attributes to the JSON message */
+            it_attr = omElement.getAllAttributes();
+            if (it_attr.hasNext()) {
+                writeAttributes(nextJSONSchemaMap);
+            }
 
-        it = omElement.getChildElements();
+            it = omElement.getChildElements();
 
-        /* Recursively call all the children */
-        if (!isXsiNil(omElement)) {
+            /* Recursively call all the children */
             while (it.hasNext()) {
                 prevElementNameSpaceLocalName = xmlTraverse(it.next(), prevElementNameSpaceLocalName,
-                        nextJSONSchemaMap);
+                                                            nextJSONSchemaMap);
             }
         }
 


### PR DESCRIPTION
…:nil attribute

Moved if(isXsiNil) check for OMElements with and without childElements, that contain xsi:nil=true as an attribute.

This if(isXsiNil) check was included only for objects of a datamapping schema, which would exclude OAwriting objects with xsi:nil=true attribute.
As this check was not included for primitive elements(String/boolean/integer/number), when a number element with above attribute went to 'writeFieldElement' method
a NumberFormatException was thrown since the element value is empty.