### PR TITLE
Set tenant domain when access swagger.json of API

### DIFF
--- a/components/mediation-initializer/org.wso2.carbon.mediation.transport.handlers/src/main/java/org/wso2/carbon/mediation/transport/handlers/PassThroughNHttpGetProcessor.java
+++ b/components/mediation-initializer/org.wso2.carbon.mediation.transport.handlers/src/main/java/org/wso2/carbon/mediation/transport/handlers/PassThroughNHttpGetProcessor.java
@@ -336,9 +336,16 @@ public class PassThroughNHttpGetProcessor implements HttpGetRequestProcessor {
                                         queryString.indexOf("&") == item.length() ||
                                         queryString.indexOf("=") == item.length())) {
                             if (axisService == null) {
-                                //check for APIs since no axis2 service found
-                                if (!RequestProcessorDispatcherUtil.isDispatchToApiGetProcessor(requestUri, cfgCtx)) {
-                                    continue;
+                                try {
+                                    String tenantDomain = TenantAxisUtils.getTenantDomain(uri);
+                                    PrivilegedCarbonContext.startTenantFlow();
+                                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+                                    //check for APIs since no axis2 service found
+                                    if (!RequestProcessorDispatcherUtil.isDispatchToApiGetProcessor(requestUri, cfgCtx)) {
+                                        continue;
+                                    }
+                                } finally {
+                                    PrivilegedCarbonContext.endTenantFlow();
                                 }
                             }
 


### PR DESCRIPTION
A regression issue has been occured due to the fix for https://wso2.org/jira/browse/CIDENTITY-25. The way that getting tenant domain in the isTenantActive menthod in the JDBCTenantManager is changed to retrieve it from the tenant flow.
Therefore, the tenat domain has to be set whatever the flow that calls the isTenantActive method. This fix is to set the tenant domain when accessing the swagger.json of an API
https://wso2.org/jira/browse/ESBJAVA-5069