### PR TITLE
Add missing parameter for WS inbound protocol

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.inbound.ui/src/main/resources/config/inbound.properties
+++ b/components/mediation-ui/org.wso2.carbon.inbound.ui/src/main/resources/config/inbound.properties
@@ -219,11 +219,12 @@ ws.mandatory.2=ws.client.side.broadcast.level ~:~ 0 ~:~ 1 ~:~ 2
 ws.mandatory.3=ws.outflow.dispatch.sequence
 ws.mandatory.4=ws.outflow.dispatch.fault.sequence
 
-ws.optional=4
+ws.optional=5
 ws.optional.1=ws.boss.thread.pool.size
 ws.optional.2=ws.worker.thread.pool.size
 ws.optional.3=ws.subprotocol.handler.class
 ws.optional.4=ws.use.port.offset ~:~ false ~:~ true
+ws.optional.5=ws.pipeline.handler.class
 
 wss.mandatory=9
 wss.mandatory.1=inbound.ws.port


### PR DESCRIPTION
This adds the missing parameter 'ws.pipeline.handler.class' for WS inbound protocol in CarbonUI
Public Jira - https://wso2.org/jira/browse/ESBJAVA-5068