### PR TITLE
Check clustering pattern before adding inbond EP

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRunner.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRunner.java
@@ -18,9 +18,11 @@
 package org.wso2.carbon.inbound.endpoint.common;
 
 import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.description.Parameter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils;
+import org.wso2.carbon.inbound.endpoint.osgi.service.ServiceReferenceHolder;
 import org.wso2.carbon.inbound.endpoint.persistence.service.InboundEndpointPersistenceServiceDSComponent;
 import org.wso2.carbon.mediation.clustering.ClusteringAgentUtil;
 import org.wso2.carbon.utils.CarbonUtils;
@@ -48,6 +50,8 @@ public class InboundRunner implements Runnable {
     private String tenantDomain;
     private boolean runOnManagerOverride = false;
 
+    private static final String CLUSTERING_PATTERN = "clusteringPattern";
+    private static final String CLUSTERING_PATTERN_WORKER_MANAGER = "WorkerManager";
     private static final Log log = LogFactory.getLog(InboundRunner.class);
 
     public InboundRunner(InboundTask task, long interval, String tenantDomain, boolean mgrOverride) {
@@ -71,8 +75,13 @@ public class InboundRunner implements Runnable {
         while (!init) {
             log.debug("Waiting for the configuration context to be loaded to run Inbound Endpoint.");
             Boolean isSinglNode = ClusteringAgentUtil.isSingleNode();
+            Parameter clusteringPattern = ServiceReferenceHolder.getInstance().getConfigurationContextService().
+                    getServerConfigContext().getAxisConfiguration().getClusteringAgent().
+                    getParameter(CLUSTERING_PATTERN);
+            Boolean isWorkerManager = clusteringPattern != null && clusteringPattern.getValue() != null
+                    && clusteringPattern.getValue().toString().equals(CLUSTERING_PATTERN_WORKER_MANAGER);
             if (isSinglNode != null) {
-                if (!isSinglNode && !CarbonUtils.isWorkerNode() && !runOnManagerOverride) {
+                if (!isSinglNode && !CarbonUtils.isWorkerNode() && !runOnManagerOverride && isWorkerManager) {
                     // Given node is the manager in the cluster, and not
                     // required to run the service
                     execute = false;


### PR DESCRIPTION
This is to fix wso2/product-ei#532

When the "clusteringPattern" is set to "nonWorkerManager", Inbound endpoint with coordination=false doesn't work. It gives an INFO log with "Inbound EP will not run in manager node. Same will run on worker(s)", when adding the inbound EP. As, the clustering pattern is nonWorkerManager, considering the node as manager is wrong.

Therefore the fix is to check for the clusterin pattern and if it is workerManager, and the node is not a worker node (in other words, the node is a manager node), then prints that INFO log to communicate that the EP will not run on the manager node.