### PR TITLE
[ESBJAVA-5085]Inbound endpoint support for javax.jms.Message types

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
@@ -190,10 +190,8 @@ public class JMSPollingConsumer {
                 return null;
             }
             while (msg != null) {
-                if (!JMSUtils.inferJMSMessageType(msg).equals(TextMessage.class.getName())) {
-                    logger.error("JMS " +
-                            "Inbound transport support JMS TextMessage type only. Found message type "
-                            + JMSUtils.inferJMSMessageType(msg));
+                if (JMSUtils.inferJMSMessageType(msg) == null) {
+                    logger.error("Invalid JMS Message type.");
                     return null;
                 }
 


### PR DESCRIPTION
This is to add the inbound endpoint support for message type javax.jms.Message types
Currently, inbound endpoints support only for javax.jms.TextMessage type.

Related JIRA : https://wso2.org/jira/browse/ESBJAVA-5085