### PR TITLE
Message processor max.delivery.attempts UI fix

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageFailoverMessageForwardingProcessor.jsp
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageFailoverMessageForwardingProcessor.jsp
@@ -96,15 +96,15 @@
             return false;
         }
         
-        if (IsEmpty(form.max_delivery_attempts) && form.max_delivery_drop.value.trim() == "Enabled") {
+        if (IsEmpty(form.max_redelivery_attempts) && form.max_delivery_drop.value.trim() == "Enabled") {
             CARBON.showWarningDialog('<fmt:message key="drop.message.Error.empty"/>')
-            form.max_delivery_attempts.focus();
+            form.max_redelivery_attempts.focus();
             return false;
         }
         
-        if (form.max_delivery_attempts.value.trim() < 1 && form.max_delivery_drop.value.trim() == "Enabled") {
+        if (form.max_redelivery_attempts.value.trim() < 1 && form.max_delivery_drop.value.trim() == "Enabled") {
             CARBON.showWarningDialog('<fmt:message key="drop.message.Error.less.than.one"/>')
-            form.max_delivery_attempts.focus();
+            form.max_redelivery_attempts.focus();
             return false;
         }
 
@@ -153,7 +153,7 @@
         // is appended to the previous value leading to errors. This is used to solve that. The append takes place inside the addServiceParameter function.
         addServiceParameter("interval", document.getElementById('retry_interval').value);
         addServiceParameter("client.retry.interval", document.getElementById('client_retry_interval').value);
-        addServiceParameter("max.delivery.attempts", document.getElementById('max_delivery_attempts').value);
+        addServiceParameter("max.delivery.attempts", document.getElementById('max_redelivery_attempts').value);
         addServiceParameter("message.processor.fault.sequence", document.getElementById('message_processor_fault_sequence').value);
         addServiceParameter("message.processor.deactivate.sequence", document.getElementById('message_processor_deactivate_sequence').value);
         addServiceParameter("quartz.conf", document.getElementById('quartz_conf').value);
@@ -458,9 +458,9 @@
                     </tr>
                     <tr>
                         <td><fmt:message key="max.redelivery.attempts"/></td>
-                        <td><input type="text" id="max_delivery_attempts" name="max_delivery_attempts"
+                        <td><input type="text" id="max_redelivery_attempts" name="max_redelivery_attempts"
                                    value="<%=((null!=processorData)&& processorData.getParams() != null
-                                        && !processorData.getParams().isEmpty()&&(processorData.getParams().get("max.redelivery.attempts")!=null))?processorData.getParams().get("max.redelivery.attempts"):"1000"%>"
+                                        && !processorData.getParams().isEmpty()&&(processorData.getParams().get("max.delivery.attempts")!=null))?processorData.getParams().get("max.delivery.attempts"):"1000"%>"
                                 />
                         </td>
                     </tr>

--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageMessageForwardingProcessor.jsp
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageMessageForwardingProcessor.jsp
@@ -103,15 +103,15 @@
             return false;
         }
         
-        if (IsEmpty(form.max_delivery_attempts) && form.max_delivery_drop.value.trim() == "Enabled") {
+        if (IsEmpty(form.max_redelivery_attempts) && form.max_delivery_drop.value.trim() == "Enabled") {
             CARBON.showWarningDialog('<fmt:message key="drop.message.Error.empty"/>')
-            form.max_delivery_attempts.focus();
+            form.max_redelivery_attempts.focus();
             return false;
         }
         
-        if (form.max_delivery_attempts.value.trim() < 1 && form.max_delivery_drop.value.trim() == "Enabled") {
+        if (form.max_redelivery_attempts.value.trim() < 1 && form.max_delivery_drop.value.trim() == "Enabled") {
             CARBON.showWarningDialog('<fmt:message key="drop.message.Error.less.than.one"/>')
-            form.max_delivery_attempts.focus();
+            form.max_redelivery_attempts.focus();
             return false;
         }
 
@@ -161,7 +161,7 @@
     	document.getElementById("tableParams").value = "";
         addServiceParameter("interval", document.getElementById('retry_interval').value);
         addServiceParameter("client.retry.interval", document.getElementById('client_retry_interval').value);
-        addServiceParameter("max.delivery.attempts", document.getElementById('max_delivery_attempts').value);
+        addServiceParameter("max.delivery.attempts", document.getElementById('max_redelivery_attempts').value);
         addServiceParameter("axis2.repo", document.getElementById('axis2_repo').value);
         addServiceParameter("axis2.config", document.getElementById('axis2_config').value);
         addServiceParameter("message.processor.reply.sequence", document.getElementById('message_processor_reply_sequence').value);
@@ -454,9 +454,9 @@
                     </tr>
                     <tr>
                         <td><fmt:message key="max.redelivery.attempts"/></td>
-                        <td><input type="text" id="max_delivery_attempts" name="max_delivery_attempts"
+                        <td><input type="text" id="max_redelivery_attempts" name="max_redelivery_attempts"
                                    value="<%=((null!=processorData)&& processorData.getParams() != null
-                                        && !processorData.getParams().isEmpty()&&(processorData.getParams().get("max.redelivery.attempts")!=null))?processorData.getParams().get("max.redelivery.attempts"):"4"%>"
+                                        && !processorData.getParams().isEmpty()&&(processorData.getParams().get("max.delivery.attempts")!=null))?processorData.getParams().get("max.delivery.attempts"):"4"%>"
                                 />
                         </td>
                     </tr>


### PR DESCRIPTION
Maximum redelivery attempts value is not reflected correctly in Message Processor UI when updated through UI. This fix is to correctly display the updated value.
Related JIRA : https://wso2.org/jira/browse/ESBJAVA-5090