### PR TITLE
Retrieve AxisService from ProxyService to update service params

### DIFF
--- a/components/mediation-initializer/org.wso2.carbon.mediation.initializer/src/main/java/org/wso2/carbon/mediation/initializer/CarbonSynapseController.java
+++ b/components/mediation-initializer/org.wso2.carbon.mediation.initializer/src/main/java/org/wso2/carbon/mediation/initializer/CarbonSynapseController.java
@@ -62,6 +62,8 @@ public class CarbonSynapseController extends Axis2SynapseController {
 
     private static final Log log = LogFactory.getLog(CarbonSynapseController.class);
 
+    private static final String PARAMETER_VALUE_TRUE = Boolean.toString(true);
+
     private String currentConfigurationName;
 
     private String synapseXMLLocation;
@@ -200,16 +202,15 @@ public class CarbonSynapseController extends Axis2SynapseController {
         AxisConfiguration axisConfiguration = synapseConfiguration.getAxisConfiguration();
         for(ProxyService proxy : synapseConfiguration.getProxyServices()) {
             try {
-                axisConfiguration.getService(proxy.getName()).addParameter(
-                    CarbonConstants.KEEP_SERVICE_HISTORY_PARAM , "true");
+                proxy.getAxisService().addParameter(CarbonConstants.KEEP_SERVICE_HISTORY_PARAM, PARAMETER_VALUE_TRUE);
             } catch (AxisFault axisFault) {
-                log.error("Error while accesing the Proxy Service " + proxy.getName()
+                log.error("Error while accessing the Proxy Service " + proxy.getName()
                         + ". Service configuration history might get lost", axisFault);
             }
 
         }
 
-        // finally call the super logic to do the destroy tasks afetr persisting
+        // finally call the super logic to do the destroy tasks after persisting
         super.destroySynapseEnvironment();
     }
 


### PR DESCRIPTION
- Set "keepServiceHistory" parameter to "true" for all the proxy services on server shutdown to preserve parameters saved in the registry.
- Retrieved service can be inactive. Hence we can't use AxisConfiguration to retrieve AxisService. It only returns active Axis Services.

Fix: https://wso2.org/jira/browse/ESBJAVA-5105
