### PR TITLE
[ESBJAVA-5056] Add the ability to provide db pool info through registry in DB mediators

### DIFF
--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.dblookup.ui/src/main/java/org/wso2/carbon/mediator/dblookup/DBLookupMediator.java
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.dblookup.ui/src/main/java/org/wso2/carbon/mediator/dblookup/DBLookupMediator.java
@@ -30,6 +30,7 @@ import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamConstants;
 import java.util.*;
 import java.sql.Types;
+import java.util.regex.Pattern;
 
 public class DBLookupMediator extends AbstractMediator {
     public static final QName URL_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "url");
@@ -47,6 +48,8 @@ public class DBLookupMediator extends AbstractMediator {
 
     static final QName ATT_COLUMN = new QName("column");
     static final QName ATT_TYPE = new QName("type");
+    static final String REGISTRY_KEY_PREFIX = "$registry:";
+    static final String ATT_KEY = "key";
 
 
     protected final Map dataSourceProps = new HashMap();
@@ -97,7 +100,13 @@ public class DBLookupMediator extends AbstractMediator {
             if (o instanceof QName) {
                 QName name = (QName) o;
                 OMElement elt = fac.createOMElement(name.getLocalPart(), synNS);
-                elt.setText(value);
+                //set as the key attribute if starts with $registry
+                if (value != null && value.startsWith(REGISTRY_KEY_PREFIX)) {
+                    value = value.replaceFirst(Pattern.quote(REGISTRY_KEY_PREFIX), "");
+                    elt.addAttribute(fac.createOMAttribute(ATT_KEY, nullNS, value));
+                } else {
+                    elt.setText(value);
+                }
                 poolElt.addChild(elt);
 
             } else if (o instanceof String) {
@@ -335,10 +344,26 @@ public class DBLookupMediator extends AbstractMediator {
 
     private void createCustomDataSource(OMElement pool) {
         //save loaded properties for later
-        dataSourceProps.put(DRIVER_Q, getValue(pool, DRIVER_Q));
-        dataSourceProps.put(URL_Q, getValue(pool, URL_Q));
-        dataSourceProps.put(USER_Q, getValue(pool, USER_Q));
-        dataSourceProps.put(PASS_Q, getValue(pool, PASS_Q));
+        if (getKey(pool,DRIVER_Q) != null) {
+            dataSourceProps.put(DRIVER_Q, REGISTRY_KEY_PREFIX + getKey(pool,DRIVER_Q));
+        } else {
+            dataSourceProps.put(DRIVER_Q, getValue(pool,DRIVER_Q));
+        }
+        if (getKey(pool,URL_Q) != null) {
+            dataSourceProps.put(URL_Q, REGISTRY_KEY_PREFIX + getKey(pool,URL_Q));
+        } else {
+            dataSourceProps.put(URL_Q, getValue(pool,URL_Q));
+        }
+        if (getKey(pool,USER_Q) != null) {
+            dataSourceProps.put(USER_Q, REGISTRY_KEY_PREFIX + getKey(pool,USER_Q));
+        } else {
+            dataSourceProps.put(USER_Q, getValue(pool,USER_Q));
+        }
+        if (getKey(pool,PASS_Q) != null) {
+            dataSourceProps.put(PASS_Q, REGISTRY_KEY_PREFIX + getKey(pool,PASS_Q));
+        } else {
+            dataSourceProps.put(PASS_Q, getValue(pool,PASS_Q));
+        }
 
         Iterator props = pool.getChildrenWithName(PROP_Q);
         while (props.hasNext()) {
@@ -347,6 +372,21 @@ public class DBLookupMediator extends AbstractMediator {
             String name = prop.getAttribute(ATT_NAME).getAttributeValue();
             String value = prop.getAttribute(ATT_VALUE).getAttributeValue();            
             dataSourceProps.put(name, value);
+        }
+    }
+
+    /**
+     * Get the value of the given key attribute of the element with QName
+     * @param pool
+     * @param qName
+     * @return key attribute value
+     */
+    private String getKey(OMElement pool, QName qName) {
+        OMElement ele = pool.getFirstChildWithName(qName);
+        if (ele != null) {
+            return ele.getAttributeValue(new QName(ATT_KEY));
+        } else {
+            return null;
         }
     }
 

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.dblookup.ui/src/main/java/org/wso2/carbon/mediator/dblookup/DBLookupMediator.java
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.dblookup.ui/src/main/java/org/wso2/carbon/mediator/dblookup/DBLookupMediator.java
@@ -385,9 +385,9 @@ public class DBLookupMediator extends AbstractMediator {
         OMElement ele = pool.getFirstChildWithName(qName);
         if (ele != null) {
             return ele.getAttributeValue(new QName(ATT_KEY));
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     protected String getValue(OMElement elt, QName qName) {

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.dbreport.ui/src/main/java/org/wso2/carbon/mediator/dbreport/DBReportMediator.java
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.dbreport.ui/src/main/java/org/wso2/carbon/mediator/dbreport/DBReportMediator.java
@@ -407,9 +407,8 @@ public class DBReportMediator extends AbstractMediator {
         OMElement ele = pool.getFirstChildWithName(qName);
         if (ele != null) {
             return ele.getAttributeValue(new QName(ATT_KEY));
-        } else {
-            return null;
         }
+        return null;
     }
 
     protected String getValue(OMElement elt, QName qName) {


### PR DESCRIPTION
This enables providing registry resource as the key attribute for db
pool config in external datasource config for DBLookup and DBReport
mediators. Fix for https://wso2.org/jira/browse/ESBJAVA-5056.