### PR TITLE
Fix ESBJAVA-5138

### DIFF
--- a/components/business-adaptors/sap/src/main/java/org/wso2/carbon/transports/sap/SAPTransportSender.java
+++ b/components/business-adaptors/sap/src/main/java/org/wso2/carbon/transports/sap/SAPTransportSender.java
@@ -72,6 +72,11 @@ public class SAPTransportSender extends AbstractTransportSender {
     public static final int SAP_TRANSPORT_ERROR = 8000;
 
     /**
+     * String constant for the header name of sap transaciton id.
+     */
+    public static final String SAP_TRANSACTION_ID = "SAP-Transaction-Id";
+
+    /**
      * SAP destination error. Possibly something wrong with the remote R/* system
      */
     public static final int SAP_DESTINATION_ERROR = 8001;
@@ -131,8 +136,15 @@ public class SAPTransportSender extends AbstractTransportSender {
                 IDocRepository iDocRepository = JCoIDoc.getIDocRepository(destination);
                 String tid = destination.createTID();
                 IDocDocumentList iDocList = getIDocs(messageContext, iDocRepository);
+
+                //Set the transaction id as a transport header so that it can be used later.
+                Object headers = messageContext.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
+                Map headersMap = (Map) headers;
+                headersMap.put(SAP_TRANSACTION_ID, tid);
+
                 JCoIDoc.send(iDocList, getIDocVersion(uri), destination, tid);
                 destination.confirmTID(tid);
+
             } else if (uri.getScheme().equals(SAPConstants.SAP_BAPI_PROTOCOL_NAME)) {
                 try {
                     OMElement payLoad,body;


### PR DESCRIPTION
The trasnaction id used for the communication between SAP and the
SAPTransaportSender to send IDOCs can be of intereset when it comes to
responding to the client back in a Proxy. It could be used to track
what transactions were successful and what failed. The improvement was
to set it as a transport header to the synapse context so that it can
be refererded to, in the synapse sequence.
Addresses the issue at: https://wso2.org/jira/browse/ESBJAVA-5138