### PR TITLE
Fix CApp artifact undeployment order

### DIFF
--- a/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/SynapseAppDeployer.java
+++ b/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/SynapseAppDeployer.java
@@ -68,6 +68,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
@@ -156,6 +157,8 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
 
         List<Artifact.Dependency> artifacts = carbonApplication.getAppConfig()
                 .getApplicationArtifact().getDependencies();
+        // Fixing ESBJAVA-5201, reverses the artifact order
+        Collections.reverse(artifacts);
 
         for (Artifact.Dependency dep : artifacts) {
 


### PR DESCRIPTION
This includes the fix for handling CApp artifact undeployment order where it reverses the order of the artifacts in the artifacts.xml file before undeploying

public jira - https://wso2.org/jira/browse/ESBJAVA-5201