### PR TITLE
Fix event sink receiver url validation

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.event.sink.config.ui/src/main/resources/web/event-sink-config/add_event_sink.jsp
+++ b/components/mediation-ui/org.wso2.carbon.event.sink.config.ui/src/main/resources/web/event-sink-config/add_event_sink.jsp
@@ -55,7 +55,7 @@
         }
 
         var receiverUrlCheck
-                = (receiverUrl.value.trim()).match(/^tcp?:\/\/\w+(\.\w+)*(:[0-9]{1,5})/g);
+                = (receiverUrl.value.trim()).match(/^tcp?:\/\/\w+(\.\w+)*(:[0-9]{1,5})(,\s*tcp?:\/\/\w+(\.\w+)*(:[0-9]{1,5}))*/g);
         if (!(receiverUrlCheck == (receiverUrl.value.trim()))) {
             CARBON.showErrorDialog("Invalid url format in Receiver url");
             return false;
@@ -110,7 +110,7 @@
     }
 
     function testURL(url, protocol) {
-        var receiverUrlCheck = (url.trim()).match(/^tcp?:\/\/\w+(\.\w+)*(:[0-9]{1,5})/g);
+        var receiverUrlCheck = (url.trim()).match(/^tcp?:\/\/\w+(\.\w+)*(:[0-9]{1,5})(,\s*tcp?:\/\/\w+(\.\w+)*(:[0-9]{1,5}))*/g);
         var authenticationUrlCheck = (url.trim()).match(/^ssl?:\/\/\w+(\.\w+)*(:[0-9]{1,5})/g);
         if (url == '') {
             CARBON.showErrorDialog("server url cannot be empty");


### PR DESCRIPTION
This PR contains the fix for the event sink URL validation issue.
This fix allows adding multiple URLs separated by commas in the Receiver URL field.
Related git issue: https://github.com/wso2/product-ei/issues/835 