### PR TITLE
Fix for Log Separator in Log mediator

### DIFF
--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.log.ui/src/main/java/org/wso2/carbon/mediator/log/LogMediator.java
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.log.ui/src/main/java/org/wso2/carbon/mediator/log/LogMediator.java
@@ -79,7 +79,7 @@ public class LogMediator extends AbstractMediator {
     }
 
     public String getSeparator() {
-        return separator;
+        return separator.replace("\n","\\n").replace("\t","\\t");
     }
 
     public int getLogCategory() {
@@ -99,7 +99,7 @@ public class LogMediator extends AbstractMediator {
     }
 
     public void setSeparator(String separator) {
-        this.separator = separator;
+        this.separator = separator.replace("\\n", "\n").replace("\\t", "\t");
     }
 
     public void addProperty(MediatorProperty p) {


### PR DESCRIPTION
Fixed the issue of not converting log separator characters '\t' and '\n' into
relevant encoded characters in the source view, when adding it from the design view.
Related Issue : https://wso2.org/jira/browse/ESBJAVA-4484