### PR TITLE
[EI-909] Add "buildMessage" attribute to management console

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/java/org/wso2/carbon/endpoint/ui/endpoints/failover/FailoverEndpoint.java
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/java/org/wso2/carbon/endpoint/ui/endpoints/failover/FailoverEndpoint.java
@@ -31,6 +31,7 @@ public class FailoverEndpoint extends ListEndpoint {
 
     private String properties = null;
     private String name;
+    private boolean buildMessage;
 
     public String getTagLocalName() {
         return "failover";
@@ -52,6 +53,14 @@ public class FailoverEndpoint extends ListEndpoint {
         this.properties = properties;
     }
 
+    public boolean isBuildMessage() {
+        return buildMessage;
+    }
+
+    public void setBuildMessage(boolean buildMessage) {
+        this.buildMessage = buildMessage;
+    }
+
     public OMElement serialize(OMElement parent) {
 
         // top element
@@ -63,6 +72,9 @@ public class FailoverEndpoint extends ListEndpoint {
 
         // failover element
         OMElement failover = fac.createOMElement("failover", synNS);
+        if (buildMessage) {
+            failover.addAttribute(fac.createOMAttribute("buildMessage", nullNS, Boolean.toString(true)));
+        }
 
         // Properties
         if (properties != null && properties.length() != 0) {
@@ -92,7 +104,14 @@ public class FailoverEndpoint extends ListEndpoint {
         if (isAnonymous) {
             elem.addAttribute("name", "anonymous", elem.getOMFactory().createOMNamespace("", ""));
         }
-        org.apache.synapse.endpoints.Endpoint failoverEndpoint = EndpointFactory.getEndpointFromElement(elem, isAnonymous, new Properties());
+        org.apache.synapse.endpoints.Endpoint failoverEndpoint = EndpointFactory
+                .getEndpointFromElement(elem, isAnonymous, new Properties());
+
+        if (failoverEndpoint instanceof org.apache.synapse.endpoints.FailoverEndpoint) {
+            org.apache.synapse.endpoints.FailoverEndpoint failOverEndpoint =
+                    (org.apache.synapse.endpoints.FailoverEndpoint) failoverEndpoint;
+            buildMessage = failOverEndpoint.isBuildMessageAtt();
+        }
         if (failoverEndpoint.getName() != null) {
             name = failoverEndpoint.getName().equals("anonymous") ? "" : failoverEndpoint.getName();
         }

--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/java/org/wso2/carbon/endpoint/ui/endpoints/loadbalance/LoadBalanceEndpoint.java
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/java/org/wso2/carbon/endpoint/ui/endpoints/loadbalance/LoadBalanceEndpoint.java
@@ -20,6 +20,7 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.config.xml.endpoints.DefinitionFactory;
 import org.apache.synapse.config.xml.endpoints.EndpointFactory;
 import org.apache.synapse.config.xml.endpoints.SALoadbalanceEndpointFactory;
+import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.AbstractEndpoint;
 import org.apache.synapse.endpoints.LoadbalanceEndpoint;
 import org.apache.synapse.endpoints.SALoadbalanceEndpoint;
@@ -38,6 +39,7 @@ public class LoadBalanceEndpoint extends ListEndpoint {
     private long sessionTimeout = 0;
     private String name;
     private String algorithmClassName = EndpointConfigurationHelper.ROUNDROBIN_ALGO_CLASS_NAME;
+    private boolean buildMessage;
 
     public String getTagLocalName() {
         return "loadbalance";
@@ -83,6 +85,14 @@ public class LoadBalanceEndpoint extends ListEndpoint {
         this.algorithmClassName = algorithmClassName;
     }
 
+    public boolean isBuildMessage() {
+        return buildMessage;
+    }
+
+    public void setBuildMessage(boolean buildMessage) {
+        this.buildMessage = buildMessage;
+    }
+
     public OMElement serialize(OMElement parent) {
         // top element
         OMElement endpoint = fac.createOMElement("endpoint", synNS);
@@ -95,6 +105,10 @@ public class LoadBalanceEndpoint extends ListEndpoint {
         // load balance element
         OMElement loadbalance = fac.createOMElement("loadbalance", synNS);
         loadbalance.addAttribute(fac.createOMAttribute("algorithm", nullNS, algorithmClassName));
+
+        if (buildMessage) {
+            loadbalance.addAttribute(fac.createOMAttribute("buildMessage", nullNS, Boolean.toString(true)));
+        }
 
         // session
         if (sessionType != null) {
@@ -135,7 +149,8 @@ public class LoadBalanceEndpoint extends ListEndpoint {
         if (isAnonymous) {
             elem.addAttribute("name", "anonymous", elem.getOMFactory().createOMNamespace("", ""));
         }
-        org.apache.synapse.endpoints.Endpoint loadbalanceEndpoint = SALoadbalanceEndpointFactory.getEndpointFromElement(elem, isAnonymous, new Properties());
+        org.apache.synapse.endpoints.Endpoint loadbalanceEndpoint = SALoadbalanceEndpointFactory
+                .getEndpointFromElement(elem, isAnonymous, new Properties());
 
         if (loadbalanceEndpoint != null && loadbalanceEndpoint instanceof SALoadbalanceEndpoint) {
             SALoadbalanceEndpoint saLoadBalanceDataElement = (SALoadbalanceEndpoint) loadbalanceEndpoint;
@@ -146,11 +161,13 @@ public class LoadBalanceEndpoint extends ListEndpoint {
                 algorithmClassName = saLoadBalanceDataElement.getAlgorithm().getClass().getName();
             }
             sessionTimeout = saLoadBalanceDataElement.getSessionTimeout();
-            OMElement sessionElement = elem.getFirstChildWithName(new QName(SynapseConstants.SYNAPSE_NAMESPACE, "session"));
+            OMElement sessionElement = elem
+                    .getFirstChildWithName(new QName(SynapseConstants.SYNAPSE_NAMESPACE, "session"));
             String session = sessionElement.getAttributeValue(new QName(null, "type"));
             if (session != null && !"".equals(session)) {
                 sessionType = session;
             }
+            buildMessage = saLoadBalanceDataElement.isBuildMessageAtt();
         } else {
             loadbalanceEndpoint = EndpointFactory.getEndpointFromElement(elem, isAnonymous, new Properties());
             if (loadbalanceEndpoint != null) {
@@ -161,6 +178,7 @@ public class LoadBalanceEndpoint extends ListEndpoint {
                 if (loadBalanceEndpoint.getAlgorithm() != null) {
                     algorithmClassName = loadBalanceEndpoint.getAlgorithm().getClass().getName();
                 }
+                buildMessage = loadBalanceEndpoint.isBuildMessageAtt();
             }
         }
 

--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/org/wso2/carbon/endpoint/ui/i18n/Resources.properties
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/org/wso2/carbon/endpoint/ui/i18n/Resources.properties
@@ -86,6 +86,7 @@ please.enter.a.numeric.value.to.the.suspend.duration.seconds.field=Please enter 
 please.enter.a.valid.session.time.out.number=Please enter a valid number to session timeout
 error.updating.the.configuration=Error while updating the configuration
 select=Select
+buildMessage=Build Message
 address.endpoint=Address Endpoint
 address.endpoint.template=Address Endpoint Template
 edit.endpoint= Edit Endpoint

--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/failoverEndpoint.jsp
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/failoverEndpoint.jsp
@@ -142,11 +142,13 @@
 
     String failoverEndpointName = "";
     String properties = "";
+    boolean isBuildMessage = false;
 
     if (endpoint != null) {
         if (endpoint.getName() != null) {
             failoverEndpointName = endpoint.getName();
         }
+        isBuildMessage = endpoint.isBuildMessage();
         if (endpoint.getProperties() != null) {
             properties = endpoint.getProperties();
         }
@@ -215,6 +217,16 @@
                                            value="<%=failoverEndpointName%>"/>
                                     <input type="hidden" name="isAnnonEndpointID"
                                            id="isAnnonEndpointID" value="<%=isAnonymous%>"/>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="leftCol-small"><fmt:message key="buildMessage"/>
+                                </td>
+                                <td>
+                                    <select name="buildMessage" id="_buildMessage">
+                                        <option <%=isBuildMessage ? "selected" : ""%> value="true">True</option>
+                                        <option <%=!isBuildMessage ? "selected" : ""%> value="false">False</option>
+                                    </select>
                                 </td>
                             </tr>
                         </table>

--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/loadBalanceEndpoint.jsp
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/loadBalanceEndpoint.jsp
@@ -154,6 +154,7 @@
     boolean isRoundRobin = true;
     long sessionTimeout = 0;
     String properties = "";
+    boolean isBuildMessage = false;
 
     if (endpoint != null) {
         if (endpoint.getName() != null) {
@@ -165,6 +166,7 @@
         if (!algorithmClassName.equals(EndpointConfigurationHelper.ROUNDROBIN_ALGO_CLASS_NAME)) {
             isRoundRobin = false;
         }
+        isBuildMessage = endpoint.isBuildMessage();
         String sessionType = endpoint.getSessionType();
         if (sessionType != null) {
             if (sessionType.equals("http")) {
@@ -302,6 +304,15 @@
                         <input name="algoClassName" type="text" id="_algoClassName"
                                style="width:450px;"
                                value="<%=algorithmClassName%>"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="leftCol-small"><fmt:message key="buildMessage"/></td>
+                    <td>
+                        <select name="buildMessage" id="_buildMessage">
+                            <option <%=isBuildMessage ? "selected" : ""%> value="true">True</option>
+                            <option <%=!isBuildMessage ? "selected" : ""%> value="false">False</option>
+                        </select>
                     </td>
                 </tr>
                 <tr>

--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/updatePages/failoverEndpoint-update.jsp
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/updatePages/failoverEndpoint-update.jsp
@@ -25,9 +25,12 @@
 
         String name = request.getParameter("listEndpointName");
         String properties = request.getParameter("endpointProperties");
+        String buildMessage = request.getParameter("buildMessage");
         if (name != null) {
             endpoint.setName(name);
         }
+        boolean buildMessageBoolean = Boolean.parseBoolean(buildMessage);
+        endpoint.setBuildMessage(buildMessageBoolean);
         if (properties != null) {
             endpoint.setProperties(properties);
         }

--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/updatePages/loadBalanceEndpoint-update.jsp
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/updatePages/loadBalanceEndpoint-update.jsp
@@ -44,10 +44,13 @@
         String sessionType = request.getParameter("sessionManagement");
         String sessionTimeout = request.getParameter("sessionTimeOut");
         String properties = request.getParameter("endpointProperties");
+        String buildMessage = request.getParameter("buildMessage");
 
         if (name != null) {
             endpoint.setName(name);
         }
+        boolean buildMessageBoolean = Boolean.parseBoolean(buildMessage);
+        endpoint.setBuildMessage(buildMessageBoolean);
         if (algo != null && algo.equals("other") && algoClassName != null) {
             endpoint.setAlgorithmClassName(algoClassName);
         } else {


### PR DESCRIPTION
Fix the issue of not supporting "buildMessage" attribute of failover and
loadbalance endpoint in the management console.
Related issue : wso2/product-ei#909