### PR TITLE
Update synapse version to the released version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2322,7 +2322,7 @@
         <carbon.rule.imp.pkg.version>[4.4.0, 4.5.0)</carbon.rule.imp.pkg.version>
 
         <!-- Synapse Version -->
-        <synapse.version>2.1.7-wso2v19-SNAPSHOT</synapse.version>
+        <synapse.version>2.1.7-wso2v19</synapse.version>
 
         <carbon.identity.entitlement.proxy.version>5.1.1</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.0.0, 6.0.0)</carbon.identity.entitlement.proxy.imp.pkg.version>


### PR DESCRIPTION
This PR updates the synapse version to the latest released version: 2.1.7-wso2v19.