### PR TITLE
Fix JMS inbound endpoint cached resource refresh issue

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
@@ -265,9 +265,10 @@ public class JMSPollingConsumer {
             }
 
         } catch (JMSException e) {
-            logger.error("Error while receiving JMS message. " + e.getMessage(), e);
+            logger.error("Error while receiving JMS message for " + name, e);
+            releaseResources(true);
         } catch (Exception e) {
-            logger.error("Error while receiving JMS message. " + e.getMessage(), e);
+            logger.error("Error while receiving JMS message for " + name, e);
         } finally {
             if (!isConnected) {
                 if (reconnectDuration != null) {
@@ -296,19 +297,29 @@ public class JMSPollingConsumer {
                        practice the Interrupted flag is set back to TRUE in this thread. */
                 }
             }
-            if (messageConsumer != null) {
-                jmsConnectionFactory.closeConsumer(messageConsumer);
-            }
-            if (session != null) {
-                jmsConnectionFactory.closeSession(session);
-            }
-            if (connection != null) {
-                jmsConnectionFactory.closeConnection(connection);
-            }
+            releaseResources(false);
         }
         return null;
     }
-    
+
+    /**
+     * Release the JMS connection, session and consumer to the pool or forcefully close the resource.
+     *
+     * @param forcefullyClose false if the resource needs to be released to the pool and true other wise
+     *
+     */
+    private void releaseResources(boolean forcefullyClose) {
+        if (messageConsumer != null) {
+            jmsConnectionFactory.closeConsumer(messageConsumer, forcefullyClose);
+        }
+        if (session != null) {
+            jmsConnectionFactory.closeSession(session, forcefullyClose);
+        }
+        if (connection != null) {
+            jmsConnectionFactory.closeConnection(connection, forcefullyClose);
+        }
+    }
+
     public void destroy(){
         if (messageConsumer != null) {
             jmsConnectionFactory.closeConsumer(messageConsumer, true);

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/factory/CachedJMSConnectionFactory.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/factory/CachedJMSConnectionFactory.java
@@ -72,7 +72,8 @@ public class CachedJMSConnectionFactory extends JMSConnectionFactory {
         try {
         	connection.start();
         } catch (JMSException e) {
-            logger.error("JMS Exception while starting connection for factory '" + this.connectionFactoryString + "' " + e.getMessage());
+            logger.error("JMS Exception while starting connection for factory '"
+                    + this.connectionFactoryString + "' ", e);
             resetCache();
             return null;
         }        
@@ -151,7 +152,7 @@ public class CachedJMSConnectionFactory extends JMSConnectionFactory {
         	}
             return true;
         } catch (JMSException e) {
-            logger.error("JMS Exception while closing the connection.");
+            logger.error("JMS Exception while closing the connection.", e);
         }
         return false;
     }
@@ -174,7 +175,7 @@ public class CachedJMSConnectionFactory extends JMSConnectionFactory {
             	connection.close();
             }
         } catch (JMSException e) {
-            logger.error("JMS Exception while closing the connection.");
+            logger.error("JMS Exception while closing the connection.", e);
         }
         return false;
     }    
@@ -185,7 +186,7 @@ public class CachedJMSConnectionFactory extends JMSConnectionFactory {
             	messageConsumer.close();
             }
         } catch (JMSException e) {
-            logger.error("JMS Exception while closing the consumer.");
+            logger.error("JMS Exception while closing the consumer.", e);
         }
         return false;
     }     
@@ -196,7 +197,7 @@ public class CachedJMSConnectionFactory extends JMSConnectionFactory {
             	session.close();
             }
         } catch (JMSException e) {
-            logger.error("JMS Exception while closing the consumer.");
+            logger.error("JMS Exception while closing the consumer.", e);
         }
         return false;
     }     


### PR DESCRIPTION
- Cached connections, sessions, and consumers don't get refreshed after a service interruption. This commit fixes that issue by reestablishing connections, sessions, and consumers.

Issue: https://github.com/wso2/product-ei/issues/999