### PR TITLE
Add granular permissions for capps and connectors

### DIFF
--- a/components/application-mgt/org.wso2.carbon.application.mgt.synapse/src/main/resources/META-INF/services.xml
+++ b/components/application-mgt/org.wso2.carbon.application.mgt.synapse/src/main/resources/META-INF/services.xml
@@ -26,7 +26,7 @@
         </parameter>
     </service>
 
-    <parameter name="AuthorizationAction" locked="true">/permission/admin/manage</parameter>
+    <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/mediation</parameter>
     <parameter name="adminService" locked="true">true</parameter>
     <parameter name="hiddenService" locked="true">true</parameter>
 </serviceGroup>

--- a/components/mediation-ui/org.wso2.carbon.mediation.library.ui/src/main/resources/META-INF/component.xml
+++ b/components/mediation-ui/org.wso2.carbon.mediation.library.ui/src/main/resources/META-INF/component.xml
@@ -16,6 +16,22 @@
  ~ under the License.
  -->
 <component xmlns="http://products.wso2.org/carbon">
+
+    <ManagementPermissions>
+        <ManagementPermission>
+            <DisplayName>Connectors</DisplayName>
+            <ResourceId>/permission/admin/manage/connectors</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>list</DisplayName>
+            <ResourceId>/permission/admin/manage/connectors/list</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>add</DisplayName>
+            <ResourceId>/permission/admin/manage/connectors/add</ResourceId>
+        </ManagementPermission>
+    </ManagementPermissions>
+
 	<menus>
 	    <menu>
             <id>libs_menu</id>
@@ -38,7 +54,7 @@
 			<order>5</order>
 			<style-class>manage</style-class>
             <icon>../mediation_library/images/list.gif</icon>
-            <require-permission>/permission/admin/manage</require-permission>
+            <require-permission>/permission/admin/manage/connectors/list</require-permission>
         </menu>
 		 <menu>
             <id>libs_add_menu</id>
@@ -50,7 +66,7 @@
             <order>10</order>
             <style-class>manage</style-class>
             <icon>../mediation_library/images/add.gif</icon>
-            <require-permission>/permission/admin/manage/add/application</require-permission>
+            <require-permission>/permission/admin/manage/connectors/add</require-permission>
         </menu>
 	</menus>
 


### PR DESCRIPTION
Currently, the list/add actions for connectors and carbon apps are assigned to "permission/admin/manage" root level permission. In a scenario where a user needs to give only specific permissions (e.g. identity/user/add) under "permission/admin/manage", the current approach will not work. Therefore adding more granular permissions.

Git Issue       : https://github.com/wso2/product-ei/issues/932