### PR TITLE
Resolve wso2/product-ei#1010

### DIFF
--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CachableResponse.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CachableResponse.java
@@ -228,7 +228,7 @@ public class CachableResponse implements Serializable {
     /**
      * @return HTTP response's Reason- Phrase that is sent by the backend.
      */
-    public String getStatusReason() {
+    public Object getStatusReason() {
         return statusReason;
     }
 


### PR DESCRIPTION
 ## Purpose
Resolve wso2/product-ei#1010
## Goals
Avoid NullPointerException in cache mediator when generating a response from EI if there are no call to the backend before the collector.

## Approach
The fix was to check for null in relevant places and ensure no NullPointerException is thrown.

## User stories
N/A

## Release note
wso2/product-ei#1010 NullPointerException in cache mediator when generating a response from EI 

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   Needs to be added to product-ei

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
https://github.com/wso2/carbon-mediation/pull/843

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8.0 Ubuntu 16.04
 
## Learning
N/A