### PR TITLE
Resolve wso2/product-ei#971

### DIFF
--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/java/org/wso2/carbon/mediator/cache/ui/CacheMediator.java
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/java/org/wso2/carbon/mediator/cache/ui/CacheMediator.java
@@ -31,77 +31,77 @@ import javax.xml.namespace.QName;
 public class CacheMediator extends AbstractListMediator {
 
     /**
-     * QName of the collector
+     * QName of the collector.
      */
     private static final QName ATT_COLLECTOR = new QName(CachingConstants.COLLECTOR_STRING);
 
     /**
-     * QName of the maximum message size
+     * QName of the maximum message size.
      */
     private static final QName ATT_MAX_MSG_SIZE = new QName(CachingConstants.MAX_MESSAGE_SIZE_STRING);
 
     /**
-     * QName of the timeout
+     * QName of the timeout.
      */
     private static final QName ATT_TIMEOUT = new QName(CachingConstants.TIMEOUT_STRING);
 
     /**
-     * QName of the mediator sequence
+     * QName of the mediator sequence.
      */
     private static final QName ATT_SEQUENCE = new QName(CachingConstants.SEQUENCE_STRING);
 
     /**
-     * QName of the implementation type
+     * QName of the implementation type.
      */
     private static final QName ATT_TYPE = new QName(CachingConstants.TYPE_STRING);
 
     /**
-     * QName of the maximum message size
+     * QName of the maximum message size.
      */
     private static final QName ATT_SIZE = new QName(CachingConstants.MAX_SIZE_STRING);
 
     /**
-     * QName of the onCacheHit mediator sequence reference
+     * QName of the onCacheHit mediator sequence reference.
      */
     private static final QName ON_CACHE_HIT_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE,
                                                           CachingConstants.ON_CACHE_HIT_STRING);
 
     /**
-     * QName of the cache implementation
+     * QName of the cache implementation.
      */
     private static final QName IMPLEMENTATION_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE,
                                                             CachingConstants.IMPLEMENTATION_STRING);
 
     /**
-     * This holds the default timeout of the mediator cache
+     * This holds the default timeout of the mediator cache.
      */
     private static final long DEFAULT_TIMEOUT = 5000L;
 
     /**
-     * QName of the onCacheHit mediator sequence reference
+     * QName of the onCacheHit mediator sequence reference.
      */
     private static final QName PROTOCOL_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE,
                                                       CachingConstants.PROTOCOL_STRING);
 
     /**
-     * QName of the hTTPMethodToCache
+     * QName of the hTTPMethodToCache.
      */
     private static final QName HTTP_METHODS_TO_CACHE_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE,
                                                                    CachingConstants.METHODS_STRING);
 
     /**
-     * QName of the headersToExcludeInHash
+     * QName of the headersToExcludeInHash.
      */
     private static final QName HEADERS_TO_EXCLUDE_IN_HASH_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE,
                                                                         CachingConstants.HEADERS_TO_EXCLUDE_STRING);
     /**
-     * QName of the response codes to include when hashing
+     * QName of the response codes to include when hashing.
      */
     private static final QName RESPONSE_CODES_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE,
                                                             CachingConstants.RESPONSE_CODES_STRING);
 
     /**
-     * QName of the digest generator
+     * QName of the digest generator.
      */
     private static final QName HASH_GENERATOR_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE,
                                                             CachingConstants.HASH_GENERATOR_STRING);
@@ -140,22 +140,22 @@ public class CacheMediator extends AbstractListMediator {
     private int maxMessageSize = -1;
 
     /**
-     * The regex expression of the HTTP response code to be cached
+     * The regex expression of the HTTP response code to be cached.
      */
     private String responseCodes = CachingConstants.ANY_RESPONSE_CODE;
 
     /**
-     * The headers to exclude when caching
+     * The headers to exclude when caching.
      */
     private String headersToExcludeInHash = "";
 
     /**
-     * The protocol type used in caching
+     * The protocol type used in caching.
      */
     private String protocolType = CachingConstants.HTTP_PROTOCOL_TYPE;
 
     /**
-     * The http method type that needs to be cached
+     * The http method type that needs to be cached.
      */
     private String hTTPMethodsToCache = CachingConstants.ALL;
 
@@ -277,7 +277,7 @@ public class CacheMediator extends AbstractListMediator {
     }
 
     /**
-     * This method gives the HTTP method that needs to be cached
+     * This method gives the HTTP method that needs to be cached.
      *
      * @return the HTTP method to be cached
      */
@@ -286,7 +286,7 @@ public class CacheMediator extends AbstractListMediator {
     }
 
     /**
-     * This sets the HTTP method that needs to be cached
+     * This sets the HTTP method that needs to be cached.
      *
      * @param hTTPMethodToCache the HTTP method to be cached
      */
@@ -295,7 +295,8 @@ public class CacheMediator extends AbstractListMediator {
     }
 
     /**
-     * Returns the protocolType of the message
+     * Returns the protocolType of the message.
+     *
      * @return the protocol type of the messages
      */
     public String getProtocolType() {
@@ -312,7 +313,8 @@ public class CacheMediator extends AbstractListMediator {
     }
 
     /**
-     * Returns the response codes (regex expression)
+     * Returns the response codes (regex expression).
+     *
      * @return The regex expression of the HTTP response code of the messages to be cached
      */
     public String getResponseCodes() {
@@ -338,7 +340,7 @@ public class CacheMediator extends AbstractListMediator {
     }
 
     /**
-     * This method sets the array of headers that would be excluded when hashing
+     * This method sets the array of headers that would be excluded when hashing.
      *
      * @param headersToExcludeInHash array of headers to exclude from hashing.
      */
@@ -359,12 +361,12 @@ public class CacheMediator extends AbstractListMediator {
 
             cache.addAttribute(fac.createOMAttribute(CachingConstants.COLLECTOR_STRING, nullNS, "false"));
 
-            if (timeout != 0) {
+            if (timeout > -1) {
                 cache.addAttribute(
                         fac.createOMAttribute(CachingConstants.TIMEOUT_STRING, nullNS, Long.toString(timeout)));
             }
 
-            if (maxMessageSize != 0) {
+            if (maxMessageSize > -1) {
                 cache.addAttribute(fac.createOMAttribute(CachingConstants.MAX_MESSAGE_SIZE_STRING, nullNS,
                                                          Integer.toString(maxMessageSize)));
             }
@@ -425,8 +427,7 @@ public class CacheMediator extends AbstractListMediator {
     }
 
     /**
-     * Creates the cache mediator with given configuration XML as OMElement
-     *
+     * Creates the cache mediator with given configuration XML as OMElement.
      * @param elem OMElement to be converted to cache mediator Object.
      */
     public void build(OMElement elem) {

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/resources/web/cache-mediator/update-mediator.jsp
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/resources/web/cache-mediator/update-mediator.jsp
@@ -18,17 +18,15 @@
 <%@ page import="org.wso2.carbon.mediator.cache.ui.CacheMediator" %>
 <%@ page import="org.wso2.carbon.mediator.service.ui.Mediator" %>
 <%@ page import="org.wso2.carbon.sequences.ui.util.SequenceEditorHelper" %>
+<%@ page import="org.wso2.carbon.mediator.cache.CachingConstants" %>
 
 <%! public boolean notNullChecker(String strChecker) {
 
     if (strChecker == null) {
         return false;
-    } else if (strChecker != null) {
-        return true;
-    } else if ((!(strChecker.equalsIgnoreCase("")))) {
-        return true;
+    } else {
+        return !strChecker.isEmpty();
     }
-    return false;
 }%>
 <%
     Mediator mediator = SequenceEditorHelper.getEditingMediator(request, session);
@@ -55,39 +53,55 @@
             cacheMediator.setCollector(false);
         }
     }
+
     if (notNullChecker(cacheTimeout)) {
         try {
             cacheMediator.setTimeout(Long.parseLong(cacheTimeout));
         } catch (NumberFormatException e) {
-
+            //This is handled in the UI validation in mediator-util.js
         }
+    } else {
+        cacheMediator.setTimeout(CachingConstants.DEFAULT_TIMEOUT);
     }
+
     if (notNullChecker(maxMsgSize)) {
         try {
             cacheMediator.setMaxMessageSize(Integer.parseInt(maxMsgSize));
         } catch (NumberFormatException e) {
-
+            //This is handled in the UI validation in mediator-util.js
         }
+    } else {
+        cacheMediator.setMaxMessageSize(CachingConstants.DEFAULT_SIZE);
     }
 
     if (notNullChecker(protocolType)) {
         cacheMediator.setProtocolType(protocolType);
+    } else {
+        cacheMediator.setProtocolType(CachingConstants.HTTP_PROTOCOL_TYPE);
     }
 
     if (notNullChecker(methods)) {
         cacheMediator.setHTTPMethodsToCache(methods);
+    } else {
+        cacheMediator.setHTTPMethodsToCache(CachingConstants.ALL);
     }
 
     if (notNullChecker(headersToExclude)) {
         cacheMediator.setHeadersToExcludeInHash(headersToExclude);
+    } else {
+        cacheMediator.setHeadersToExcludeInHash("");
     }
 
     if (notNullChecker(responseCodes)) {
         cacheMediator.setResponseCodes(responseCodes);
+    } else {
+        cacheMediator.setResponseCodes(CachingConstants.ANY_RESPONSE_CODE);
     }
 
     if (notNullChecker(hashGen)) {
         cacheMediator.setDigestGenerator(hashGen);
+    } else {
+        cacheMediator.setDigestGenerator(CachingConstants.DEFAULT_HASH_GENERATOR.getClass().toString());
     }
 
     if (notNullChecker(maxSize)) {
@@ -96,6 +110,8 @@
         } catch (NumberFormatException e) {
             //This is handled in the UI validation in mediator-util.js
         }
+    } else {
+        cacheMediator.setInMemoryCacheSize(CachingConstants.DEFAULT_SIZE);
     }
 
     if ("selectFromRegistry".equals(sequenceOption)) {
@@ -108,9 +124,5 @@
     } else {
         cacheMediator.setOnCacheHitRef(null);
     }
-
-    //String cacheScope = request.getParameter("")
-
-    // todo : data collection from the edit jsp
 %>
 

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
@@ -117,7 +117,7 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
      * The size of the messages to be cached in memory. If this is 0 then no disk cache, and if there is no size
      * specified in the config  factory will assign a default value to enable disk based caching.
      */
-    private int inMemoryCacheSize = -1;
+    private int inMemoryCacheSize = CachingConstants.DEFAULT_SIZE;
 
     /**
      * Variable to represent 'NO_ENTITY_BODY' property of synapse.
@@ -132,7 +132,7 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
     /**
      * The maximum size of the messages to be cached. This is specified in bytes.
      */
-    private int maxMessageSize = -1;
+    private int maxMessageSize = CachingConstants.DEFAULT_SIZE;
 
     /**
      * The regex expression of the HTTP response code to be cached.

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediatorSerializer.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediatorSerializer.java
@@ -50,7 +50,7 @@ public class CacheMediatorSerializer extends AbstractMediatorSerializer {
         } else {
             cacheElem.addAttribute(fac.createOMAttribute(CachingConstants.COLLECTOR_STRING, nullNS, "false"));
 
-            if (cacheMediator.getTimeout() != 0) {
+            if (cacheMediator.getTimeout() > -1) {
                 cacheElem.addAttribute(
                         fac.createOMAttribute(CachingConstants.TIMEOUT_STRING, nullNS,
                                               Long.toString(cacheMediator.getTimeout())));

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CachingConstants.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CachingConstants.java
@@ -78,7 +78,13 @@ public class CachingConstants {
     public static final String CACHE_KEY = "cacheKey";
 
     /**
-     * Following names represent the local names used in QNames in MediatorFactory, Serializer and the UI CacheMediator.
+     * The default size for the maxSize and maxMessageSize
+     */
+    public static final int DEFAULT_SIZE = -1;
+
+    /**
+     * Following names represent the local names used in QNames in MediatorFactory, Serializer and the UI
+     * CacheMediator.
      */
     public static final String TIMEOUT_STRING = "timeout";
     public static final String COLLECTOR_STRING = "collector";


### PR DESCRIPTION
## Purpose
>When a field is set to empty after an edit to the cache mediator in the management console, this value >is simply ignored and the previous value is taken by the cache mediator.

## Goals
>Fix the issue in the management console so that the default value is set if the field is empty

## Approach
>The fix was that when an empty string appears the default value is set and displayed accordingly

## User stories
>N/A

## Release note
>https://github.com/wso2/product-ei/issues/971 Can not remove the initial value assigned to the >Maximum message size property in cache mediator

## Documentation
>N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > Will be added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/wso2/carbon-mediation/pull/843

## Migrations (if applicable)
>N/A
## Test environment
> JDK 1.8, Ubuntu 16.04
 
## Learning
> N/A