### PR TITLE
Fix wso2/product-ei/#1135

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/pom.xml
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/pom.xml
@@ -85,6 +85,10 @@
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.mediation</groupId>
+            <artifactId>org.wso2.carbon.mediation.ntask</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRequestProcessorImpl.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRequestProcessorImpl.java
@@ -25,18 +25,25 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.inbound.InboundRequestProcessor;
 import org.apache.synapse.startup.quartz.StartUpController;
-import org.apache.synapse.task.Task;
 import org.apache.synapse.task.TaskDescription;
-import org.wso2.carbon.CarbonConstants;
+import org.apache.synapse.task.TaskManager;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.inbound.endpoint.osgi.service.ServiceReferenceHolder;
 import org.wso2.carbon.inbound.endpoint.persistence.InboundEndpointsDataStore;
 import org.wso2.carbon.inbound.endpoint.protocol.PollingConstants;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSTask;
+import org.wso2.carbon.mediation.ntask.NTaskTaskManager;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringTokenizer;
 
 /**
  * 
@@ -89,6 +96,14 @@ public abstract class InboundRequestProcessorImpl implements InboundRequestProce
                 startUpController.setTaskDescription(taskDescription);
                 startUpController.init(synapseEnvironment);
                 startUpControllersList.add(startUpController);
+                //register a listener to be notified when the local jms task is deleted
+                if (task instanceof JMSTask) {
+                    TaskManager taskManagerImpl = synapseEnvironment.getTaskManager().getTaskManagerImpl();
+                    if (taskManagerImpl instanceof NTaskTaskManager) {
+                        ((NTaskTaskManager) taskManagerImpl)
+                                .registerListener((JMSTask) task, taskDescription.getName());
+                    }
+                }
             } catch (Exception e) {
                 log.error("Error starting the inbound endpoint " + name
                         + ". Unable to schedule the task. " + e.getLocalizedMessage(), e);

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSTask.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSTask.java
@@ -19,9 +19,9 @@ package org.wso2.carbon.inbound.endpoint.protocol.jms;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.core.SynapseEnvironment;
 import org.wso2.carbon.inbound.endpoint.common.InboundTask;
+import org.wso2.carbon.ntask.core.impl.LocalTaskActionListener;
 
 import java.util.Properties;
 
@@ -31,7 +31,7 @@ import java.util.Properties;
  * is required
  * 
  */
-public class JMSTask extends InboundTask {
+public class JMSTask extends InboundTask implements LocalTaskActionListener {
     private static final Log logger = LogFactory.getLog(JMSTask.class.getName());
 
     private JMSPollingConsumer jmsPollingConsumer;
@@ -57,7 +57,20 @@ public class JMSTask extends InboundTask {
     }
 
     public void destroy() {
-        logger.debug("Destroying.");
+        logger.debug("Destroying JMS Task.");
+        jmsPollingConsumer.destroy();
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Destroys the JMS task upon deletion of the local task.
+     *
+     * @param taskName the name of the task that was deleted
+     */
+    @Override
+    public void notifyLocalTaskDeletion(String taskName) {
+        destroy();
+        logger.debug("Destroyed JMS task due to deletion of task: " + taskName);
+    }
 }

--- a/components/mediation-ntask/src/main/java/org/wso2/carbon/mediation/ntask/NTaskTaskManager.java
+++ b/components/mediation-ntask/src/main/java/org/wso2/carbon/mediation/ntask/NTaskTaskManager.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.axis2.description.Parameter;
 import org.apache.commons.logging.Log;
@@ -37,6 +38,7 @@ import org.wso2.carbon.core.ServerStartupHandler;
 import org.wso2.carbon.mediation.ntask.internal.NtaskService;
 import org.wso2.carbon.ntask.common.TaskException;
 import org.wso2.carbon.ntask.core.TaskInfo;
+import org.wso2.carbon.ntask.core.impl.LocalTaskActionListener;
 import org.wso2.carbon.ntask.core.impl.clustered.ClusteredTaskManager;
 import org.wso2.carbon.ntask.core.service.TaskService;
 import org.wso2.carbon.utils.CarbonUtils;
@@ -745,6 +747,29 @@ public class NTaskTaskManager implements TaskManager, TaskServiceObserver, Serve
             }
         }
 
+    }
+
+    /**
+     * Registers a listener to the {@link org.wso2.carbon.ntask.core.TaskManager} to be notified when a local task is
+     * deleted.
+     *
+     * @param listener the listener to be notified
+     * @param taskName the task name for which the listener is bound
+     */
+    public void registerListener(final LocalTaskActionListener listener, final String taskName) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                while (taskManager == null) {
+                    try {
+                        TimeUnit.SECONDS.sleep(1);
+                    } catch (InterruptedException e) {
+                        //Continue looping to check if task manager is set.
+                    }
+                }
+                taskManager.registerLocalTaskActionListener(listener, taskName);
+            }
+        }).start();
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2298,7 +2298,7 @@
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
 
         <!-- Carbon Commons version-->
-        <carbon.commons.version>4.6.5</carbon.commons.version>
+        <carbon.commons.version>4.6.6</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.5.0, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <!-- Carbon Deployment version-->


### PR DESCRIPTION
## Purpose
Resolves: https://github.com/wso2/product-ei/issues/1135

## Goals
The underlying JMS consumer used to communicate when a JMS inbound is used, should be disconnected when the inbound task is deleted.

## Approach
Adds a JMS task as a listener for task deletion. Whenever the task is
deleted locally, the underlying consumer is removed.

## User stories
N/A

## Release note
This fix adds a JMS task as a listener for task deletion. Whenever the task is deleted locally, the underlying consumer is removed.

## Documentation
N/A. This is an internal implementation which is not useful to an end user.

## Training
N/A. The implementation is done as a resolution to an issue which is an edge case in CAR deployment with a JMS inbound endpoint.

## Certification
N/A. The implementation is done as a resolution to an issue which is an edge case in CAR deployment with a JMS inbound endpoint.

## Marketing
N/A

## Automation tests
N/A. The issue only occurs in a clustered environment.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
https://github.com/wso2/carbon-commons/pull/283

## Migrations (if applicable)
N/A

## Test environment
java version "1.8.0_131"