### PR TITLE
Fix for scheduling inbound task at delete and shutdown

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/file/VFSProcessor.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/file/VFSProcessor.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.inbound.InboundTaskProcessor;
 import org.apache.synapse.inbound.InboundProcessorParams;
 import org.apache.synapse.task.Task;
 import org.apache.synapse.task.TaskStartupObserver;
@@ -29,7 +30,7 @@ import org.wso2.carbon.inbound.endpoint.common.InboundRequestProcessorImpl;
 import org.wso2.carbon.inbound.endpoint.common.InboundTask;
 import org.wso2.carbon.inbound.endpoint.protocol.PollingConstants;
 
-public class VFSProcessor extends InboundRequestProcessorImpl implements TaskStartupObserver {
+public class VFSProcessor extends InboundRequestProcessorImpl implements TaskStartupObserver, InboundTaskProcessor {
 
     private static final String ENDPOINT_POSTFIX = "FILE" + COMMON_ENDPOINT_POSTFIX;
     private static final Log log = LogFactory.getLog(VFSProcessor.class);
@@ -95,5 +96,17 @@ public class VFSProcessor extends InboundRequestProcessorImpl implements TaskSta
 
     public void update() {
         // This will not be called for inbound endpoints
+    }
+
+    /**
+     * Remove inbound endpoints.
+     *
+     * @param removeTask Whether to remove scheduled task from the registry or not.
+     */
+    @Override
+    public void destroy(boolean removeTask) {
+        if (removeTask) {
+            destroy();
+        }
     }
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSProcessor.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSProcessor.java
@@ -24,13 +24,14 @@ import java.util.Properties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.inbound.InboundTaskProcessor;
 import org.apache.synapse.inbound.InboundProcessorParams;
 import org.apache.synapse.task.TaskStartupObserver;
 import org.wso2.carbon.inbound.endpoint.common.InboundRequestProcessorImpl;
 import org.wso2.carbon.inbound.endpoint.common.InboundTask;
 import org.wso2.carbon.inbound.endpoint.protocol.PollingConstants;
 
-public class JMSProcessor extends InboundRequestProcessorImpl implements TaskStartupObserver {
+public class JMSProcessor extends InboundRequestProcessorImpl implements TaskStartupObserver, InboundTaskProcessor {
 
     private static final Log log = LogFactory.getLog(JMSProcessor.class.getName());
 
@@ -120,5 +121,17 @@ public class JMSProcessor extends InboundRequestProcessorImpl implements TaskSta
 
     public void update() {
         // This will not be called for inbound endpoints
+    }
+
+    /**
+     * Remove inbound endpoints.
+     *
+     * @param removeTask Whether to remove scheduled task from the registry or not.
+     */
+    @Override
+    public void destroy(boolean removeTask) {
+        if (removeTask) {
+            destroy();
+        }
     }
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/kafka/KAFKAProcessor.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/kafka/KAFKAProcessor.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.inbound.InboundProcessorParams;
+import org.apache.synapse.inbound.InboundTaskProcessor;
 import org.apache.synapse.task.TaskStartupObserver;
 import org.wso2.carbon.inbound.endpoint.common.InboundRequestProcessorImpl;
 import org.wso2.carbon.inbound.endpoint.common.InboundTask;
@@ -29,7 +30,7 @@ import org.wso2.carbon.inbound.endpoint.protocol.PollingConstants;
 import java.util.Properties;
 
 
-public class KAFKAProcessor extends InboundRequestProcessorImpl implements TaskStartupObserver {
+public class KAFKAProcessor extends InboundRequestProcessorImpl implements TaskStartupObserver, InboundTaskProcessor {
     private static final Log log = LogFactory.getLog(KAFKAProcessor.class.getName());
 
     private static final String ENDPOINT_POSTFIX = "KAFKA" + COMMON_ENDPOINT_POSTFIX;
@@ -132,5 +133,17 @@ public class KAFKAProcessor extends InboundRequestProcessorImpl implements TaskS
             log.error("Error while shutdown the consumer connector" + e.getMessage(), e);
         }
         super.destroy();
+    }
+
+    /**
+     * Remove inbound endpoints.
+     *
+     * @param removeTask Whether to remove scheduled task from the registry or not.
+     */
+    @Override
+    public void destroy(boolean removeTask) {
+        if (removeTask) {
+            destroy();
+        }
     }
 }


### PR DESCRIPTION
## Purpose
Fix the issue of deleting registry task at cluster node shutdown with hazelcast.shutdownhook.enabled=false.

## Goals
Fixed: https://github.com/wso2/product-ei/issues/1206

## Approach
As the approach, we introduced a new parameter to differentiate shutdown and delete scenarios, and delete the registry task only at inbound endpoint delete. Inbound task at registry will remain at the shutdown scenario.

## Release note
will be released with 6.2.0

## Documentation
https://docs.wso2.com/display/EI611/Clustered+Deployment


## Related PRs
https://github.com/wso2/wso2-synapse/pull/958
