### PR TITLE
Resolves ESBJAVA-5247

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/factory/CachedJMSConnectionFactory.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/factory/CachedJMSConnectionFactory.java
@@ -147,9 +147,10 @@ public class CachedJMSConnectionFactory extends JMSConnectionFactory {
     
     public boolean closeConnection() {
         try {
-        	if(cachedConnection != null){
-        		cachedConnection.close();
-        	}
+            if (cachedConnection != null) {
+                cachedConnection.close();
+                cachedConnection = null;
+            }
             return true;
         } catch (JMSException e) {
             logger.error("JMS Exception while closing the connection.", e);
@@ -171,8 +172,9 @@ public class CachedJMSConnectionFactory extends JMSConnectionFactory {
     
     public boolean closeConnection(Connection connection, boolean forcefully) {
         try {
-            if(this.cacheLevel < JMSConstants.CACHE_CONNECTION || forcefully){
-            	connection.close();
+            if (this.cacheLevel < JMSConstants.CACHE_CONNECTION || forcefully) {
+                connection.close();
+                cachedConnection = null;
             }
         } catch (JMSException e) {
             logger.error("JMS Exception while closing the connection.", e);
@@ -182,8 +184,9 @@ public class CachedJMSConnectionFactory extends JMSConnectionFactory {
 
     public boolean closeConsumer(MessageConsumer messageConsumer, boolean forcefully) {
         try {
-            if(this.cacheLevel < JMSConstants.CACHE_CONSUMER || forcefully){
-            	messageConsumer.close();
+            if (this.cacheLevel < JMSConstants.CACHE_CONSUMER || forcefully) {
+                messageConsumer.close();
+                cachedMessageConsumer = null;
             }
         } catch (JMSException e) {
             logger.error("JMS Exception while closing the consumer.", e);
@@ -193,8 +196,9 @@ public class CachedJMSConnectionFactory extends JMSConnectionFactory {
 
     public boolean closeSession(Session session, boolean forcefully) {
         try {
-            if(this.cacheLevel < JMSConstants.CACHE_SESSION || forcefully){
-            	session.close();
+            if (this.cacheLevel < JMSConstants.CACHE_SESSION || forcefully) {
+                session.close();
+                cachedSession = null;
             }
         } catch (JMSException e) {
             logger.error("JMS Exception while closing the consumer.", e);


### PR DESCRIPTION
Refer - https://wso2.org/jira/browse/ESBJAVA-5247

## Purpose
> To resolves the issue of getting a jms error (JMS Exception while starting connection for factory 'QueueConnectionFactory') when shutting down one node in a cluster environment.

## Goals
>After closing connections they are assigned null values.  

## Test environment
> Two node nonWorkerManager cluster
 