### PR TITLE
[ESBJAVA-4397] Fix Endpoint list view issue when description is added

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/java/org/wso2/carbon/endpoint/ui/util/EndpointConfigurationHelper.java
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/java/org/wso2/carbon/endpoint/ui/util/EndpointConfigurationHelper.java
@@ -98,8 +98,7 @@ public class EndpointConfigurationHelper {
             try {
                 URL conn = new URL(url);
                 conn.openConnection().connect();
-                testWSDLURI(url + "?wsdl");
-                returnValue = "success";
+                returnValue = testWSDLURI(url + "?wsdl");
             } catch (UnknownHostException e) {
                 returnValue = "unknown";
             } catch (MalformedURLException e) {

--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/index.jsp
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/index.jsp
@@ -618,7 +618,7 @@ function resetVars() {
                         <% if(endpoint.getIsEdited()) { %> <span style="color:grey"> ( Edited )</span><% } %>
                     </span>
                 <% } else { %>
-                    span href="#"><%= Encode.forHtmlContent(endpoint.getName())%></span>
+                    <span href="#"><%= Encode.forHtmlContent(endpoint.getName())%></span>
                 <% } %>
                 <% } else { %>
                 <% if (endpoint.getArtifactContainerName() != null) { %>


### PR DESCRIPTION
## Purpose
When a description is added to an endpoint, in list view of management console, endpoint name is displayed with a span tag. This is due to a missing '<' tag. Please refer [1] 



[1] https://wso2.org/jira/browse/ESBJAVA-4397