### PR TITLE
Add Unit tests for JMS Inbound EPs

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/pom.xml
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/pom.xml
@@ -89,6 +89,22 @@
             <groupId>org.wso2.carbon.mediation</groupId>
             <artifactId>org.wso2.carbon.mediation.ntask</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-broker</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -118,6 +134,51 @@
                         </Fragment-Host>
                     </instructions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>jacoco-agent.destfile</name>
+                            <value>
+                                target/coverage-reports/jacoco-unit-commons.exec
+                            </value>
+                        </property>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-instrument</id>
+                        <goals>
+                            <goal>instrument</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>target/coverage-reports/jacoco-unit-commons.exec</dataFile>
+                            <outputDirectory>target/coverage-reports/site</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/JMSBrokerController.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/JMSBrokerController.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package endpoint.protocol.jms;
+
+import org.apache.activemq.broker.BrokerService;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Assert;
+
+import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MapMessage;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.ObjectMessage;
+import javax.jms.Queue;
+import javax.jms.QueueConnectionFactory;
+import javax.jms.Session;
+import javax.jms.StreamMessage;
+import javax.jms.TextMessage;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Properties;
+
+public class JMSBrokerController {
+
+    private static final Log log = LogFactory.getLog(JMSBrokerController.class);
+
+    private String providerURL;
+    private BrokerService broker;
+    private Connection connection = null;
+    private Session session = null;
+    private MessageProducer producer = null;
+    private QueueConnectionFactory connectionFactory = null;
+
+    public JMSBrokerController(String providerURL, Properties properties) {
+        this.providerURL = providerURL;
+        InitialContext ctx;
+        try {
+            ctx = new InitialContext(properties);
+            this.connectionFactory = (QueueConnectionFactory)ctx.lookup("QueueConnectionFactory");
+        } catch (NamingException e) {
+            log.info("Error while creating connection factory");
+        }
+    }
+
+    public boolean startProcess() {
+        try {
+            //using embedded jms broker
+            broker = new BrokerService();
+            // configure the broker
+            broker.setBrokerName("inboundSampleBroker");
+            broker.addConnector(providerURL);
+            broker.setPersistent(true);
+            broker.start();
+            log.info("JMSBrokerController: ActiveMQ Broker is Successfully started. continuing tests");
+            return true;
+        } catch (Exception e) {
+            log.error("There was an error starting JMS broker for providerURL : " + providerURL, e);
+            return false;
+        }
+    }
+
+    public boolean stopProcess() {
+        try {
+            broker.stop();
+            return true;
+        } catch (Exception e) {
+            log.error("Error while shutting down the broker", e);
+            return false;
+        }
+    }
+
+    public Queue connect(String queueName, boolean persistMessage) throws JMSException {
+        this.connection = this.connectionFactory.createConnection();
+        this.connection.start();
+        this.session = this.connection.createSession(false, 1);
+        Queue destination = this.session.createQueue(queueName);
+        this.producer = this.session.createProducer(destination);
+        if(persistMessage) {
+            this.producer.setDeliveryMode(2);
+        } else {
+            this.producer.setDeliveryMode(1);
+        }
+        return destination;
+    }
+
+    public void disconnect() {
+        if(this.producer != null) {
+            try {
+                this.producer.close();
+            } catch (JMSException e) {
+                log.error("Error while sending message", e);
+                Assert.fail();
+            }
+        }
+
+        if(this.session != null) {
+            try {
+                this.session.close();
+            } catch (JMSException e) {
+                log.error("Error while sending message", e);
+                Assert.fail();
+            }
+        }
+
+        if(this.connection != null) {
+            try {
+                this.connection.close();
+            } catch (JMSException e) {
+                log.error("Error while sending message", e);
+                Assert.fail();
+            }
+        }
+
+    }
+
+    public TextMessage pushMessage(String messageContent) {
+        if(this.producer == null) {
+            log.error("The producer is null");
+            Assert.fail();
+            return null;
+        } else {
+            TextMessage message = null;
+            try {
+                message = this.session.createTextMessage(messageContent);
+                this.producer.send(message);
+            } catch (JMSException e) {
+                log.error("Error while sending message", e);
+                Assert.fail();
+            }
+            return message;
+        }
+    }
+
+    public BytesMessage createBytesMessage(byte[] payload) {
+        BytesMessage bm = null;
+        try {
+            bm = this.session.createBytesMessage();
+            bm.writeBytes(payload);
+        } catch (JMSException e) {
+            log.error("Error while sending message", e);
+            Assert.fail();
+        }
+        return bm;
+    }
+
+    public Message receiveMessage(Destination destination) throws JMSException, InterruptedException {
+        this.connection = this.connectionFactory.createConnection();
+        this.connection.start();
+        this.session = this.connection.createSession(false, 1);
+        MessageConsumer consumer = this.session.createConsumer(destination);
+        Message receivedMsg  = consumer.receive(1);
+        int count = 0;
+        while (receivedMsg == null) {
+            count ++;
+            if (count == 10) {
+                // return null to avoid hanging
+                return null;
+            }
+            Thread.sleep(10);
+            receivedMsg  = consumer.receive(1);
+        }
+        return receivedMsg;
+    }
+
+    public MapMessage createMapMessage() {
+        MapMessage mapMessage = null;
+        try {
+            mapMessage = this.session.createMapMessage();
+        } catch (JMSException e) {
+            log.error("Error while creating message", e);
+            Assert.fail();
+        }
+        return mapMessage;
+    }
+
+    public StreamMessage createStreamMessage() {
+        StreamMessage streamMessage = null;
+        try {
+            streamMessage = this.session.createStreamMessage();
+        } catch (JMSException e) {
+            log.error("Error while creating message", e);
+            Assert.fail();
+        }
+        return streamMessage;
+    }
+
+    public ObjectMessage createObjectMessage() {
+        ObjectMessage objMessage = null;
+        try {
+            objMessage = this.session.createObjectMessage();
+        } catch (JMSException e) {
+            log.error("Error while creating message", e);
+            Assert.fail();
+        }
+        return objMessage;
+    }
+
+    public BrokerService getBrokerService() {
+        return broker;
+    }
+
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/JMSTestsUtils.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/JMSTestsUtils.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package endpoint.protocol.jms;
+
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMNamespace;
+import org.apache.axiom.soap.SOAPBody;
+import org.apache.axiom.soap.SOAPEnvelope;
+import org.apache.axiom.util.UIDGenerator;
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.OperationContext;
+import org.apache.axis2.context.ServiceContext;
+import org.apache.axis2.description.InOutAxisOperation;
+import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.synapse.config.SynapseConfiguration;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSConstants;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSPollingConsumer;
+
+import javax.jms.Message;
+import java.util.Properties;
+
+public class JMSTestsUtils {
+
+    /**
+     * Poll message from destination using JMSPollingConsumer
+     *
+     * @return Properties
+     */
+    public static Properties getJMSPropertiesForDestination(String destinationName, String providerURL, boolean isQueue) {
+        Properties jmsProperties = new Properties();
+        jmsProperties.put(JMSConstants.PROVIDER_URL, providerURL);
+        jmsProperties.put(JMSConstants.NAMING_FACTORY_INITIAL, "org.apache.activemq.jndi.ActiveMQInitialContextFactory");
+        jmsProperties.put(JMSConstants.CONNECTION_FACTORY_JNDI_NAME, "QueueConnectionFactory");
+        if (isQueue) {
+            jmsProperties.put(JMSConstants.CONNECTION_FACTORY_TYPE, JMSConstants.DESTINATION_TYPE_QUEUE);
+        } else {
+            jmsProperties.put(JMSConstants.CONNECTION_FACTORY_TYPE, JMSConstants.DESTINATION_TYPE_TOPIC);
+        }
+        jmsProperties.put(JMSConstants.DESTINATION_NAME, destinationName);
+        jmsProperties.put(JMSConstants.SESSION_TRANSACTED, "false");
+        jmsProperties.put(JMSConstants.SESSION_ACK, "AUTO_ACKNOWLEDGE");
+        jmsProperties.put(JMSConstants.PARAM_CACHE_LEVEL, 3);
+        return jmsProperties;
+    }
+
+    /**
+     * Poll message from destination using JMSPollingConsumer
+     *
+     * @return Message
+     * @throws InterruptedException on an error polling message
+     */
+    public static Message pollMessagesFromDestination (JMSPollingConsumer jmsPollingConsumer) throws InterruptedException {
+        Message receivedMsg  = jmsPollingConsumer.poll();
+        int count = 0;
+        while (receivedMsg == null) {
+            count ++;
+            if (count == 10) {
+                // return null to avoid hanging
+                return null;
+            }
+            Thread.sleep(10);
+            receivedMsg  = jmsPollingConsumer.poll();
+        }
+        return receivedMsg;
+    }
+
+    /**
+     * Create a empty message context.
+     *
+     * @return A context with empty message
+     * @throws AxisFault on an error creating a context
+     */
+    public static org.apache.synapse.MessageContext createMessageContext() throws AxisFault {
+
+        Axis2SynapseEnvironment synapseEnvironment = new Axis2SynapseEnvironment(new SynapseConfiguration());
+        org.apache.axis2.context.MessageContext axis2MC
+                = new org.apache.axis2.context.MessageContext();
+        axis2MC.setConfigurationContext(new ConfigurationContext(new AxisConfiguration()));
+
+        ServiceContext svcCtx = new ServiceContext();
+        OperationContext opCtx = new OperationContext(new InOutAxisOperation(), svcCtx);
+        axis2MC.setServiceContext(svcCtx);
+        axis2MC.setOperationContext(opCtx);
+        org.apache.synapse.MessageContext mc = new Axis2MessageContext(axis2MC, new SynapseConfiguration(),
+                synapseEnvironment);
+        mc.setMessageID(UIDGenerator.generateURNString());
+        SOAPEnvelope env = OMAbstractFactory.getSOAP11Factory().createSOAPEnvelope();
+        OMNamespace namespace = OMAbstractFactory.getSOAP11Factory().createOMNamespace(
+                "http://ws.apache.org/commons/ns/payload", "text");
+        env.declareNamespace(namespace);
+        mc.setEnvelope(env);
+        SOAPBody body = OMAbstractFactory.getSOAP11Factory().createSOAPBody();
+        OMElement element = OMAbstractFactory.getSOAP11Factory().createOMElement("TestElement", namespace);
+        element.setText("This is a test!!");
+        body.addChild(element);
+        mc.getEnvelope().addChild(body);
+        return mc;
+    }
+
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/tests/JMSConnectionFactoryTestCase.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/tests/JMSConnectionFactoryTestCase.java
@@ -1,0 +1,448 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package endpoint.protocol.jms.tests;
+
+import endpoint.protocol.jms.JMSBrokerController;
+import endpoint.protocol.jms.JMSTestsUtils;
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.ActiveMQMessageConsumer;
+import org.junit.Test;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSConstants;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.factory.CachedJMSConnectionFactory;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.factory.JMSConnectionFactory;
+
+import javax.jms.Connection;
+import javax.jms.MessageConsumer;
+import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.Session;
+import javax.jms.TopicConnection;
+import java.util.Properties;
+
+public class JMSConnectionFactoryTestCase extends TestCase {
+
+    private static final String PROVIDER_URL = "tcp://127.0.0.1:61616";
+
+    /**
+     * Test cached connection when the transport.jms.CacheLevel is 1
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCacheLevelOne() throws Exception {
+        String queueName = "testCaching1";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        jmsProperties.put(JMSConstants.PARAM_CACHE_LEVEL, "1");
+        try {
+            brokerController.startProcess();
+            Queue queue = brokerController.connect(queueName, true);
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            Connection connection1 = cachedJMSConnectionFactory.getConnection(null, null);
+            String clientID1 = connection1.getClientID();
+            Session session1 = cachedJMSConnectionFactory.getSession(connection1);
+            MessageConsumer consumer1 = cachedJMSConnectionFactory.getMessageConsumer(session1,queue);
+            Connection connection2 = cachedJMSConnectionFactory.getConnection(null, null);
+            Session session2 = cachedJMSConnectionFactory.getSession(connection2);
+            MessageConsumer consumer2 = cachedJMSConnectionFactory.getMessageConsumer(session2,queue);
+            Assert.assertEquals("Connection should be cached", clientID1, connection2.getClientID());
+            Assert.assertNotSame("Session should not be cached", session1, session2);
+            Assert.assertNotSame("Message Consumer should not be cached", ((ActiveMQMessageConsumer) consumer1).
+                    getConsumerId().toString(), ((ActiveMQMessageConsumer) consumer2).getConsumerId().toString());
+            cachedJMSConnectionFactory.closeConnection();
+            Connection connection3 = cachedJMSConnectionFactory.getConnection(null, null);
+            Assert.assertNotSame("Connection should be closed", clientID1, connection3.getClientID());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test cached session when the transport.jms.CacheLevel is 2
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCacheLevelTwo() throws Exception {
+        String queueName = "testCaching2";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        jmsProperties.put(JMSConstants.PARAM_CACHE_LEVEL, "2");
+        try {
+            brokerController.startProcess();
+            Queue queue = brokerController.connect(queueName, true);
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            Connection connection1 = cachedJMSConnectionFactory.getConnection(null, null);
+            Session session1 = cachedJMSConnectionFactory.getSession(connection1);
+            MessageConsumer consumer1 = cachedJMSConnectionFactory.getMessageConsumer(session1,queue);
+            Connection connection2 = cachedJMSConnectionFactory.getConnection(null, null);
+            Session session2 = cachedJMSConnectionFactory.getSession(connection2);
+            MessageConsumer consumer2 = cachedJMSConnectionFactory.getMessageConsumer(session2,queue);
+            Assert.assertEquals("Connection should be cached", connection1.getClientID(), connection2.getClientID());
+            Assert.assertEquals("Session should be cached", session1, session2);
+            Assert.assertNotSame("Message Consumer should not be cached", ((ActiveMQMessageConsumer) consumer1).
+                    getConsumerId().toString(), ((ActiveMQMessageConsumer) consumer2).getConsumerId().toString());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test cached message consumer when the transport.jms.CacheLevel is 3 when the JMS Spec Version is 2.0
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCacheLevelThreeV2() throws Exception {
+        String queueName = "testCaching3V2";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        jmsProperties.put(JMSConstants.PARAM_CACHE_LEVEL, "3");
+        jmsProperties.put(JMSConstants.PARAM_JMS_SPEC_VER, JMSConstants.JMS_SPEC_VERSION_2_0);
+        try {
+            brokerController.startProcess();
+            Queue queue = brokerController.connect(queueName, true);
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            Connection connection1 = cachedJMSConnectionFactory.getConnection(null, null);
+            Session session1 = cachedJMSConnectionFactory.getSession(connection1);
+            MessageConsumer consumer1 = cachedJMSConnectionFactory.getMessageConsumer(session1,queue);
+            Connection connection2 = cachedJMSConnectionFactory.getConnection(null, null);
+            Session session2 = cachedJMSConnectionFactory.getSession(connection2);
+            MessageConsumer consumer2 = cachedJMSConnectionFactory.getMessageConsumer(session2,queue);
+            Assert.assertEquals("Connection should be cached", connection1.getClientID(), connection2.getClientID());
+            Assert.assertEquals("Session should be cached", session1, session2);
+            Assert.assertEquals("Message Consumer should be cached", ((ActiveMQMessageConsumer) consumer1).
+                    getConsumerId().toString(), ((ActiveMQMessageConsumer) consumer2).getConsumerId().toString());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test cached message consumer when the transport.jms.CacheLevel is 3
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCacheLevelThree() throws Exception {
+        String queueName = "testCaching3";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        jmsProperties.put(JMSConstants.PARAM_CACHE_LEVEL, "3");
+        try {
+            brokerController.startProcess();
+            Queue queue = brokerController.connect(queueName, true);
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            Connection connection1 = cachedJMSConnectionFactory.getConnection(null, null);
+            Session session1 = cachedJMSConnectionFactory.getSession(connection1);
+            MessageConsumer consumer1 = cachedJMSConnectionFactory.getMessageConsumer(session1,queue);
+            Connection connection2 = cachedJMSConnectionFactory.getConnection(null, null);
+            Session session2 = cachedJMSConnectionFactory.getSession(connection2);
+            MessageConsumer consumer2 = cachedJMSConnectionFactory.getMessageConsumer(session2,queue);
+            Assert.assertEquals("Connection should be cached", connection1.getClientID(), connection2.getClientID());
+            Assert.assertEquals("Session should be cached", session1, session2);
+            Assert.assertEquals("Message Consumer should be cached", ((ActiveMQMessageConsumer) consumer1).
+                    getConsumerId().toString(), ((ActiveMQMessageConsumer) consumer2).getConsumerId().toString());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test close cached connection, session, message consumer when the transport.jms.CacheLevel is 3 not forcefully
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCloseCached() throws Exception {
+        String queueName = "testCloseCache";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        jmsProperties.put(JMSConstants.PARAM_CACHE_LEVEL, "3");
+        try {
+            brokerController.startProcess();
+            Queue queue = brokerController.connect(queueName, true);
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            Connection connection1 = cachedJMSConnectionFactory.getConnection(null, null);
+            Session session1 = cachedJMSConnectionFactory.getSession(connection1);
+            MessageConsumer consumer1 = cachedJMSConnectionFactory.getMessageConsumer(session1,queue);
+            cachedJMSConnectionFactory.closeConnection(connection1);
+            cachedJMSConnectionFactory.closeSession(session1);
+            cachedJMSConnectionFactory.closeConsumer(consumer1);
+            Connection connection2 = cachedJMSConnectionFactory.getConnection(null, null);
+            Session session2 = cachedJMSConnectionFactory.getSession(connection2);
+            MessageConsumer consumer2 = cachedJMSConnectionFactory.getMessageConsumer(session2,queue);
+            Assert.assertEquals("Connection should be cached", connection1.getClientID(), connection2.getClientID());
+            Assert.assertEquals("Session should be cached", session1, session2);
+            Assert.assertEquals("Message Consumer should be cached", ((ActiveMQMessageConsumer) consumer1).
+                    getConsumerId().toString(), ((ActiveMQMessageConsumer) consumer2).getConsumerId().toString());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test creating CachedConnectionFactory using cached connection
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCachedConnection() throws Exception {
+        String queueName = "testCaching3";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        jmsProperties.put(JMSConstants.PARAM_CACHE_LEVEL, "3");
+        try {
+            brokerController.startProcess();
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            Connection connection1 = cachedJMSConnectionFactory.getConnection(null, null);
+            CachedJMSConnectionFactory cachedJMSConnectionFactory2 = new CachedJMSConnectionFactory(jmsProperties,
+                    connection1);
+            Connection connection2 = cachedJMSConnectionFactory2.getConnection(null, null);
+            Assert.assertEquals("Connection should be cached", connection1.getClientID(), connection2.getClientID());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test check destination type
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCheckDestinationType() throws Exception {
+        String queueName = "testCaching3";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        jmsProperties.put(JMSConstants.PARAM_CACHE_LEVEL, "3");
+        try {
+            brokerController.startProcess();
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            JMSConstants.JMSDestinationType type = cachedJMSConnectionFactory.getDestinationType();
+            Assert.assertEquals("The destination type should be matched", JMSConstants.JMSDestinationType.QUEUE, type);
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test get connection null if broker is unreachable
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testFailToConnectToBroker() throws Exception {
+        String queueName = "testConnectionFail";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        jmsProperties.put(JMSConstants.PARAM_CACHE_LEVEL, "3");
+        try {
+            brokerController.startProcess();
+            Queue queue = brokerController.connect(queueName, true);
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            Connection connection1 = cachedJMSConnectionFactory.getConnection(null, null);
+            Session session1 = cachedJMSConnectionFactory.getSession(connection1);
+            cachedJMSConnectionFactory.getMessageConsumer(session1,queue);
+            Assert.assertNotNull("The connection should be created", connection1);
+            brokerController.disconnect();
+            brokerController.stopProcess();
+            Connection connection2 = cachedJMSConnectionFactory.getConnection(null, null);
+            Assert.assertNull("The connection should be null", connection2);
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test create connection with credentials
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreateConnectionWithCredentials() throws Exception {
+        String queueName = "testWithCred";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        jmsProperties.put(JMSConstants.PARAM_CACHE_LEVEL, "3");
+        try {
+            brokerController.startProcess();
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            Connection connection = cachedJMSConnectionFactory.getConnection("admin", "admin");
+            Assert.assertNotNull("The connection should be created", connection);
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test create connection with credentials when the JMS Spec Version is 2.0
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreateConnectionWithCredentialsV2() throws Exception {
+        String queueName = "testWithCredV2";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        jmsProperties.put(JMSConstants.PARAM_JMS_SPEC_VER, JMSConstants.JMS_SPEC_VERSION_2_0);
+        jmsProperties.put(JMSConstants.PARAM_CACHE_LEVEL, "3");
+        try {
+            brokerController.startProcess();
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            Connection connection = cachedJMSConnectionFactory.getConnection("admin", "admin");
+            Assert.assertNotNull("The connection should be created", connection);
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test check JMS properties of the connection factory
+     *
+     * @throws Exception
+     */
+    @Test
+
+    public void testCheckJMSProperties() throws Exception {
+        String queueName = "testJMSProperties";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        jmsProperties.put(JMSConstants.SESSION_ACK, "CLIENT_ACKNOWLEDGE");
+        jmsProperties.put(JMSConstants.SESSION_TRANSACTED, "true");
+        JMSConnectionFactory connectionFactory = new JMSConnectionFactory(jmsProperties);
+        Assert.assertEquals("The JMS connection factory string mismatch", jmsProperties.getProperty
+                (JMSConstants.CONNECTION_FACTORY_JNDI_NAME), connectionFactory.getConnectionFactoryString());
+        Assert.assertEquals("The session acknowledgement mismatch", 2, connectionFactory.getSessionAckMode());
+        Assert.assertEquals("The destination type mismatch", JMSConstants.JMSDestinationType.QUEUE,
+                connectionFactory.getDestinationType());
+        Assert.assertTrue("The transacted property mismatch", connectionFactory.isTransactedSession());
+    }
+
+    /**
+     * Test stop/Close connection
+     *
+     * @throws Exception
+     */
+    @Test
+
+    public void testStopConnection() throws Exception {
+        String queueName = "testStopCon";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            JMSConnectionFactory connectionFactory = new JMSConnectionFactory(jmsProperties);
+            Connection connection = connectionFactory.getConnection();
+            connectionFactory.start(connection);
+            Assert.assertTrue("The connection should be started", ((ActiveMQConnection)connection).isStarted());
+            connectionFactory.stop(connection);
+            Assert.assertFalse("The connection should be stopped", ((ActiveMQConnection) connection).isStarted());
+            boolean isClosed = connectionFactory.closeConnection(connection);
+            Assert.assertTrue("The connection should be closed", isClosed);
+            //Exception should be thrown and caught thrown when trying to start/stop/close closed connection
+            connectionFactory.start(connection);
+            connectionFactory.stop(connection);;
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test create queue/topic connection fail scenario - the broker is not started
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreateQueueAndTopicConnectionsFail() throws Exception {
+        String queueName = "testCreateConQ";
+        Properties jmsPropertiesQ = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSConnectionFactory connectionFactoryQ = new JMSConnectionFactory(jmsPropertiesQ);
+        String topicName = "testCreateConT";
+        Properties jmsPropertiesT = JMSTestsUtils.getJMSPropertiesForDestination(topicName, PROVIDER_URL, true);
+        JMSConnectionFactory connectionFactoryT = new JMSConnectionFactory(jmsPropertiesT);
+        Assert.assertNull("The create queue connection should fail", connectionFactoryQ.createQueueConnection());
+        Assert.assertNull("The create topic connection should fail", connectionFactoryT.createTopicConnection());
+        Assert.assertNull("The create queue connection should fail", connectionFactoryQ.
+                createQueueConnection("admin", "admin"));
+        Assert.assertNull("The create queue connection should fail", connectionFactoryT.
+                createTopicConnection("admin", "admin"));
+    }
+
+    /**
+     * Test create queue connection
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreateQueueConnections() throws Exception {
+        String queueName = "testCreateConQ";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSConnectionFactory connectionFactory = new JMSConnectionFactory(jmsProperties);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            QueueConnection queueConnection = connectionFactory.createQueueConnection();
+            Assert.assertTrue("The queue connection is created", ((ActiveMQConnection) queueConnection).
+                    getTransport().getRemoteAddress().contains("61616"));
+            QueueConnection queueConnectionWithCred = connectionFactory.createQueueConnection("admin", "admin");
+            Assert.assertTrue("The queue connection is created", ((ActiveMQConnection) queueConnectionWithCred).
+                    getTransport().getRemoteAddress().contains("61616"));
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test create topic connection
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreateTopicConnections() throws Exception {
+        String topicName = "testCreateConT";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(topicName, PROVIDER_URL, true);
+        JMSConnectionFactory connectionFactory = new JMSConnectionFactory(jmsProperties);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            TopicConnection topicConnection = connectionFactory.createTopicConnection();
+            Assert.assertTrue("The queue connection is created", ((ActiveMQConnection) topicConnection).
+                    getTransport().getRemoteAddress().contains("61616"));
+            TopicConnection topicConnectionWithCred = connectionFactory.createTopicConnection("admin", "admin");
+            Assert.assertTrue("The queue connection is created", ((ActiveMQConnection) topicConnectionWithCred).
+                    getTransport().getRemoteAddress().contains("61616"));
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/tests/JMSPollingConsumerQueueTest.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/tests/JMSPollingConsumerQueueTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package endpoint.protocol.jms.tests;
+
+import endpoint.protocol.jms.JMSBrokerController;
+import endpoint.protocol.jms.JMSTestsUtils;
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.junit.Test;
+import org.wso2.carbon.inbound.endpoint.common.InboundTask;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSConstants;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSPollingConsumer;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSTask;
+
+import javax.jms.Message;
+import java.util.Properties;
+
+public class JMSPollingConsumerQueueTest extends TestCase {
+
+    private static final String PROVIDER_URL = "tcp://127.0.0.1:61616";
+    private static final String INBOUND_EP_NAME = "testPolling";
+    private static final long INTERVAL = 1000;
+    private static final String SEND_MSG = "<?xml version='1.0' encoding='UTF-8'?>" +
+            "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"" +
+            " xmlns:ser=\"http://services.samples\" xmlns:xsd=\"http://services.samples/xsd\">" +
+            "  <soapenv:Header/>" +
+            "  <soapenv:Body>" +
+            "    <ser:getQuote> " +
+            "      <ser:request>" +
+            "        <xsd:symbol>IBM</xsd:symbol>" +
+            "      </ser:request>" +
+            "    </ser:getQuote>" +
+            "  </soapenv:Body>" +
+            "</soapenv:Envelope>";
+
+    /**
+     * Test Run Inbound Task to poll messages from Queue
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPollingOnQueue() throws Exception {
+        String queueName = "testQueue1";
+        boolean isQueueExist = false;
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        JMSPollingConsumer jmsPollingConsumer = new JMSPollingConsumer( jmsProperties, INTERVAL, INBOUND_EP_NAME);
+        InboundTask task = new JMSTask(jmsPollingConsumer, INTERVAL);
+        Assert.assertEquals(task.getInboundProperties().getProperty(JMSConstants.PROVIDER_URL), PROVIDER_URL);
+        try {
+            brokerController.startProcess();
+            task.execute();
+            ActiveMQDestination[] activeMQDestination = brokerController.getBrokerService().getRegionBroker().
+                    getDestinations();
+            for (ActiveMQDestination destination : activeMQDestination) {
+                if (destination.isQueue() && queueName.equals(destination.getPhysicalName())) {
+                    isQueueExist = true;
+                }
+            }
+            Assert.assertTrue("Queue is not added as a subscription", isQueueExist);
+        } finally {
+            task.destroy();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test Polling Messages From Queue when the JMS Spec Version is 1.1
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPollingMessageFromQueue() throws Exception {
+        String queueName = "testQueue1";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            brokerController.connect(queueName, true);
+            brokerController.pushMessage(SEND_MSG);
+            JMSPollingConsumer jmsPollingConsumer = new JMSPollingConsumer(jmsProperties, INTERVAL, INBOUND_EP_NAME);
+            Message receivedMsg = JMSTestsUtils.pollMessagesFromDestination(jmsPollingConsumer);
+            Assert.assertNotNull("Received message is null", receivedMsg);
+            Assert.assertEquals("The send message is not received.", SEND_MSG,
+                    ((ActiveMQTextMessage) receivedMsg).getText());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test Polling Messages From Queue when the JMS Spec Version is 2.0
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPollingMessageFromQueueSpecV20() throws Exception {
+        String queueName = "testQueue1v20";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        jmsProperties.put(JMSConstants.PARAM_JMS_SPEC_VER, JMSConstants.JMS_SPEC_VERSION_2_0);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            brokerController.connect(queueName, true);
+            brokerController.pushMessage(SEND_MSG);
+            JMSPollingConsumer jmsPollingConsumer = new JMSPollingConsumer(jmsProperties, INTERVAL, INBOUND_EP_NAME);
+            Message receivedMsg = JMSTestsUtils.pollMessagesFromDestination(jmsPollingConsumer);
+            Assert.assertNotNull("Received message is null", receivedMsg);
+            Assert.assertEquals("The send message is not received.", SEND_MSG,
+                    ((ActiveMQTextMessage) receivedMsg).getText());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test Polling Messages From Queue when the JMS Spec Version is 1.0
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPollingMessageFromQueueSpecV10() throws Exception {
+        String queueName = "testQueue1v20";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        jmsProperties.put(JMSConstants.PARAM_JMS_SPEC_VER, JMSConstants.JMS_SPEC_VERSION_1_0);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            brokerController.connect(queueName, true);
+            brokerController.pushMessage(SEND_MSG);
+            JMSPollingConsumer jmsPollingConsumer = new JMSPollingConsumer(jmsProperties, INTERVAL, INBOUND_EP_NAME);
+            Message receivedMsg = JMSTestsUtils.pollMessagesFromDestination(jmsPollingConsumer);
+            Assert.assertNotNull("Received message is null", receivedMsg);
+            Assert.assertEquals("The send message is not received.", SEND_MSG,
+                    ((ActiveMQTextMessage) receivedMsg).getText());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/tests/JMSPollingConsumerTopicTest.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/tests/JMSPollingConsumerTopicTest.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package endpoint.protocol.jms.tests;
+
+import endpoint.protocol.jms.JMSBrokerController;
+import endpoint.protocol.jms.JMSTestsUtils;
+import junit.framework.TestCase;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.carbon.inbound.endpoint.common.InboundTask;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSConstants;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSPollingConsumer;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSTask;
+
+import java.util.Properties;
+import java.util.Set;
+
+public class JMSPollingConsumerTopicTest extends TestCase {
+
+    private final static String PROVIDER_URL = "tcp://127.0.0.1:61616";
+    private final static long INTERVAL = 1000;
+    private final static String INBOUND_EP_NAME = "testPolling";
+
+    /**
+     * Test polling on topic using JMS inbound endpoint task
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPollingOnTopic() throws Exception {
+        String topicName = "testTopic1";
+        boolean isTopicExist = false;
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(topicName, PROVIDER_URL, false);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        JMSPollingConsumer jmsPollingConsumer = new JMSPollingConsumer( jmsProperties, INTERVAL, INBOUND_EP_NAME);
+        InboundTask task = new JMSTask(jmsPollingConsumer, INTERVAL);
+        try {
+            brokerController.startProcess();
+            task.execute();
+            ActiveMQDestination[] activeMQDestination = brokerController.getBrokerService().getRegionBroker().
+                    getDestinations();
+            for (ActiveMQDestination destination : activeMQDestination) {
+                if (destination.isTopic() && topicName.equals(destination.getPhysicalName())) {
+                    isTopicExist = true;
+                }
+            }
+            Assert.assertTrue("Topic is not added as a subscription", isTopicExist);
+        } finally {
+            task.destroy();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test polling on durable topic using JMS inbound endpoint task
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPollingOnDurableTopic() throws Exception {
+        String topicName = "testTopic2";
+        boolean isTopicExist = false;
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(topicName, PROVIDER_URL, false);
+        jmsProperties.put(JMSConstants.PARAM_SUB_DURABLE, "true");
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        JMSPollingConsumer jmsPollingConsumer = new JMSPollingConsumer(jmsProperties, INTERVAL, INBOUND_EP_NAME);
+        InboundTask task = new JMSTask(jmsPollingConsumer, INTERVAL);
+        try {
+            brokerController.startProcess();
+            task.execute();
+            Set<ActiveMQDestination> activeMQDestination = brokerController.getBrokerService().getRegionBroker().
+                    getDurableDestinations();
+            for (ActiveMQDestination destination : activeMQDestination) {
+                if (destination.isTopic() && topicName.equals(destination.getPhysicalName())) {
+                    isTopicExist = true;
+                }
+            }
+            Assert.assertTrue("Topic is not added as a subscription", isTopicExist);
+        } finally {
+            task.destroy();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test polling on durable topic using JMS inbound endpoint task when the JMS Spec Version is 2.0
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPollingOnDurableTopicV2() throws Exception {
+        String topicName = "testTopic3";
+        boolean isTopicExist = false;
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(topicName, PROVIDER_URL, false);
+        jmsProperties.put(JMSConstants.PARAM_SUB_DURABLE, "true");
+        jmsProperties.put(JMSConstants.PARAM_JMS_SPEC_VER, JMSConstants.JMS_SPEC_VERSION_2_0);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        JMSPollingConsumer jmsPollingConsumer = new JMSPollingConsumer(jmsProperties, INTERVAL, INBOUND_EP_NAME);
+        InboundTask task = new JMSTask(jmsPollingConsumer, INTERVAL);
+        try {
+            brokerController.startProcess();
+            task.execute();
+            Set<ActiveMQDestination> activeMQDestination = brokerController.getBrokerService().getRegionBroker().
+                    getDurableDestinations();
+            for (ActiveMQDestination destination : activeMQDestination) {
+                if (destination.isTopic() && topicName.equals(destination.getPhysicalName())) {
+                    isTopicExist = true;
+                }
+            }
+            Assert.assertTrue("Topic is not added as a subscription", isTopicExist);
+        } finally {
+            task.destroy();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test polling on durable topic using JMS inbound endpoint task when the JMS Spec Version is 1.0
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPollingOnDurableTopicV1() throws Exception {
+        String topicName = "testTopic4";
+        boolean isTopicExist = false;
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(topicName, PROVIDER_URL, false);
+        jmsProperties.put(JMSConstants.PARAM_SUB_DURABLE, "true");
+        jmsProperties.put(JMSConstants.PARAM_JMS_SPEC_VER, JMSConstants.JMS_SPEC_VERSION_1_0);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        JMSPollingConsumer jmsPollingConsumer = new JMSPollingConsumer(jmsProperties, INTERVAL, INBOUND_EP_NAME);
+        InboundTask task = new JMSTask(jmsPollingConsumer, INTERVAL);
+        try {
+            brokerController.startProcess();
+            task.execute();
+            Set<ActiveMQDestination> activeMQDestination = brokerController.getBrokerService().getRegionBroker().
+                    getDurableDestinations();
+            for (ActiveMQDestination destination : activeMQDestination) {
+                if (destination.isTopic() && topicName.equals(destination.getPhysicalName())) {
+                    isTopicExist = true;
+                }
+            }
+            Assert.assertTrue("Topic is not added as a subscription", isTopicExist);
+        } finally {
+            task.destroy();
+            brokerController.stopProcess();
+        }
+    }
+
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/tests/JMSReplySenderTest.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/tests/JMSReplySenderTest.java
@@ -1,0 +1,346 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package endpoint.protocol.jms.tests;
+
+import endpoint.protocol.jms.JMSBrokerController;
+import endpoint.protocol.jms.JMSTestsUtils;
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.apache.activemq.command.ActiveMQBytesMessage;
+import org.apache.activemq.command.ActiveMQMapMessage;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMText;
+import org.apache.axiom.soap.SOAPEnvelope;
+import org.apache.axiom.soap.SOAPFactory;
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.transport.base.BaseConstants;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.junit.Test;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.BytesMessageDataSource;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSConstants;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSReplySender;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.factory.CachedJMSConnectionFactory;
+
+import javax.activation.DataHandler;
+import javax.jms.BytesMessage;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+public class JMSReplySenderTest extends TestCase {
+
+    private final static String PROVIDER_URL = "tcp://127.0.0.1:61616";
+
+    /**
+     * Test SendBackTextMessages
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSendBackTextMessages() throws Exception {
+        String replyQueueName = "testQueueReplyTxt";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(replyQueueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            Queue replyQueue = brokerController.connect(replyQueueName, true);
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            MessageContext messageContext = JMSTestsUtils.createMessageContext();
+            String correlationID = UUID.randomUUID().toString();
+            this.setSOAPEnvelopWithTextBody(messageContext);
+            this.setTransportHeaders(((Axis2MessageContext) messageContext).getAxis2MessageContext(),
+                    JMSConstants.JMS_TEXT_MESSAGE, correlationID);
+            messageContext.setProperty(JMSConstants.JMS_COORELATION_ID, correlationID);
+            JMSReplySender replySender = new JMSReplySender(replyQueue, cachedJMSConnectionFactory,
+                    null, null);
+            String soapAction = "urn:test";
+            ((Axis2MessageContext) messageContext).getAxis2MessageContext().setServerSide(true);
+            ((Axis2MessageContext) messageContext).getAxis2MessageContext().setProperty(BaseConstants.SOAPACTION,
+                    soapAction);
+            replySender.sendBack(messageContext);
+            Message replyMsg  = brokerController.receiveMessage(replyQueue);
+            Assert.assertNotNull("The reply message cannot be null", replyMsg);
+            Assert.assertEquals("The Message type of received message does not match", JMSConstants.JMS_TEXT_MESSAGE,
+                    replyMsg.getJMSType());
+            Assert.assertEquals("The Content of received message does not match", "TestSendBack",
+                    ((ActiveMQTextMessage) replyMsg).getText());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test SendBackByteMessages
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSendBackByteMessages() throws Exception {
+        String replyQueueName = "testQueueReplyBinary";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(replyQueueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            Queue replyQueue = brokerController.connect(replyQueueName, true);
+            String content = "This is a test";
+            BytesMessage message = brokerController.createBytesMessage(content.getBytes());
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            MessageContext messageContext = JMSTestsUtils.createMessageContext();
+            String correlationID = UUID.randomUUID().toString();
+            this.setSOAPEnvelopWithBinaryBody(messageContext, message);
+            this.setTransportHeaders(((Axis2MessageContext) messageContext).getAxis2MessageContext(),
+                    JMSConstants.JMS_BYTE_MESSAGE, correlationID);
+            messageContext.setProperty(JMSConstants.JMS_COORELATION_ID, correlationID);
+            JMSReplySender replySender = new JMSReplySender(replyQueue, cachedJMSConnectionFactory,
+                    null, null);
+            String soapAction = "urn:test";
+            ((Axis2MessageContext) messageContext).getAxis2MessageContext().getOptions().setAction(soapAction);
+            replySender.sendBack(messageContext);
+            Message replyMsg  = brokerController.receiveMessage(replyQueue);
+            Assert.assertNotNull("The reply message cannot be null", replyMsg);
+            Assert.assertEquals("The Message type of received message does not match", JMSConstants.JMS_BYTE_MESSAGE,
+                    replyMsg.getJMSType());
+            Assert.assertEquals("The Content of received message does not match", content,
+                    new String(((ActiveMQBytesMessage) replyMsg).getContent().getData()));
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test SendBackMapMessages
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSendBackMapMessages() throws Exception {
+        String replyQueueName = "testQueueReplyMap";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(replyQueueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            Queue replyQueue = brokerController.connect(replyQueueName, true);
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            MessageContext messageContext = JMSTestsUtils.createMessageContext();
+            String correlationID = UUID.randomUUID().toString();
+            this.setSOAPEnvelopWithMapMessageBody(messageContext);
+            this.setTransportHeaders(((Axis2MessageContext) messageContext).getAxis2MessageContext(),
+                    JMSConstants.JMS_MAP_MESSAGE, correlationID);
+            messageContext.setProperty(JMSConstants.JMS_COORELATION_ID, correlationID);
+            JMSReplySender replySender = new JMSReplySender(replyQueue, cachedJMSConnectionFactory,
+                    null, null);
+            replySender.sendBack(messageContext);
+            Message replyMsg  = brokerController.receiveMessage(replyQueue);
+            Assert.assertNotNull("The reply message cannot be null", replyMsg);
+            Assert.assertEquals("The Message type of received message does not match", JMSConstants.JMS_MAP_MESSAGE,
+                    replyMsg.getJMSType());
+            Assert.assertEquals("The Content of received message does not match", "10",
+                    ((ActiveMQMapMessage) replyMsg).getContentMap().get("Price"));
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test SendBackNoPayloadTypeTextMessages
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSendBackNoPayloadTypeTextMessages() throws Exception {
+        String replyQueueName = "testQueueNoPayloadTypeText";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(replyQueueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            Queue replyQueue = brokerController.connect(replyQueueName, true);
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            MessageContext messageContext = JMSTestsUtils.createMessageContext();
+            String correlationID = UUID.randomUUID().toString();
+            this.setSOAPEnvelopWithoutTypeTextMessageBody(messageContext);
+            this.setTransportHeaders(((Axis2MessageContext) messageContext).getAxis2MessageContext(),
+                    JMSConstants.JMS_TEXT_MESSAGE, correlationID);
+            messageContext.setProperty(JMSConstants.JMS_COORELATION_ID, correlationID);
+            JMSReplySender replySender = new JMSReplySender(replyQueue, cachedJMSConnectionFactory,
+                    null, null);
+            replySender.sendBack(messageContext);
+            Message replyMsg  = brokerController.receiveMessage(replyQueue);
+            Assert.assertNotNull("The reply message cannot be null", replyMsg);
+            Assert.assertEquals("The Message type of received message does not match", JMSConstants.JMS_TEXT_MESSAGE,
+                    replyMsg.getJMSType());
+            Assert.assertTrue("The Content of received message does not match",
+                    ((ActiveMQTextMessage) replyMsg).getText().contains("Price"));
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test SendBackNoPayloadTypeByteMessages
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSendBackNoPayloadTypeByteMessages() throws Exception {
+        String replyQueueName = "testQueueNoPayloadTypeByte";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(replyQueueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            Queue replyQueue = brokerController.connect(replyQueueName, true);
+            String content = "This is a test";
+            BytesMessage message = brokerController.createBytesMessage(content.getBytes());
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            MessageContext messageContext = JMSTestsUtils.createMessageContext();
+            String correlationID = UUID.randomUUID().toString();
+            this.setSOAPEnvelopWithoutTypeByteMessageBody(messageContext, message);
+            this.setTransportHeaders(((Axis2MessageContext) messageContext).getAxis2MessageContext(),
+                    JMSConstants.JMS_BYTE_MESSAGE, correlationID);
+            messageContext.setProperty(JMSConstants.JMS_COORELATION_ID, correlationID);
+            JMSReplySender replySender = new JMSReplySender(replyQueue, cachedJMSConnectionFactory,
+                    null, null);
+            replySender.sendBack(messageContext);
+            Message replyMsg  = brokerController.receiveMessage(replyQueue);
+            Assert.assertNotNull("The reply message cannot be null", replyMsg);
+            Assert.assertEquals("The Message type of received message does not match", JMSConstants.JMS_BYTE_MESSAGE,
+                    replyMsg.getJMSType());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test SendBackWhenMessageContextNull
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSendBackWhenMessageContextNull() throws Exception {
+        String replyQueueName = "testQueueNullMsgCtx";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(replyQueueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            Queue replyQueue = brokerController.connect(replyQueueName, true);
+            CachedJMSConnectionFactory cachedJMSConnectionFactory = new CachedJMSConnectionFactory(jmsProperties);
+            MessageContext messageContext = null;
+            JMSReplySender replySender = new JMSReplySender(replyQueue, cachedJMSConnectionFactory,
+                    null, null);
+            replySender.sendBack(messageContext);
+            Message replyMsg  = brokerController.receiveMessage(replyQueue);
+            Assert.assertNull("The message should be null", replyMsg);
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    private void setTransportHeaders(org.apache.axis2.context.MessageContext axis2MsgCxt, String messageType,
+                                     String correlationID) {
+        Map<String,Object> headerMap = new HashMap<>();
+        headerMap.put(JMSConstants.JMS_COORELATION_ID, correlationID);
+        headerMap.put(JMSConstants.JMS_DELIVERY_MODE, "1");
+        headerMap.put(JMSConstants.JMS_EXPIRATION, "10");
+        headerMap.put(JMSConstants.JMS_MESSAGE_ID, correlationID);
+        headerMap.put(JMSConstants.JMS_PRIORITY, "1");
+        headerMap.put(JMSConstants.JMS_TIMESTAMP, "" + new Timestamp(System.currentTimeMillis()).getTime());
+        headerMap.put(JMSConstants.JMS_MESSAGE_TYPE, messageType);
+        headerMap.put("CUSTOM_HEADER", "HEADER1");
+        headerMap.put("Content-Type", "text/xml; charset=\"utf-8\"");
+        headerMap.put("Content-Length", axis2MsgCxt.getEnvelope().toString().length());
+        axis2MsgCxt.setProperty(JMSConstants.JMS_MESSAGE_TYPE, messageType);
+        axis2MsgCxt.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, headerMap);
+    }
+
+    private void setSOAPEnvelopWithTextBody(MessageContext messageContext) throws AxisFault {
+        SOAPFactory fac = OMAbstractFactory.getSOAP11Factory();
+        SOAPEnvelope env = fac.createSOAPEnvelope();
+        fac.createSOAPBody(env);
+        OMElement firstEle = fac.createOMElement(BaseConstants.DEFAULT_TEXT_WRAPPER);
+        firstEle.setText("TestSendBack");
+        env.getBody().addChild(firstEle);
+        messageContext.setEnvelope(env);
+    }
+
+    private void setSOAPEnvelopWithBinaryBody(MessageContext messageContext, BytesMessage message) throws AxisFault {
+        SOAPFactory fac = OMAbstractFactory.getSOAP11Factory();
+        SOAPEnvelope env = fac.createSOAPEnvelope();
+        fac.createSOAPBody(env);
+        OMElement firstEle = fac.createOMElement(BaseConstants.DEFAULT_BINARY_WRAPPER);
+        DataHandler dataHandler = new DataHandler(new BytesMessageDataSource(message));
+        OMText textEle = fac.createOMText(dataHandler, true);
+        firstEle.addChild(textEle);
+        env.getBody().addChild(firstEle);
+        messageContext.setEnvelope(env);
+    }
+
+    private void setSOAPEnvelopWithMapMessageBody(MessageContext messageContext) throws AxisFault, XMLStreamException {
+        SOAPFactory fac = OMAbstractFactory.getSOAP11Factory();
+        SOAPEnvelope env = fac.createSOAPEnvelope();
+        fac.createSOAPBody(env);
+        OMElement mapElement1 = fac.createOMElement(new QName("Price"));
+        mapElement1.setText("10");
+        OMElement mapElement2 = fac.createOMElement(new QName("Name"));
+        mapElement2.setText("Queue");
+        OMElement firstEle = fac.createOMElement(JMSConstants.JMS_MAP_QNAME);
+        firstEle.addChild(mapElement1);
+        firstEle.addChild(mapElement2);
+        env.getBody().addChild(firstEle);
+        messageContext.setEnvelope(env);
+    }
+
+    private void setSOAPEnvelopWithoutTypeTextMessageBody(MessageContext messageContext) throws AxisFault,
+            XMLStreamException {
+        SOAPFactory fac = OMAbstractFactory.getSOAP11Factory();
+        SOAPEnvelope env = fac.createSOAPEnvelope();
+        fac.createSOAPBody(env);
+        OMElement mapElement1 = fac.createOMElement(new QName("Price"));
+        mapElement1.setText("10");
+        OMElement firstEle = fac.createOMElement(new QName("First"));
+        firstEle.addChild(mapElement1);
+        env.getBody().addChild(firstEle);
+        messageContext.setEnvelope(env);
+    }
+
+    private void setSOAPEnvelopWithoutTypeByteMessageBody(MessageContext messageContext, BytesMessage message)
+            throws AxisFault {
+        SOAPFactory fac = OMAbstractFactory.getSOAP11Factory();
+        SOAPEnvelope env = fac.createSOAPEnvelope();
+        fac.createSOAPBody(env);
+        OMElement firstEle = fac.createOMElement(new QName("Binary"));
+        DataHandler dataHandler = new DataHandler(new BytesMessageDataSource(message));
+        OMText textEle = fac.createOMText(dataHandler, true);
+        firstEle.addChild(textEle);
+        env.getBody().addChild(firstEle);
+        messageContext.setEnvelope(env);
+    }
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/tests/JMSUtilsTest.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/endpoint/protocol/jms/tests/JMSUtilsTest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package endpoint.protocol.jms.tests;
+
+import endpoint.protocol.jms.JMSBrokerController;
+import endpoint.protocol.jms.JMSTestsUtils;
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.apache.activemq.command.ActiveMQMapMessage;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.junit.Test;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSConstants;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSInjectHandler;
+import org.wso2.carbon.inbound.endpoint.protocol.jms.JMSUtils;
+
+import javax.jms.Destination;
+import javax.jms.MapMessage;
+import javax.jms.Message;
+import javax.naming.InitialContext;
+import java.util.Properties;
+
+public class JMSUtilsTest extends TestCase {
+
+    private final static String PROVIDER_URL = "tcp://127.0.0.1:61616";
+
+    /**
+     * Test ConvertJMSMapToXML
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConvertJMSMapToXML() throws Exception {
+        String queueName = "testHandler";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, false);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            brokerController.connect(queueName, true);
+            MapMessage mapMessage = brokerController.createMapMessage();
+            mapMessage.setStringProperty("MessageFormat", "Person");
+            mapMessage.setString("NAME", queueName);
+            mapMessage.setInt("COUNT", 10);
+            mapMessage.setDouble("PRICE", 12.00);
+            OMElement result = JMSInjectHandler.convertJMSMapToXML(mapMessage);
+            Assert.assertEquals("The converted XML is not correct", "10", ((OMElement) result.
+                    getChildrenWithLocalName("COUNT").next()).getText());
+            Assert.assertEquals("The converted XML is not correct", queueName, ((OMElement) result.
+                    getChildrenWithLocalName("NAME").next()).getText());
+        } finally {
+            brokerController.stopProcess();
+        }
+    }
+
+
+    /**
+     * Test convertXMLtoJMSMap
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConvertXMLtoJMSMap() throws Exception {
+        String queueName = "testHandler1";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, false);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            brokerController.connect(queueName, true);
+            MapMessage mapMessage = brokerController.createMapMessage();
+            OMElement omElement = AXIOMUtil.stringToOM(
+                    "<JMSMap xmlns=\"http://axis.apache.org/axis2/java/transports/jms/map-payload\">" +
+                            "<PRICE>12.0</PRICE>" +
+                            "<COUNT>10</COUNT>" +
+                            "<NAME>" + queueName + "</NAME>" +
+                            "</JMSMap>");
+            JMSUtils.convertXMLtoJMSMap(omElement, mapMessage);
+            Assert.assertEquals("The converted JMS Map is not correct", "12.0", ((ActiveMQMapMessage) mapMessage).
+                    getContentMap().get("PRICE"));
+            Assert.assertEquals("The converted JMS Map is not correct", queueName, ((ActiveMQMapMessage) mapMessage).
+                    getContentMap().get("NAME"));
+        } finally {
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test lookupDestination
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLookupDestination() throws Exception {
+        String queueName = "testQueueExist";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            InitialContext ctx = new InitialContext(jmsProperties);
+            brokerController.connect(queueName, true);
+            Destination existDest = JMSUtils.lookupDestination(ctx, queueName, JMSConstants.DESTINATION_TYPE_QUEUE);
+            Assert.assertEquals("The destination should be exist", queueName,
+                    ((ActiveMQQueue) existDest).getPhysicalName());
+            Destination nullDest = JMSUtils.lookupDestination(ctx, null, JMSConstants.DESTINATION_TYPE_QUEUE);
+            Assert.assertNull("Destination should be null when the destination name is null", nullDest);
+            String notExistQueueName = "Not_Exist";
+            Destination nonExistDest = JMSUtils.lookupDestination(ctx, notExistQueueName,
+                    JMSConstants.DESTINATION_TYPE_QUEUE);
+            Assert.assertEquals("The destination should be exist", notExistQueueName,
+                    ((ActiveMQQueue) nonExistDest).getPhysicalName());
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+    /**
+     * Test inferJMSMessageType
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInferJMSMessageType() throws Exception {
+        String queueName = "testQueueExist1";
+        Properties jmsProperties = JMSTestsUtils.getJMSPropertiesForDestination(queueName, PROVIDER_URL, true);
+        JMSBrokerController brokerController = new JMSBrokerController(PROVIDER_URL, jmsProperties);
+        try {
+            brokerController.startProcess();
+            brokerController.connect(queueName, true);
+            Message mapMessage = brokerController.createMapMessage();
+            String mapClassName = JMSUtils.inferJMSMessageType(mapMessage);
+            Assert.assertEquals("The Class name should be javax.jms.MapMessage", "javax.jms.MapMessage", mapClassName);
+            String text = "This is a test";
+            Message textMessage = brokerController.pushMessage(text);
+            String textClassName = JMSUtils.inferJMSMessageType(textMessage);
+            Assert.assertEquals("The Class name should be javax.jms.TextMessage", "javax.jms.TextMessage",
+                    textClassName);
+            Message byteMessage = brokerController.createBytesMessage(text.getBytes());
+            String byteClassName = JMSUtils.inferJMSMessageType(byteMessage);
+            Assert.assertEquals("The Class name should be javax.jms.BytesMessage", "javax.jms.BytesMessage",
+                    byteClassName);
+            Message objMessage = brokerController.createObjectMessage();
+            String objClassName = JMSUtils.inferJMSMessageType(objMessage);
+            Assert.assertEquals("The Class name should be javax.jms.ObjectMessage", "javax.jms.ObjectMessage",
+                    objClassName);
+            Message streamMessage = brokerController.createStreamMessage();
+            String streamClassName = JMSUtils.inferJMSMessageType(streamMessage);
+            Assert.assertEquals("The Class name should be javax.jms.StreamMessage", "javax.jms.StreamMessage",
+                    streamClassName);
+        } finally {
+            brokerController.disconnect();
+            brokerController.stopProcess();
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,11 @@
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>2.4</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${maven.jacoco.plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -1846,6 +1851,7 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>rhino.wso2</groupId>
@@ -2280,6 +2286,24 @@
                 <artifactId>encoder</artifactId>
                 <version>${owasp.encoder.wso2.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jacoco</groupId>
+                <artifactId>org.jacoco.agent</artifactId>
+                <classifier>runtime</classifier>
+                <version>${jacoco.agent.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-core</artifactId>
+                <version>${activemq.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-broker</artifactId>
+                <version>${activemq.broker.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -2400,7 +2424,7 @@
         <imp.pkg.version.javax.servlet.jsp.jstl>[1.2.1, 1.3.0)</imp.pkg.version.javax.servlet.jsp.jstl>
         <gson.version>2.1</gson.version>
         <slf4j.wso2.version>1.5.10.wso2v1</slf4j.wso2.version>
-        <junit.version>3.8.2</junit.version>
+        <junit.version>4.8.2</junit.version>
         <quartz.wso2.version>2.1.1.wso2v1</quartz.wso2.version>
         <jaxen.version>1.1.1</jaxen.version>
         <orbit.version.infinispan>5.1.2.wso2v1</orbit.version.infinispan>
@@ -2473,6 +2497,11 @@
         <!-- OWASP encoder versions -->
         <owasp.encoder.wso2.version>1.2.0.wso2v1</owasp.encoder.wso2.version>
         <owasp.encoder.wso2.imp.pkg.version>[1.2.0,1.3.0)</owasp.encoder.wso2.imp.pkg.version>
+        <maven.surefire.plugin.version>2.12.4</maven.surefire.plugin.version>
+        <maven.jacoco.plugin.version>0.7.2.201409121644</maven.jacoco.plugin.version>
+        <jacoco.agent.version>0.7.2.201409121644</jacoco.agent.version>
+        <activemq.version>5.2.0</activemq.version>
+        <activemq.broker.version>5.15.2</activemq.broker.version>
     </properties>
     <pluginRepositories>
         <pluginRepository>


### PR DESCRIPTION
## Purpose
This is to add unit tests for JMS Inbound EPs. 

## Approach
Following testcases are added

JMSPollingConsumerQueueTest - start ActiveMQ embeded server. Add a JMS Inbound Task. Check whether the queue is added in the broker
JMSPollingConsumerTopicTest - start ActiveMQ embeded server. Add a JMS Inbound Task. Check whether the topic is added in the broker

ActiveMQ embedded server is used as the broker.

Further jacoco maven plug-in is added to get the coverage report.

## Automation tests
 - Unit tests 
   > Code coverage information
org.wso2.carbon.inbound.endpoint.protocol.jms.factory - coverage increased from 0% to 68%
org.wso2.carbon.inbound.endpoint.protocol.jms -  coverage increased from 0% to 28%
