### PR TITLE
Fix ESBJAVA-4950 NPE if the connectionFactory null

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/factory/JMSConnectionFactory.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/factory/JMSConnectionFactory.java
@@ -249,6 +249,10 @@ public class JMSConnectionFactory implements ConnectionFactory, QueueConnectionF
     }
 
     public Connection createConnection(String userName, String password) {
+        if (connectionFactory == null) {
+            logger.error("Connection cannot be establish to the broker. Please check the broker libs provided.");
+            return null;
+        }
         Connection connection = null;
         try {
             if ( JMSConstants.JMS_SPEC_VERSION_1_1.equals(jmsSpec) ) {


### PR DESCRIPTION
## Purpose
A NPE is thrown when creating a connection if the connectionFactory is null. This fix is to handle that scenario, when the connection is created by using the credentials. The connectionFactory can be null if it fails to create a connection factory for a given connection factory string

https://wso2.org/jira/browse/ESBJAVA-4950
