### PR TITLE
Add transaction support for BAPI in SAP adaptor

### DIFF
--- a/components/business-adaptors/sap/src/main/java/org/wso2/carbon/transports/sap/SAPConstants.java
+++ b/components/business-adaptors/sap/src/main/java/org/wso2/carbon/transports/sap/SAPConstants.java
@@ -40,6 +40,7 @@ public class SAPConstants {
     public static final String CUSTOM_ERROR_LISTENER_PARAM = "transport.sap.customErrorListener";
     public static final String CUSTOM_EXCEPTION_LISTENER_PARAM = "transport.sap.customExceptionListener";
     public static final String CUSTOM_TID_HANDLER_PARAM = "transport.sap.customTIDHandler";
+    public static final String TRANSACTION_COMMIT_PARAM = "transport.sap.transactionCommit";
 
     /* Transport sender parameters */
     public static final String CUSTOM_IDOC_XML_MAPPERS = "transport.sap.customXMLMappers";
@@ -57,4 +58,8 @@ public class SAPConstants {
     /* Client options */
     public static final String CLIENT_XML_MAPPER_KEY = "transport.sap.xmlMapper";
     public static final String CLIENT_XML_PARSER_OPTIONS = "transport.sap.xmlParserOptions";
+
+    /* bapi for transaction */
+    public static final String BAPI_TRANSACTION_COMMIT = "BAPI_TRANSACTION_COMMIT";
+    public static final String BAPI_TRANSACTION_ROLLBACK = "BAPI_TRANSACTION_ROLLBACK";
 }


### PR DESCRIPTION
## Purpose
The current implementation doesn't support transaction for the BAPIs. 
Resolves https://github.com/wso2/product-ei/issues/1601.  

## Goals
Improve SAP adaptor implementation to support BAPI transaction.

## Approach
A user has to explicitly define the following property in the mediation flow before invoking the SAP endpoint to run it as BAPI transaction.
`<property name="transport.sap.transactionCommit" scope="axis2" type="STRING" value="true"/>`

## User stories
A user wants to invoke BAPI as a transaction.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
https://docs.wso2.com/display/ESB481/SAP+Integration#SAPIntegration-AdditionalConfigurationParameter

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
“N/A”

## Marketing
“N/A”

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.