### PR TITLE
Fix data publisher dependency in HL7

### DIFF
--- a/components/business-adaptors/hl7/org.wso2.carbon.business.messaging.hl7.common/pom.xml
+++ b/components/business-adaptors/hl7/org.wso2.carbon.business.messaging.hl7.common/pom.xml
@@ -78,10 +78,9 @@
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.databridge.commons</artifactId>
         </dependency>
-        <!--TODO: Remove this after refactoring logic-->
         <dependency>
-            <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.bam.data.publisher.util</artifactId>
+            <groupId>org.wso2.carbon.mediation</groupId>
+            <artifactId>org.wso2.carbon.das.data.publisher.util</artifactId>
         </dependency>
     </dependencies>
 

--- a/components/business-adaptors/hl7/org.wso2.carbon.business.messaging.hl7.common/src/main/java/org/wso2/carbon/business/messaging/hl7/common/data/conf/HL7MessagePublisherConfig.java
+++ b/components/business-adaptors/hl7/org.wso2.carbon.business.messaging.hl7.common/src/main/java/org/wso2/carbon/business/messaging/hl7/common/data/conf/HL7MessagePublisherConfig.java
@@ -6,7 +6,7 @@ import ca.uhn.hl7v2.util.Terser;
 import org.apache.axis2.context.MessageContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.bam.data.publisher.util.PublisherUtil;
+import org.wso2.carbon.das.data.publisher.util.PublisherUtil;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.business.messaging.hl7.common.HL7Constants;
 import org.wso2.carbon.business.messaging.hl7.common.data.MessageData;

--- a/pom.xml
+++ b/pom.xml
@@ -1799,12 +1799,6 @@
                 <artifactId>org.wso2.carbon.caching.core</artifactId>
                 <version>${org.wso2.carbon.caching.core.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.bam.data.publisher.util</artifactId>
-                <version>${bam.data.publisher.version}</version>
-            </dependency>
-
 
             <!--12 Misc -->
             <dependency>
@@ -2390,7 +2384,6 @@
         <org.wso2.uri.template.version>1.6.4</org.wso2.uri.template.version>
         <org.wso2.caching.version>4.0.3</org.wso2.caching.version>
         <org.wso2.carbon.caching.core.version>4.2.0</org.wso2.carbon.caching.core.version>
-        <bam.data.publisher.version>4.2.0</bam.data.publisher.version>
         <carbon.datastore.version>4.2.0</carbon.datastore.version>
         <wso2.sap.version>1.0</wso2.sap.version>
         <wsdl4j.wso2.version>1.6.2.wso2v4</wsdl4j.wso2.version>


### PR DESCRIPTION
## Purpose
HL7MessagePublisherConfig was using PublisherUtil from an old(org.wso2.carbon.bam.data.publisher.util)dependency.
This need to be fixed with the correct dependency : org.wso2.carbon.das.data.publisher.util

https://wso2.org/jira/browse/ESBJAVA-4889

## Goals
Prevent class not found exception during runtime

## Approach
Added the correct dependency 

## User stories
N/A

## Release note
N/A

## Documentation
For the older version of ESB 5.0.0 or EI. the HL7 common jar should be corrected with building pointing to the correct dependency

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8, Linux environment
 
## Learning
N/A