### PR TITLE
Fix EI-1622.

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
@@ -31,6 +31,14 @@ public class JMSConstants {
         QUEUE, TOPIC
     };
 
+    // Fix with EI-1622
+    // No. of retries for JMS client polling that occurs before suspending polling.
+    public static final String JMS_CLIENT_POLLING_RETRIES_BEFORE_SUSPENSION = "transport.jms.RetriesBeforeSuspension";
+    // Time in milliseconds for the polling suspension period.
+    public static final String JMS_CLIENT_POLLING_SUSPENSION_PERIOD = "transport.jms.PollingSuspensionPeriod";
+    // Default time in milliseconds for the polling suspension period.
+    public static final int DEFAULT_JMS_CLIENT_POLLING_SUSPENSION_PERIOD = 60000;
+
     public static final String TOPIC_PREFIX = "topic.";
     public static final String QUEUE_PREFIX = "queue.";
 

--- a/components/mediation-ui/org.wso2.carbon.inbound.ui/src/main/resources/config/inbound.properties
+++ b/components/mediation-ui/org.wso2.carbon.inbound.ui/src/main/resources/config/inbound.properties
@@ -54,7 +54,7 @@ jms.mandatory.8=transport.jms.Destination
 jms.mandatory.9=transport.jms.SessionAcknowledgement ~:~ AUTO_ACKNOWLEDGE ~:~ CLIENT_ACKNOWLEDGE ~:~ DUPS_OK_ACKNOWLEDGE ~:~ SESSION_TRANSACTED
 jms.mandatory.10=transport.jms.CacheLevel ~:~ 3 ~:~ 2 ~:~ 1 ~:~ 0
 
-jms.optional=16
+jms.optional=18
 jms.optional.1=transport.jms.UserName
 jms.optional.2=transport.jms.Password
 jms.optional.3=transport.jms.JMSSpecVersion
@@ -72,6 +72,8 @@ jms.optional.13=transport.jms.SharedSubscription ~:~ false ~:~ true
 jms.optional.14=pinnedServers
 jms.optional.15=concurrent.consumers
 jms.optional.16=transport.jms.retry.duration
+jms.optional.17=transport.jms.RetriesBeforeSuspension
+jms.optional.18=transport.jms.PollingSuspensionPeriod
 
 https.mandatory=2
 https.mandatory.1=inbound.http.port


### PR DESCRIPTION
Add the functionality to JMS inbound endpoints to suspend and do reactivate polling when a certain number of mediation failures occurs.

## Purpose
> Add the functionality to JMS inbound endpoints to suspend and do reactivate polling when a certain number of mediation failures occurs.

## Goals
> Fix https://github.com/wso2/product-ei/issues/1622

## Approach
> Introduced two optional parameters, "transport.jms.RetriesBeforeSuspension" & "transport.jms.PollingSuspensionPeriod" to configure the Polling Suspension Limit and Polling Suspension Period.

Based on Polling Suspension Limit, polling will be suspended for Polling Suspension Period when the limit is attained.

## User stories
> N/A

## Release note
> This fix has introduced two new optional parameters, "transport.jms.RetriesBeforeSuspension" & "transport.jms.PollingSuspensionPeriod" to configure the Polling Suspension Limit and Polling Suspension Period. These can be used in Inbound endpoints to suspend polling after certain no. of retries.

## Documentation
> 

## Automation tests
 - Integration tests
   > Added in product EI.


## Related PRs
> https://github.com/wso2/product-ei/pull/1673


## Test environment
> JDK 1.8, Ubuntu 16.04
 
## Learning
> N/A
  