### PR TITLE
Fix for ESBJAVA-4015

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/java/org/wso2/carbon/endpoint/ui/endpoints/address/AddressEndpoint.java
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/java/org/wso2/carbon/endpoint/ui/endpoints/address/AddressEndpoint.java
@@ -33,6 +33,7 @@ public class AddressEndpoint extends Endpoint {
     private String susProgFactor;
     private String errorCodes;
     private String format;
+    private String encoding;
     private boolean swa = false;
     private boolean mtom = false;
     private boolean soap11 = false;
@@ -321,6 +322,10 @@ public class AddressEndpoint extends Endpoint {
         if (address != null && !"".equals(address)) {
             addressElement.addAttribute(fac.createOMAttribute("uri", nullNS, address));
         }
+        if (encoding != null && !encoding.isEmpty()) {
+            addressElement.addAttribute(fac.createOMAttribute("encoding", nullNS, encoding));
+        }
+
         // format
         if (isSoap11()) {
             addressElement.addAttribute(fac.createOMAttribute("format", nullNS, "soap11"));
@@ -513,6 +518,7 @@ public class AddressEndpoint extends Endpoint {
         if (addressEndpoint.getName() != null) {
             setEndpointName((addressEndpoint.getName().equals("anonymous") ? "" : addressEndpoint.getName()));
         }
+        setEncoding(addressEndpoint.getDefinition().getCharSetEncoding());
         setAddress(addressEndpoint.getDefinition().getAddress());
         setDescription(addressEndpoint.getDescription());
         setSoap11(addressEndpoint.getDefinition().isForceSOAP11());
@@ -565,5 +571,13 @@ public class AddressEndpoint extends Endpoint {
 
     public void setOutboundWsSecPolicyKey(String outboundWsSecPolicyKey) {
         this.outboundWsSecPolicyKey = outboundWsSecPolicyKey;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
     }
 }

--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/forms/addressEndpoint-form.jsp
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/forms/addressEndpoint-form.jsp
@@ -207,8 +207,13 @@
     String rmPolicy = "";
     String description = "";
     String properties = "";
+    String encoding = "";
 
     if (endpoint != null) {
+        // Encoding
+        if (endpoint.getEncoding() != null) {
+            encoding = endpoint.getEncoding();
+        }
         // Endpoint Name
         if (endpoint.getEndpointName() != null) {
             addressEpName = endpoint.getEndpointName();
@@ -482,6 +487,7 @@
                    onclick="testURL(document.getElementById('url').value)"
                    value="<fmt:message key="test.url"/>"/>
         </td>
+        <td><input id="encoding" name="encoding" type="hidden" value="<%=encoding%>"/></td>
     </tr>
 
     <%

--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/updatePages/addressEndpoint-update.jsp
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/updatePages/addressEndpoint-update.jsp
@@ -41,6 +41,7 @@
     String disabledErrorCodes = request.getParameter("disabledErrorCodes");
     String action = request.getParameter("actionSelect");
     String actionDuration = null;
+    String encoding = request.getParameter("encoding");
     if (action != null && !action.equals("neverTimeout")) {
         actionDuration = request.getParameter("actionDuration");
     }
@@ -108,7 +109,9 @@
         addressEndpoint.setSwa(false);
         addressEndpoint.setMtom(false);
     }
-
+    if (encoding != null && !"".equals(encoding)) {
+        addressEndpoint.setEncoding(encoding);
+    }
     if (description != null && !"".equals(description)) {
         addressEndpoint.setDescription(description);
     } else {


### PR DESCRIPTION
## Purpose
> Fix for ESBJAVA-4015

## Goals
> Add encoding attribute to the AddressEndpoint and make it visible in source view

## Approach
> Introduce new property in AddressEndpoint class to hold encoding.
Add a new hidden field to hold encoding details in address endpoint edit web form.
So, when submitted (going to source view) it will bring encoding details to the source view.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 8, Ubuntu 16.04