### PR TITLE
Add SapTransportSender to have login support for BAPI calls

### DIFF
--- a/components/business-adaptors/sap/src/main/java/org/wso2/carbon/transports/sap/SAPConstants.java
+++ b/components/business-adaptors/sap/src/main/java/org/wso2/carbon/transports/sap/SAPConstants.java
@@ -41,6 +41,16 @@ public class SAPConstants {
     public static final String CUSTOM_EXCEPTION_LISTENER_PARAM = "transport.sap.customExceptionListener";
     public static final String CUSTOM_TID_HANDLER_PARAM = "transport.sap.customTIDHandler";
     public static final String TRANSACTION_COMMIT_PARAM = "transport.sap.transactionCommit";
+    public static final String TRANSACTION_SAP_LOGON = "transport.sap.logon";
+    public static final String TRANSPORT_SAP_EXTCOMPANY = "transport.sap.EXTCOMPANY";
+    public static final String TRANSPORT_SAP_EXTPRODUCT = "transport.sap.EXTPRODUCT";
+    public static final String TRANSPORT_SAP_INTERFACE = "transport.sap.INTERFACE";
+    public static final String TRANSPORT_SAP_VERSION = "transport.sap.VERSION";
+    public static final String EXTCOMPANY = "EXTCOMPANY";
+    public static final String EXTPRODUCT = "EXTPRODUCT";
+    public static final String INTERFACE = "INTERFACE";
+    public static final String VERSION = "VERSION";
+    public static final String BABI_XMI_LOGON = "BAPI_XMI_LOGON";
 
     /* Transport sender parameters */
     public static final String CUSTOM_IDOC_XML_MAPPERS = "transport.sap.customXMLMappers";


### PR DESCRIPTION
## Purpose
Add login support for BAPI SAP calls.
Resolves https://github.com/wso2/product-ei/issues/1693

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
EI-1693: Add login support for BAPI calls
