### PR TITLE
Fix EI-1421 for wrong HL7 ACK responses on multithreading requests

### DIFF
--- a/components/business-adaptors/hl7/org.wso2.carbon.business.messaging.hl7.common/src/main/java/org/wso2/carbon/business/messaging/hl7/common/HL7ProcessingContext.java
+++ b/components/business-adaptors/hl7/org.wso2.carbon.business.messaging.hl7.common/src/main/java/org/wso2/carbon/business/messaging/hl7/common/HL7ProcessingContext.java
@@ -456,8 +456,7 @@ public class HL7ProcessingContext {
             	String messageControlID_in = terser.get("/MSH-10");
             	
             	Message response= pollMyResponse(messageControlID_in);
-				
-                return response;
+            	return response;
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }

--- a/components/business-adaptors/hl7/org.wso2.carbon.business.messaging.hl7.common/src/main/java/org/wso2/carbon/business/messaging/hl7/common/HL7ProcessingContext.java
+++ b/components/business-adaptors/hl7/org.wso2.carbon.business.messaging.hl7.common/src/main/java/org/wso2/carbon/business/messaging/hl7/common/HL7ProcessingContext.java
@@ -473,7 +473,7 @@ public class HL7ProcessingContext {
 	
 	/**
 	 * Try to get ACK response from applicationResponses. If no response match with messageControlID_in
-	 * it retry every 1 second. After timeOutVal 
+	 * it retry every 1 second until the timeOutVal is triggered  
 	 * @param messageControlID_in
 	 * @return
 	 * @throws InterruptedException after Transport Timeout
@@ -491,9 +491,10 @@ public class HL7ProcessingContext {
 			applicationResponses.forEach(consumer);
 			timeEnd=Calendar.getInstance().getTimeInMillis();
 			timeDiff=timeEnd-timeStart;
-			Thread.sleep(1000);
-		}while(responseWrapper.getMsg()==null && timeDiff < timeOutVal);
-		response=responseWrapper.getMsg();
+			response=responseWrapper.getMsg();
+			if(response==null)
+				Thread.sleep(1000);
+		}while(response==null && timeDiff < timeOutVal);
 		if(response== null){
 			log.error("thread["+Thread.currentThread().getId()+"] No response received for messageControlID_in:"+messageControlID_in );
 			throw new InterruptedException("No response received for messageControlID_in:"+messageControlID_in );

--- a/components/business-adaptors/hl7/org.wso2.carbon.business.messaging.hl7.common/src/main/java/org/wso2/carbon/business/messaging/hl7/common/HL7ProcessingContext.java
+++ b/components/business-adaptors/hl7/org.wso2.carbon.business.messaging.hl7.common/src/main/java/org/wso2/carbon/business/messaging/hl7/common/HL7ProcessingContext.java
@@ -57,6 +57,11 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import java.util.function.Consumer;
+import java.util.Calendar;
+import ca.uhn.hl7v2.util.Terser;
+
+
 /**
  * This class represents an HL7 message processing context.
  */
@@ -446,7 +451,12 @@ public class HL7ProcessingContext {
 				+ "generate ACK message or not.";
         if (("true").equalsIgnoreCase(applicationAck)) {
             try {
-                Message response = applicationResponses.poll(timeOutVal, TimeUnit.MILLISECONDS);
+            	
+            	Terser terser = new Terser(hl7Msg);
+            	String messageControlID_in = terser.get("/MSH-10");
+            	
+            	Message response= pollMyResponse(messageControlID_in);
+				
                 return response;
             } catch (InterruptedException e) {
                 e.printStackTrace();
@@ -459,6 +469,39 @@ public class HL7ProcessingContext {
             }
         }
         return this.createNack(hl7Msg, errMsg);
+	}
+	
+	
+	/**
+	 * Try to get ACK response from applicationResponses. If no response match with messageControlID_in
+	 * it retry every 1 second. After timeOutVal 
+	 * @param messageControlID_in
+	 * @return
+	 * @throws InterruptedException after Transport Timeout
+	 */
+	private Message pollMyResponse(String messageControlID_in) throws InterruptedException {
+		
+		long timeStart=Calendar.getInstance().getTimeInMillis();
+		long timeEnd=0;
+		long timeDiff=0;
+		log.debug("thread["+Thread.currentThread().getId()+"] startTime: "+timeStart+" timeOutVal: "+timeOutVal);
+		MsgWrapper responseWrapper= new MsgWrapper();
+		Hl7Consumer consumer=new Hl7Consumer(messageControlID_in,responseWrapper);
+		Message response=null;
+		do{
+			applicationResponses.forEach(consumer);
+			timeEnd=Calendar.getInstance().getTimeInMillis();
+			timeDiff=timeEnd-timeStart;
+			Thread.sleep(1000);
+		}while(responseWrapper.getMsg()==null && timeDiff < timeOutVal);
+		response=responseWrapper.getMsg();
+		if(response== null){
+			log.error("thread["+Thread.currentThread().getId()+"] No response received for messageControlID_in:"+messageControlID_in );
+			throw new InterruptedException("No response received for messageControlID_in:"+messageControlID_in );
+		}
+		
+		log.debug("thread["+Thread.currentThread().getId()+"] found response for messageControlID_in:"+messageControlID_in );
+		return response;
 	}
 	
 	/**
@@ -519,4 +562,60 @@ public class HL7ProcessingContext {
 	public void setTimeOutVal(int timeOut) {
 	    this.timeOutVal = timeOut;
     }
+	
+	
+	/**
+	 * Custom Consumer for match and return response ACK
+	 *
+	 */
+	private class Hl7Consumer implements Consumer<Message>{
+
+		private String msgControlId;
+		private MsgWrapper responseWrapper;
+		
+		public Hl7Consumer(String msgControlId,MsgWrapper responseWrapper) {
+			this.msgControlId=msgControlId;
+			this.responseWrapper=responseWrapper;
+		}
+
+		@Override
+		public void accept(Message t) {
+			
+			Terser terser = new Terser(t);
+			String messageControlerID_out=null;
+            try {
+				messageControlerID_out = terser.get("/MSA-2");
+			} catch (HL7Exception e) {
+				log.error("Missing field MSA-2 for message:"+t);
+				return;
+			}
+			if(msgControlId.equals(messageControlerID_out)){
+				log.debug("thread["+Thread.currentThread().getId()+"] accept response");
+				responseWrapper.setMsg(t);
+				applicationResponses.remove(t);
+			}
+			
+		}
+		
+	}
+	
+	/**
+	 * Simple message wrapper class
+	 *
+	 */
+	private class MsgWrapper {
+		private Message msg;
+		
+		
+		public void setMsg(Message msg) {
+			this.msg = msg;
+		}
+		
+		
+		public Message getMsg() {
+			return msg;
+		}
+		
+		
+	}
 }


### PR DESCRIPTION
## Purpose
> When a HL7 proxy receive parallel requests, the response ACKs are delivered  back in casual order without check the match of the **Message Control Id**.  This bug makes dangerous to use the WSO2' HL7 module in healthcare production environments (surgical operating rooms, laboratories, ecc.)
Resolves [issue928](https://github.com/wso2/carbon-mediation/issues/928), [issue1421](https://github.com/wso2/product-ei/issues/1421)

## Goals
> The fix no longer takes the first message from the applicationResponses  BlockingQueue, but try to get the correct message with matching  control id. If no response match it retry every 1 until the timeout is triggered.

## Approach
> I have implemented a new private method `pollMyResponse` that uses an `HL7Consumer` class (that implements java.util.function.Consumer<Message>) for check the applicationResponses queue and match/accept the correct message.
The timeout is preserved

## User stories
> In production enviroments we have noticed that the responses of parallel requests were often sent back at the wrong process.

## Release note
> Fixed wrong HL7 ACK response sent back

## Documentation
> N/A
The documentation is not impacted because the fix is related to wrong implementation of a functionality
## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> N/A.

## Marketing
>N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Windows 7, jdk1.8.0

 
## Learning
> I have used Wireshark and debugger of Eclipse for the research of the bug