### PR TITLE
Fix ESBJAVA-4932

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQConstants.java
@@ -65,6 +65,9 @@ public class RabbitMQConstants {
     public static final String EXCHANGE_TYPE = "rabbitmq.exchange.type";
     public static final String EXCHANGE_DURABLE = "rabbitmq.exchange.durable";
     public static final String EXCHANGE_AUTODELETE = "rabbitmq.exchange.auto.delete";
+    public static final String EXCHANGE_TYPE_DEFAULT = "direct";
+    public static final String EXCHANGE_DURABLE_DEFAULT = "true";
+    public static final String EXCHANGE_AUTODELETE_DEFAULT = "false";
 
     public static final String QUEUE_NAME = "rabbitmq.queue.name";
     public static final String QUEUE_DURABLE = "rabbitmq.queue.durable";

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQUtils.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQUtils.java
@@ -134,8 +134,22 @@ public class RabbitMQUtils {
         Boolean exchangeAvailable = false;
         Channel channel = connection.createChannel();
         String exchangeType = properties
-                .get(RabbitMQConstants.EXCHANGE_TYPE);
-        String durable = properties.get(RabbitMQConstants.EXCHANGE_DURABLE);
+                .getOrDefault(RabbitMQConstants.EXCHANGE_TYPE, RabbitMQConstants.EXCHANGE_TYPE_DEFAULT);
+        String durable = properties
+                .getOrDefault(RabbitMQConstants.EXCHANGE_DURABLE, RabbitMQConstants.EXCHANGE_DURABLE_DEFAULT);
+        String autoDelete = properties
+                .getOrDefault(RabbitMQConstants.EXCHANGE_AUTODELETE, RabbitMQConstants.EXCHANGE_AUTODELETE_DEFAULT);
+
+        if (exchangeType.isEmpty()) {
+            exchangeType = RabbitMQConstants.EXCHANGE_TYPE_DEFAULT;
+        }
+        if (durable.isEmpty()) {
+            durable = RabbitMQConstants.EXCHANGE_DURABLE_DEFAULT;
+        }
+        if (autoDelete.isEmpty()) {
+            autoDelete = RabbitMQConstants.EXCHANGE_AUTODELETE_DEFAULT;
+        }
+
         try {
             // check availability of the named exchange.
             // The server will raise an IOException
@@ -153,19 +167,9 @@ public class RabbitMQUtils {
                 log.debug("Channel is not open. Creating a new channel.");
             }
             try {
-                if (exchangeType != null
-                        && !exchangeType.equals("")) {
-                    if (durable != null && !durable.equals("")) {
-                        channel.exchangeDeclare(exchangeName,
-                                exchangeType,
-                                Boolean.parseBoolean(durable));
-                    } else {
-                        channel.exchangeDeclare(exchangeName,
-                                exchangeType, true);
-                    }
-                } else {
-                    channel.exchangeDeclare(exchangeName, "direct", true);
-                }
+                channel.exchangeDeclare(exchangeName, exchangeType, Boolean.parseBoolean(durable),
+                        Boolean.parseBoolean(autoDelete),
+                        null); // null since passing no extra arguments
             } catch (IOException e) {
                 handleException("Error occurred while declaring exchange.", e);
             }


### PR DESCRIPTION
Creating RabbitMQ exchange with auto delete property if it is defined.

## Purpose
> Create Rabbit MQ endpoint with the "rabbitmq.exchange.auto.delete" property if its declared.
 Previously even if the property is read there were no implementations of it in code.

## Goals
> Fix https://wso2.org/jira/browse/ESBJAVA-4932 , 
auto-deletion parameter ignored from a Rabbitmq Inbound Endpoint.

## Approach
> Create the exchange with auto-delete paramter.

## User stories
> N/A

## Release note
>  N/A

## Documentation
>  This property description is documented incorrectly.
https://github.com/wso2/product-ei/issues/1772 

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 -N/A

## Security checks
 - N/A

## Samples
> N/A

## Related PRs
> None

## Migrations (if applicable)
> N/A

## Test environment
>  JDK 1.8
 
## Learning
> https://www.rabbitmq.com/releases/rabbitmq-java-client/v2.2.0/rabbitmq-java-client-javadoc-2.2.0/com/rabbitmq/client/Channel.html
https://www.cloudamqp.com/blog/2015-09-03-part4-rabbitmq-for-beginners-exchanges-routing-keys-bindings.html