### PR TITLE
Update carbon commons and synapse versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2316,7 +2316,7 @@
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
 
         <!-- Carbon Commons version-->
-        <carbon.commons.version>4.6.13</carbon.commons.version>
+        <carbon.commons.version>4.6.15</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.5.0, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <!-- Carbon Deployment version-->
@@ -2340,7 +2340,7 @@
         <carbon.rule.imp.pkg.version>[4.4.0, 4.5.0)</carbon.rule.imp.pkg.version>
 
         <!-- Synapse Version -->
-        <synapse.version>2.1.7-wso2v36</synapse.version>
+        <synapse.version>2.1.7-wso2v37</synapse.version>
 
         <carbon.identity.entitlement.proxy.version>5.1.1</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.0.0, 6.0.0)</carbon.identity.entitlement.proxy.imp.pkg.version>


### PR DESCRIPTION
## Purpose
> Update carbon commons and synapse versions to the latest for EI update 19 release