### PR TITLE
Resolve wso2/product-ei#943

### DIFF
--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CachableResponse.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CachableResponse.java
@@ -100,6 +100,11 @@ public class CachableResponse implements Serializable {
     private Pattern responseCodePattern;
 
     /**
+     * This holds whether the response is doing REST.
+     */
+    private boolean doingREST;
+
+    /**
      * Sets the responsePayload and the headerProperties to null
      */
     public void clean() {
@@ -321,5 +326,19 @@ public class CachableResponse implements Serializable {
      */
     public void setHttpMethod(String httpMethod) {
         this.httpMethod = httpMethod;
+    }
+
+    /**
+     * @return whether the response is doing REST or not.
+     */
+    public boolean isDoingREST() {
+        return doingREST;
+    }
+
+    /**
+     * @param doingREST whether the response doing REST or not
+     */
+    public void setDoingREST(boolean doingREST) {
+        this.doingREST = doingREST;
     }
 }

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
@@ -23,8 +23,6 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
-import org.apache.axis2.context.ConfigurationContext;
-import org.apache.axis2.context.OperationContext;
 import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
@@ -192,16 +190,10 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
             }
         }
 
-        ConfigurationContext cfgCtx = ((Axis2MessageContext) synCtx).getAxis2MessageContext().getConfigurationContext();
-
-        if (cfgCtx == null) {
-            handleException("Unable to perform caching,  ConfigurationContext cannot be found", synCtx);
-            return false; // never executes.. but keeps IDE happy
-        }
         boolean result = true;
         try {
             if (synCtx.isResponse()) {
-                processResponseMessage(synCtx, cfgCtx, synLog);
+                processResponseMessage(synCtx, synLog);
             } else {
                 result = processRequestMessage(synCtx, synLog);
             }
@@ -294,17 +286,23 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
                     msgCtx.setProperty(PassThroughConstants.HTTP_SC_DESC, cachedResponse.getStatusReason());
                 }
             }
-            if (msgCtx.isDoingREST()) {
+            msgCtx.setDoingREST(cachedResponse.isDoingREST());
+
+            if (cachedResponse.isDoingREST()) {
 
                 msgCtx.removeProperty(PassThroughConstants.NO_ENTITY_BODY);
                 msgCtx.removeProperty(Constants.Configuration.CONTENT_TYPE);
             }
             if ((headerProperties = cachedResponse.getHeaderProperties()) != null) {
+                Map<String, Object> headers = new HashMap<>();
+                headers.putAll(headerProperties);
 
-                msgCtx.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS,
-                                   headerProperties);
                 msgCtx.setProperty(Constants.Configuration.MESSAGE_TYPE,
-                                   headerProperties.get(Constants.Configuration.MESSAGE_TYPE));
+                                   headers.remove(Constants.Configuration.MESSAGE_TYPE));
+                msgCtx.setProperty(Constants.Configuration.CONTENT_TYPE,
+                                   headers.remove(Constants.Configuration.CONTENT_TYPE));
+                msgCtx.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS,
+                                   headers);
             }
 
             // take specified action on cache hit
@@ -348,10 +346,9 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
      *
      * @param synLog the Synapse log to use
      * @param synCtx the current message (response)
-     * @param cfgCtx the abstract context in which the cache will be kept
      */
     @SuppressWarnings("unchecked")
-    private void processResponseMessage(MessageContext synCtx, ConfigurationContext cfgCtx, SynapseLog synLog) {
+    private void processResponseMessage(MessageContext synCtx, SynapseLog synLog) {
         if (!collector) {
             handleException("Response messages cannot be handled in a non collector cache", synCtx);
         }
@@ -393,9 +390,9 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
                 }
             }
             if (toCache) {
-                String contentType = ((String) msgCtx.getProperty(Constants.Configuration.CONTENT_TYPE)).split(";")[0];
+                String contentType = (String) msgCtx.getProperty(Constants.Configuration.CONTENT_TYPE);
 
-                if (contentType.equals(jsonContentType)) {
+                if (contentType.split(";")[0].equals(jsonContentType)) {
                     byte[] responsePayload = JsonUtil.jsonPayloadToByteArray(msgCtx);
                     if (response.getMaxMessageSize() > -1 &&
                             responsePayload.length > response.getMaxMessageSize()) {
@@ -428,7 +425,7 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
                             }
                         }
                     }
-
+                    response.setDoingREST(msgCtx.isDoingREST());
                     response.setResponsePayload(null);
                     response.setResponseEnvelope(clonedEnvelope);
                     response.setJson(false);
@@ -455,10 +452,11 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
                 for (Map.Entry<String, String> entry : headers.entrySet()) {
                     headerProperties.put(entry.getKey(), entry.getValue());
                 }
-                headerProperties.put(Constants.Configuration.MESSAGE_TYPE, messageType);
+                headers.put(CachingConstants.CACHE_KEY, response.getRequestHash());
                 headerProperties.put(CachingConstants.CACHE_KEY, response.getRequestHash());
+                headerProperties.put(Constants.Configuration.MESSAGE_TYPE, messageType);
+                headerProperties.put(Constants.Configuration.CONTENT_TYPE, contentType);
                 response.setHeaderProperties(headerProperties);
-                msgCtx.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, headerProperties);
 
             } else {
                 response.clean();


### PR DESCRIPTION
## Purpose
> Resolve wso2/product-ei#943 

## Goals
> Fix the incorrect handling of SOAP responses

## Approach
> The issue doingRest parameter of the Axis2 MessageContext of the response was not included in the response from the cache mediator. Also the PR removes unused parameter.

## Related PRs
> https://github.com/wso2/carbon-mediation/pull/843
>https://github.com/wso2/carbon-mediation/pull/887
>https://github.com/wso2/carbon-mediation/pull/889
>https://github.com/wso2/carbon-mediation/pull/949