### PR TITLE
Fix wso2/product-ei#1801

### DIFF
--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheManager.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheManager.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * There would be two instances of the cache mediator in a single mediation flow. Hence it must be possible for the
  * cache created in one instance to be reused in the next. This CacheManager enables this feature with static methods.
  */
-class CacheManager {
+public class CacheManager {
 
     /**
      * Maps the id with the relevant LoadingCache

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
@@ -566,7 +566,7 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
      *
      * @return DigestGenerator used evaluate hash values.
      */
-    DigestGenerator getDigestGenerator() {
+    public DigestGenerator getDigestGenerator() {
         return digestGenerator;
     }
 
@@ -575,7 +575,7 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
      *
      * @param digestGenerator DigestGenerator to be set to evaluate hash values.
      */
-    void setDigestGenerator(DigestGenerator digestGenerator) {
+    public void setDigestGenerator(DigestGenerator digestGenerator) {
         this.digestGenerator = digestGenerator;
     }
 


### PR DESCRIPTION
Make CacheManager class and CacheMediator methods (getDigestGenerator, setDigestGenerator) publicly accessible for developer studio usages.

## Purpose
Fixed https://github.com/wso2/product-ei/issues/1801

## Related PRs
https://github.com/wso2/devstudio-tooling-esb/pull/312
https://github.com/wso2/carbon-mediation/pull/949
