### PR TITLE
 Fix JSON not working in cache mediator

### DIFF
--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
@@ -425,13 +425,13 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
                             }
                         }
                     }
-                    response.setDoingREST(msgCtx.isDoingREST());
                     response.setResponsePayload(null);
                     response.setResponseEnvelope(clonedEnvelope);
                     response.setJson(false);
 
                 }
 
+                response.setDoingREST(msgCtx.isDoingREST());
                 if (synLog.isTraceOrDebugEnabled()) {
                     synLog.traceOrDebug("Storing the response message into the cache with ID : "
                                                 + id + " for request hash : " + response.getRequestHash());


### PR DESCRIPTION
## Purpose
>     This was a regression issue because of the previous fix #961 . The above fix broke JSON functionality and hence this resolves it.