### PR TITLE
Fix https://github.com/wso2/product-ei/issues/1835

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
@@ -30,6 +30,8 @@ public class InboundWebsocketConstants {
     public static final String INBOUND_SSL_TRUST_STORE_FILE = "wss.ssl.trust.store.file";
     public static final String INBOUND_SSL_TRUST_STORE_PASS = "wss.ssl.trust.store.pass";
     public static final String INBOUND_SSL_CERT_PASS = "wss.ssl.cert.pass";
+    public static final String SSL_PROTOCOLS = "wss.ssl.protocols";
+    public static final String CIPHER_SUITES = "wss.ssl.cipher.suites";
 
     @Deprecated
     public static final String WEBSOCKET_SOURCE_HANDSHAKE_PRESENT = "websocket.source.handshake.present";

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/management/WebsocketEndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/management/WebsocketEndpointManager.java
@@ -280,8 +280,9 @@ public class WebsocketEndpointManager extends AbstractInboundEndpointManager {
                         InboundWebsocketConstants.INBOUND_SSL_TRUST_STORE_FILE),
                 params.getProperties().getProperty(
                         InboundWebsocketConstants.INBOUND_SSL_TRUST_STORE_PASS),
-                params.getProperties().getProperty(
-                        InboundWebsocketConstants.INBOUND_SSL_CERT_PASS)).build();
+                params.getProperties().getProperty(InboundWebsocketConstants.INBOUND_SSL_CERT_PASS),
+                params.getProperties().getProperty(InboundWebsocketConstants.SSL_PROTOCOLS),
+                params.getProperties().getProperty(InboundWebsocketConstants.CIPHER_SUITES)).build();
     }
 
     public void loadEndpointListeners() {

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/ssl/InboundWebsocketSSLConfiguration.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/ssl/InboundWebsocketSSLConfiguration.java
@@ -17,6 +17,8 @@
 package org.wso2.carbon.inbound.endpoint.protocol.websocket.ssl;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 public class InboundWebsocketSSLConfiguration {
     private File keyStore;
@@ -24,6 +26,24 @@ public class InboundWebsocketSSLConfiguration {
     private String certPass;
     private File trustStore;
     private String trustStorePass;
+    private String[] sslProtocols;
+    private String[] cipherSuites;
+
+    public String[] getSslProtocols() {
+        return sslProtocols;
+    }
+
+    public void setSslProtocols(String[] sslProtocols) {
+        this.sslProtocols = sslProtocols;
+    }
+
+    public String[] getCipherSuites() {
+        return cipherSuites;
+    }
+
+    public void setCipherSuites(String[] cipherSuites) {
+        this.cipherSuites = cipherSuites;
+    }
 
     public InboundWebsocketSSLConfiguration(File keyStore, String keyStorePass) {
         this.keyStore = keyStore;
@@ -72,6 +92,8 @@ public class InboundWebsocketSSLConfiguration {
         private String trustStoreFile;
         private String trustStorePass;
         private String certPass;
+        private String sslProtocols;
+        private String cipherSuites;
 
         public SSLConfigurationBuilder(String keyStoreFile,
                                        String keyStorePass,
@@ -84,6 +106,17 @@ public class InboundWebsocketSSLConfiguration {
             this.trustStorePass = trustStorePass;
             this.certPass = certPass;
 
+        }
+
+        public SSLConfigurationBuilder(String keyStoreFile, String keyStorePass, String trustStoreFile,
+                String trustStorePass, String certPass, String sslProtocols, String cipherSuites) {
+            this.keyStoreFile = keyStoreFile;
+            this.keyStorePass = keyStorePass;
+            this.trustStoreFile = trustStoreFile;
+            this.trustStorePass = trustStorePass;
+            this.certPass = certPass;
+            this.sslProtocols = sslProtocols;
+            this.cipherSuites = cipherSuites;
         }
 
         public InboundWebsocketSSLConfiguration build() {
@@ -108,6 +141,35 @@ public class InboundWebsocketSSLConfiguration {
                     throw new IllegalArgumentException("trustStorePass is not defined ");
                 }
                 sslConfig.setTrustStore(trustStore).setTrustStorePass(trustStorePass);
+            }
+
+            if (sslProtocols == null || sslProtocols.trim().isEmpty() ) {
+                sslProtocols = "TLS";
+            }
+
+            String[] preferredSSLProtocols = sslProtocols.trim().split(",");
+            List<String> protocolList = new ArrayList<>(preferredSSLProtocols.length);
+            for (String protocol : preferredSSLProtocols) {
+                if (!protocol.trim().isEmpty()) {
+                    protocolList.add(protocol.trim());
+                }
+            }
+            preferredSSLProtocols = protocolList.toArray(new String[protocolList.size()]);
+
+            sslConfig.setSslProtocols(preferredSSLProtocols);
+
+            if (cipherSuites != null && cipherSuites.trim().length() != 0) {
+
+                String[] preferredCipherSuites = cipherSuites.trim().split(",");
+                List<String> cipherSuiteList = new ArrayList<>(preferredCipherSuites.length);
+                for (String cipherSuite : preferredCipherSuites) {
+                    if (!cipherSuite.trim().isEmpty()) {
+                        cipherSuiteList.add(cipherSuite.trim());
+                    }
+                }
+                preferredCipherSuites = cipherSuiteList.toArray(new String[cipherSuiteList.size()]);
+
+                sslConfig.setCipherSuites(preferredCipherSuites);
             }
             return sslConfig;
         }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/ssl/SSLHandlerFactory.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/ssl/SSLHandlerFactory.java
@@ -41,6 +41,8 @@ public class SSLHandlerFactory {
     private static final String protocol = "TLS";
     private final SSLContext serverContext;
     private boolean needClientAuth;
+    private String[] cipherSuites;
+    private String[] sslProtocols;
 
     public SSLHandlerFactory(InboundWebsocketSSLConfiguration sslConfiguration) {
         String algorithm = Security.getProperty("ssl.KeyManagerFactory.algorithm");
@@ -63,6 +65,8 @@ public class SSLHandlerFactory {
             }
             serverContext = SSLContext.getInstance(protocol);
             serverContext.init(keyManagers, trustManagers, null);
+            cipherSuites = sslConfiguration.getCipherSuites();
+            sslProtocols = sslConfiguration.getSslProtocols();
         } catch (UnrecoverableKeyException | KeyManagementException |
                 NoSuchAlgorithmException | KeyStoreException | IOException ex) {
             throw new IllegalArgumentException("Failed to initialize the server side SSLContext", ex);
@@ -82,6 +86,12 @@ public class SSLHandlerFactory {
 
     public SslHandler create() {
         SSLEngine engine = serverContext.createSSLEngine();
+        if (cipherSuites != null) {
+            engine.setEnabledCipherSuites(cipherSuites);
+        }
+        if (sslProtocols != null) {
+            engine.setEnabledProtocols(sslProtocols);
+        }
         engine.setNeedClientAuth(needClientAuth);
         engine.setUseClientMode(false);
         return new SslHandler(engine);

--- a/components/mediation-ui/org.wso2.carbon.inbound.ui/src/main/resources/config/inbound.properties
+++ b/components/mediation-ui/org.wso2.carbon.inbound.ui/src/main/resources/config/inbound.properties
@@ -243,7 +243,7 @@ wss.mandatory.7=wss.ssl.trust.store.file
 wss.mandatory.8=wss.ssl.trust.store.pass
 wss.mandatory.9=wss.ssl.cert.pass
 
-wss.optional=7
+wss.optional=9
 wss.optional.1=ws.boss.thread.pool.size
 wss.optional.2=ws.worker.thread.pool.size
 wss.optional.3=ws.subprotocol.handler.class
@@ -251,6 +251,8 @@ wss.optional.4=ws.default.content.type
 wss.optional.5=ws.shutdown.status.code
 wss.optional.6=ws.shutdown.status.message
 wss.optional.7=ws.use.port.offset ~:~ false ~:~ true
+wss.optional.8=wss.ssl.protocols
+wss.optional.9=wss.ssl.cipher.suites
 
 wso2mb.mandatory=11
 wso2mb.mandatory.1=interval


### PR DESCRIPTION
Here we are intoducing two parameters to configure preferred ciphers and SSL enabled protocols for WSS inbound endpoints

## Purpose
>  Enable configuring preferred Ciphers and SSL enabled protocols for WSS inbound endpoints.

## Goals
> Fix https://github.com/wso2/product-ei/issues/1835

## Approach
> Two new parameters,  "wss.ssl.protocols" and "wss.ssl.cipher.suites"  are introduced to configure the preferred Ciphers and SSL enabled protocols for WSS inbound endpoints.


## Documentation
> Docs need to incorporate these two newly added parameters.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> 

## Related PRs
> 

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> JDK 1.8  , Ubuntu 16.04
 
## Learning
> 