### PR TITLE
Fix response swap when FORCE_SC_ACCEPTED present

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
@@ -33,6 +33,8 @@ import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.axis2.MessageContextCreatorForAxis2;
+import org.apache.synapse.core.axis2.ResponseState;
+import org.apache.synapse.core.axis2.SynapseMessageReceiver;
 import org.apache.synapse.inbound.InboundEndpoint;
 import org.apache.synapse.inbound.InboundEndpointConstants;
 import org.apache.synapse.mediators.MediatorFaultHandler;
@@ -90,6 +92,8 @@ public class InboundHttpServerWorker extends ServerWorker {
                 updateAxis2MessageContextForSynapse(synCtx);
 
                 setInboundProperties(synCtx);
+                // setting ResponseState for http inbound endpoint request
+                synCtx.setProperty(SynapseConstants.RESPONSE_STATE, new ResponseState());
                 String method = request.getRequest() != null ? request.getRequest().
                         getRequestLine().getMethod().toUpperCase() : "";
                 processHttpRequestUri(axis2MsgContext, method);
@@ -192,7 +196,7 @@ public class InboundHttpServerWorker extends ServerWorker {
                     injectToMainSequence(synCtx, endpoint);
                 }
 
-
+                SynapseMessageReceiver.doPostInjectUpdates(synCtx);
                 // send ack for client if needed
                 sendAck(axis2MsgContext);
             } catch (Exception e) {

--- a/pom.xml
+++ b/pom.xml
@@ -2340,7 +2340,7 @@
         <carbon.rule.imp.pkg.version>[4.4.0, 4.5.0)</carbon.rule.imp.pkg.version>
 
         <!-- Synapse Version -->
-        <synapse.version>2.1.7-wso2v39</synapse.version>
+        <synapse.version>2.1.7-wso2v40</synapse.version>
 
         <carbon.identity.entitlement.proxy.version>5.1.1</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.0.0, 6.0.0)</carbon.identity.entitlement.proxy.imp.pkg.version>


### PR DESCRIPTION
# This Pull request is depended on https://github.com/wso2/wso2-synapse/pull/1043 

When configuration has FORCE_SC_ACCEPTED and respond in a different path(like fault sequence)
two requests are comming on a same conntion receives swapped/incorrect response
Fix related to requests coming via http inbound endpoint
wso2/product-ei#1829

## Purpose
Fix response swapping when 202 accepted is added

## Goals
Make sure correct response is sent to all requests

## Approach
Fixed by validating the response state

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
https://github.com/wso2/wso2-synapse/pull/1043

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8
 
## Learning
N/A