### PR TITLE
Fix product-ei#1853

### DIFF
--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CachableResponse.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CachableResponse.java
@@ -20,6 +20,7 @@ import org.apache.axiom.soap.SOAPEnvelope;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 /**
@@ -57,7 +58,7 @@ public class CachableResponse implements Serializable {
     /**
      * This holds the HTTP Header Properties of the response.
      */
-    private Map<String, Object> headerProperties;
+    private ConcurrentHashMap<String, Object> headerProperties;
 
     /**
      * The HTTP status code number of the response
@@ -190,7 +191,7 @@ public class CachableResponse implements Serializable {
      * @param headerProperties HTTP Header Properties to be stored in to cache as a map
      */
     public void setHeaderProperties(Map<String, Object> headerProperties) {
-        this.headerProperties = headerProperties;
+        this.headerProperties = (ConcurrentHashMap) headerProperties;
     }
 
     /**

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
@@ -47,10 +47,10 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.mediator.cache.digest.DigestGenerator;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -449,7 +449,7 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
                         (Map<String, String>) msgCtx.getProperty(
                                 org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
                 String messageType = (String) msgCtx.getProperty(Constants.Configuration.MESSAGE_TYPE);
-                Map<String, Object> headerProperties = new HashMap<>();
+                ConcurrentHashMap<String, Object> headerProperties = new ConcurrentHashMap<>();
                 //Individually copying All TRANSPORT_HEADERS to headerProperties Map instead putting whole
                 //TRANSPORT_HEADERS map as single Key/Value pair to fix hazelcast serialization issue.
                 for (Map.Entry<String, String> entry : headers.entrySet()) {


### PR DESCRIPTION
Fix ConcurrentModificationException error while sending a load using the cache mediator with a binary content.

## Purpose
Fixed https://github.com/wso2/product-ei/issues/1853

## Approach
Replace hashmap with ConcurrentHashMap

## Related PRs
https://github.com/wso2/carbon-mediation/commit/dbfb25b01c915319d034801709465ac8a6679140#diff-27b6b1e0d16b94fd7174706f75b33a7e
