### PR TITLE
Fix https://github.com/wso2/product-ei/issues/1877

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
@@ -38,6 +38,9 @@ public class JMSConstants {
     public static final String JMS_CLIENT_POLLING_SUSPENSION_PERIOD = "transport.jms.PollingSuspensionPeriod";
     // Default time in milliseconds for the polling suspension period.
     public static final int DEFAULT_JMS_CLIENT_POLLING_SUSPENSION_PERIOD = 60000;
+    // This property need to be enabled if the connection need to be reset after polling suspension.
+    public static final String JMS_CLIENT_CONNECTION_RESET_AFTER_POLLING_SUSPENSION
+            = "transport.jms.ResetConnectionOnPollingSuspension";
 
     public static final String TOPIC_PREFIX = "topic.";
     public static final String QUEUE_PREFIX = "queue.";

--- a/components/mediation-ui/org.wso2.carbon.inbound.ui/src/main/resources/config/inbound.properties
+++ b/components/mediation-ui/org.wso2.carbon.inbound.ui/src/main/resources/config/inbound.properties
@@ -54,7 +54,7 @@ jms.mandatory.8=transport.jms.Destination
 jms.mandatory.9=transport.jms.SessionAcknowledgement ~:~ AUTO_ACKNOWLEDGE ~:~ CLIENT_ACKNOWLEDGE ~:~ DUPS_OK_ACKNOWLEDGE ~:~ SESSION_TRANSACTED
 jms.mandatory.10=transport.jms.CacheLevel ~:~ 3 ~:~ 2 ~:~ 1 ~:~ 0
 
-jms.optional=20
+jms.optional=21
 jms.optional.1=transport.jms.UserName
 jms.optional.2=transport.jms.Password
 jms.optional.3=transport.jms.JMSSpecVersion
@@ -74,8 +74,9 @@ jms.optional.15=concurrent.consumers
 jms.optional.16=transport.jms.retry.duration
 jms.optional.17=java.naming.security.principal
 jms.optional.18=java.naming.security.credentials
-jms.optional.19=transport.jms.RetriesBeforeSuspension
-jms.optional.20=transport.jms.PollingSuspensionPeriod
+jms.optional.19=transport.jms.ResetConnectionOnPollingSuspension ~:~ false ~:~ true
+jms.optional.20=transport.jms.RetriesBeforeSuspension
+jms.optional.21=transport.jms.PollingSuspensionPeriod
 
 https.mandatory=2
 https.mandatory.1=inbound.http.port


### PR DESCRIPTION
This introduces a new property to JMS inbound endpoint making enabling the reset connection after polling suspension possible

## Purpose
>  Enabling the JMS inbound to reset connection to the broker on polling suspension.


## Approach
> Introduced a new property "transport.jms.ResetConnectionOnPollingSuspension" to JMS Inbound endpoint which will fascilitate this functionality.

## User stories
> N/A

## Release note
> 
## Documentation
>  Adding the newly added property to documentation. Created a doc JIRA internally.

## Related PRs
> https://github.com/wso2-support/carbon-mediation/pull/133
