### PR TITLE
Handle exception when Invalid value for RabbitMQ QoS

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQConnectionConsumer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQConnectionConsumer.java
@@ -141,11 +141,6 @@ public class RabbitMQConnectionConsumer {
             channel = connection.createChannel();
             log.debug("Channel is not open. Creating a new channel for inbound " + inboundName);
         }
-        //set the qos value for the consumer//
-        String qos = rabbitMQProperties.getProperty(RabbitMQConstants.CONSUMER_QOS);
-        if (qos != null && !qos.isEmpty()) {
-            channel.basicQos(Integer.parseInt(qos));
-        }
 
         //unable to connect to the queue
         if (queueingConsumer == null) {
@@ -265,11 +260,17 @@ public class RabbitMQConnectionConsumer {
             log.debug("Channel is not open. Creating a new channel for inbound " + inboundName);
         }
 
-        //set QoS parameter for the channel before it is assigned to the consumer
+        // set QoS parameter for the channel before it is assigned to the consumer
         String qos = rabbitMQProperties.getProperty(RabbitMQConstants.CONSUMER_QOS);
         if (qos != null && !qos.isEmpty()) {
-            channel.basicQos(Integer.parseInt(qos));
+            try {
+                channel.basicQos(Integer.parseInt(qos));
+            } catch (NumberFormatException e) {
+                log.warn("Unable to parse given QoS value, " + qos + " as an integer. Therefore using channel " +
+                        "without QoS.");
+            }
         }
+
         queueingConsumer = new QueueingConsumer(channel);
 
         consumerTagString = rabbitMQProperties.getProperty(RabbitMQConstants.CONSUMER_TAG);


### PR DESCRIPTION
## Purpose
Remove duplicate QoS setting code and handle NumberFormatException when parsing QoS value.
Resolves #1040

## Goals
Handle the NumberFormatException when parsing the QoS value.
Remove duplication QoS setting code.

## Approach
When the parameter "rabbitmq.channel.consumer.qos" is not an integer value then log a warn message and create the InboundEndpoint (RabbitMQ) without QoS.

## User stories
N/A

## Release note
Previously when the QoS value is not an integer, then an exception is thrown and CApp file/ inbound endpoint is not deployed. In this fix, it will log a warning and deploy the artifact without QoS.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
yes
 - Ran FindSecurityBugs plugin and verified report? 
yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes, this does not contain any of these values.

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Oracle JDK 1.8.0_60
 
## Learning
N/A