### PR TITLE
Fix wso2/product-ei/issues/2391

### DIFF
--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/output/writers/XMLWriter.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/output/writers/XMLWriter.java
@@ -118,9 +118,6 @@ public class XMLWriter implements Writer {
                     }
                 } else if (name.equals(SCHEMA_XML_ELEMENT_TEXT_VALUE_FIELD)){
                     xmlStreamWriter.writeCharacters(value);
-                } else if (name.equals(latestElementName)) {
-                    xmlStreamWriter.writeCharacters(value);
-                    xmlStreamWriter.writeEndElement();
                 } else {
                     writeStartElement(name, xmlStreamWriter);
                     xmlStreamWriter.writeCharacters(value);


### PR DESCRIPTION
## Purpose
> Fix wso2/product-ei/issues/2391

## Goals
> allow nested elements with same name in datamapper mediator

## Approach
> Remove logic related to not writing start element tag if that element is
already written.

## Test environment
> JDK 8