### PR TITLE
Fix release build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2591,12 +2591,12 @@
         <repository>
             <id>nexus-releases</id>
             <name>WSO2 Release Distribution Repository</name>
-            <url>http://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
+            <url>https://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
             <id>wso2.snapshots</id>
             <name>Apache Snapshot Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
## Purpose
Fixes the release build being failed due to the following:
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project command-mediator: Failed to deploy artifacts: Could not transfer artifact org.wso2.carbon.mediation:command-mediator:pom:4.6.98 from/to nexus-releases (http://maven.wso2.org/nexus/service/local/staging/deploy/maven2/): Connection to http://maven.wso2.org refused: Connection timed out