### PR TITLE
Fix EI-2614

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRunner.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRunner.java
@@ -87,9 +87,9 @@ public class InboundRunner implements Runnable {
                     execute = false;
                     log.info("Inbound EP will not run in manager node. Same will run on worker(s).");
                 }
-            } else {
-                init = true;
             }
+            init = true;
+
             try {
                 Thread.sleep(interval);
             } catch (InterruptedException e) {


### PR DESCRIPTION
## Purpose
> Resolves: wso2/product-ei/issues/2614

## Goals
> Undeploy CAPPs with inbound endpoints without hanging the server

## Approach
> The issue is faced due to the variable 'init' being not set to true in
clustered mode even after initialization of the inbound endpoint. This
causes the InboundRunner thread to run endlessly thus being unable to
stop it at undeployment.