### PR TITLE
performance enhancement of datamapper

### DIFF
--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/pom.xml
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/pom.xml
@@ -94,5 +94,9 @@
             <groupId>org.apache.ws.commons.axiom</groupId>
             <artifactId>axiom-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.sf.saxon.wso2</groupId>
+            <artifactId>saxon</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingHandler.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingHandler.java
@@ -26,6 +26,7 @@ import javax.xml.transform.TransformerFactory;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.Map;
+import javax.xml.transform.stream.StreamSource;
 
 public class XSLTMappingHandler {
 
@@ -36,7 +37,7 @@ public class XSLTMappingHandler {
      * @throws TransformerException errors arise from xslt transformation
      */
     public XSLTMappingHandler(XSLTMappingResource xsltMappingResource) throws TransformerException {
-        Source xsltSource = new javax.xml.transform.stream.StreamSource(xsltMappingResource
+        Source xsltSource = new StreamSource(xsltMappingResource
                 .getInputStream());
         TransformerFactory transFact = new TransformerFactoryImpl();
         transformer = transFact.newTransformer(xsltSource);
@@ -54,7 +55,7 @@ public class XSLTMappingHandler {
             TransformerException {
 
         setParameters(properties);
-        Source xmlSource = new javax.xml.transform.stream.StreamSource(inputXML);
+        Source xmlSource = new StreamSource(inputXML);
         StringWriter sw = new StringWriter();
         Result result = new javax.xml.transform.stream.StreamResult(sw);
         transformer.transform(xmlSource, result);
@@ -69,8 +70,9 @@ public class XSLTMappingHandler {
      */
     private void setParameters(Map<String, Object> properties) {
         transformer.clearParameters();
-        for (Map.Entry<String, Object> property : properties.entrySet())
+        for (Map.Entry<String, Object> property : properties.entrySet()){
             transformer.setParameter(property.getKey(), property.getValue());
+        }    
     }
 
 }

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingHandler.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.mediator.datamapper.engine.core.mapper;
+
+import net.sf.saxon.TransformerFactoryImpl;
+
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.Map;
+
+public class XSLTMappingHandler {
+
+    private Transformer transformer;
+
+    /**
+     * @param xsltMappingResource xslt mapping resource
+     * @throws TransformerException errors arise from xslt transformation
+     */
+    public XSLTMappingHandler(XSLTMappingResource xsltMappingResource) throws TransformerException {
+        Source xsltSource = new javax.xml.transform.stream.StreamSource(xsltMappingResource
+                .getInputStream());
+        TransformerFactory transFact = new TransformerFactoryImpl();
+        transformer = transFact.newTransformer(xsltSource);
+    }
+
+    /**
+     * This method performs xslt transformation from input xml to the output xml
+     *
+     * @param properties set of runtime properties with values
+     * @param inputXML   input stream of the input xml message
+     * @return output xml as a string
+     * @throws TransformerException errors arise from xslt transformation
+     */
+    public String doMap(Map<String, Object> properties, InputStream inputXML) throws
+            TransformerException {
+
+        setParameters(properties);
+        Source xmlSource = new javax.xml.transform.stream.StreamSource(inputXML);
+        StringWriter sw = new StringWriter();
+        Result result = new javax.xml.transform.stream.StreamResult(sw);
+        transformer.transform(xmlSource, result);
+        return sw.toString();
+
+    }
+
+    /**
+     * Set runtime properties as parameters in the transformer
+     *
+     * @param properties Map of properties with values
+     */
+    private void setParameters(Map<String, Object> properties) {
+        transformer.clearParameters();
+        for (Map.Entry<String, Object> property : properties.entrySet())
+            transformer.setParameter(property.getKey(), property.getValue());
+    }
+
+}

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingHandler.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingHandler.java
@@ -55,7 +55,7 @@ public class XSLTMappingHandler {
      * @throws TransformerException errors arise from xslt transformation
      */
     public String doMap(Map<String, Object> properties, InputStream inputXML) throws
-            TransformerException {
+                                                                              TransformerException {
 
         setParameters(properties);
         Source xmlSource = new StreamSource(inputXML);

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingHandler.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingHandler.java
@@ -23,11 +23,15 @@ import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamSource;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.Map;
-import javax.xml.transform.stream.StreamSource;
 
+/**
+ * This class handle the transformation of the input xml to the output xml.
+ * Saxon xslt transformation engine is used for the transformation.
+ */
 public class XSLTMappingHandler {
 
     private Transformer transformer;
@@ -37,8 +41,7 @@ public class XSLTMappingHandler {
      * @throws TransformerException errors arise from xslt transformation
      */
     public XSLTMappingHandler(XSLTMappingResource xsltMappingResource) throws TransformerException {
-        Source xsltSource = new StreamSource(xsltMappingResource
-                .getInputStream());
+        Source xsltSource = new StreamSource(xsltMappingResource.getInputStream());
         TransformerFactory transFact = new TransformerFactoryImpl();
         transformer = transFact.newTransformer(xsltSource);
     }
@@ -70,9 +73,9 @@ public class XSLTMappingHandler {
      */
     private void setParameters(Map<String, Object> properties) {
         transformer.clearParameters();
-        for (Map.Entry<String, Object> property : properties.entrySet()){
+        for (Map.Entry<String, Object> property : properties.entrySet()) {
             transformer.setParameter(property.getKey(), property.getValue());
-        }    
+        }
     }
 
 }

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingResource.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingResource.java
@@ -107,13 +107,19 @@ public class XSLTMappingResource {
         Node rootNode = document.getElementsByTagName(PARAMETER_FILE_ROOT).item(0);
         for (int j = 0; j < rootNode.getAttributes().getLength(); j++) {
             Node propertyNode = rootNode.getAttributes().item(j);
+
+            // Process configuration details passed as attributes
             switch (propertyNode.getNodeName()) {
                 case RUN_TIME_PROPERTIES:
+                    //Runtime properties are passed as "propertyName1,propertyScope1,proertyName2,propertyScope2, .."
+                    //Property name followed by its scope, separated by a comma
                     String runTimePropertyString = propertyNode.getNodeValue();
                     if (!EMPTY_STRING.equals(runTimePropertyString)) {
+                        //first element of the array is a property name followed by its scope.
                         String[] properties = runTimePropertyString.split(PROPERTY_SEPERATOR);
                         int currentIndex = 0;
                         while (currentIndex < properties.length) {
+                            //adding property name and its scope to the runTimeProperties map
                             runTimeProperties.put(properties[currentIndex],
                                                   properties[currentIndex + 1]);
                             currentIndex += 2;

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingResource.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingResource.java
@@ -52,7 +52,7 @@ public class XSLTMappingResource {
     private final Map<String, String> runTimeProperties;
     private String name;
     private String content;
-    private boolean notXSLTCompatible;
+    private boolean xsltCompatible;
 
 
     public XSLTMappingResource(String content) throws SAXException,
@@ -61,8 +61,8 @@ public class XSLTMappingResource {
         this.content = content;
         this.runTimeProperties = new HashMap<>();
         Document document = getDocument();
-        notXSLTCompatible = processConfigurationDetails(document);
-        if (notXSLTCompatible) {
+        xsltCompatible = processConfigurationDetails(document);
+        if (!xsltCompatible) {
             this.content = null;
         }
     }
@@ -107,7 +107,7 @@ public class XSLTMappingResource {
      * @return return whether the xslt transformation possible or not
      */
     private boolean processConfigurationDetails(Document document) {
-        boolean not_compatible = true;
+        boolean compatible = false;
         Node rootNode = document.getElementsByTagName(PARAMETER_FILE_ROOT).item(0);
         for (int j = 0; j < rootNode.getAttributes().getLength(); j++) {
             Node propertyNode = rootNode.getAttributes().item(j);
@@ -126,9 +126,9 @@ public class XSLTMappingResource {
                     break;
                 case NOT_XSLT_COMPATIBLE:
                     if (propertyNode.getNodeValue().equals(XSLT_COMPATIBLE_DEFAULT)) {
-                        not_compatible = false;
+                        compatible = true;
                     } else {
-                        return not_compatible;
+                        return compatible;
                     }
                     break;
                 case FIRST_ELEMENT_OF_THE_INPUT:
@@ -137,9 +137,9 @@ public class XSLTMappingResource {
             }
         }
         if (this.name == null) {
-            return true;
+            return false;
         }
-        return not_compatible;
+        return compatible;
 
     }
 
@@ -166,7 +166,7 @@ public class XSLTMappingResource {
      *
      * @return whether xslt transformation is possible or not
      */
-    public boolean isNotXSLTCompatible() {
-        return notXSLTCompatible;
+    public boolean isXsltCompatible() {
+        return xsltCompatible;
     }
 }

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingResource.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingResource.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.mediator.datamapper.engine.core.mapper;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
+        .EMPTY_STRING;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
+        .FIRST_ELEMENT_OF_THE_INPUT;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
+        .NOT_XSLT_COMPATIBLE;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
+        .PARAMETER_FILE_ROOT;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
+        .PROPERTY_SEPERATOR;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
+        .RUN_TIME_PROPERTIES;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
+        .XSLT_COMPATIBLE_DEFAULT;
+
+public class XSLTMappingResource {
+
+    private final Map<String, String> runTimeProperties;
+    private String name;
+    private String content;
+    private boolean notXSLTCompatible;
+
+
+    public XSLTMappingResource(String content) throws SAXException,
+            IOException,
+            ParserConfigurationException {
+        this.content = content;
+        this.runTimeProperties = new HashMap<>();
+        Document document = getDocument();
+        notXSLTCompatible = processConfigurationDetails(document);
+        if (notXSLTCompatible) {
+            this.content = null;
+        }
+    }
+
+    /**
+     * Create a input stream from the available content
+     *
+     * @return Input stream of the xslt stylesheet
+     */
+    InputStream getInputStream() {
+        return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Create a input source from the available content
+     *
+     * @return Input source of the xslt stylesheet
+     */
+    private InputSource getInputSource() {
+        return new InputSource(new StringReader(content));
+    }
+
+    /**
+     * Creating a document to process the xslt stylesheet
+     *
+     * @return document of the xslt stylesheet
+     * @throws SAXException
+     * @throws IOException
+     * @throws ParserConfigurationException
+     */
+    private Document getDocument() throws SAXException, IOException,
+            ParserConfigurationException {
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        return documentBuilder.parse(getInputSource());
+    }
+
+    /**
+     * Process configuration details included in the xslt stylesheet
+     *
+     * @param document xslt stylesheet as a document
+     * @return return whether the xslt transformation possible or not
+     */
+    private boolean processConfigurationDetails(Document document) {
+        boolean not_compatible = true;
+        Node rootNode = document.getElementsByTagName(PARAMETER_FILE_ROOT).item(0);
+        for (int j = 0; j < rootNode.getAttributes().getLength(); j++) {
+            Node propertyNode = rootNode.getAttributes().item(j);
+            switch (propertyNode.getNodeName()) {
+                case RUN_TIME_PROPERTIES:
+                    String runTimePropertyString = propertyNode.getNodeValue();
+                    if (!EMPTY_STRING.equals(runTimePropertyString)) {
+                        String[] properties = runTimePropertyString.split(PROPERTY_SEPERATOR);
+                        int currentIndex = 0;
+                        while (currentIndex < properties.length) {
+                            runTimeProperties.put(properties[currentIndex],
+                                    properties[currentIndex + 1]);
+                            currentIndex += 2;
+                        }
+                    }
+                    break;
+                case NOT_XSLT_COMPATIBLE:
+                    if (propertyNode.getNodeValue().equals(XSLT_COMPATIBLE_DEFAULT)) {
+                        not_compatible = false;
+                    } else {
+                        return not_compatible;
+                    }
+                    break;
+                case FIRST_ELEMENT_OF_THE_INPUT:
+                    this.name = propertyNode.getNodeValue();
+                    break;
+            }
+        }
+        if (this.name == null) {
+            return true;
+        }
+        return not_compatible;
+
+    }
+
+    /**
+     * Return name of the root element of the input xml
+     *
+     * @return name of the root element of the input xml
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Return run time properties included in the xslt stylesheet
+     *
+     * @return runtime properties
+     */
+    public Map<String, String> getRunTimeProperties() {
+        return runTimeProperties;
+    }
+
+    /**
+     * Indicate whether xslt transformation is possible or not
+     *
+     * @return whether xslt transformation is possible or not
+     */
+    public boolean isNotXSLTCompatible() {
+        return notXSLTCompatible;
+    }
+}

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingResource.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingResource.java
@@ -47,6 +47,9 @@ import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineC
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
         .XSLT_COMPATIBLE_DEFAULT;
 
+/**
+ * This class contains required resources for the xslt transformation
+ */
 public class XSLTMappingResource {
 
     private final Map<String, String> runTimeProperties;

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingResource.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/XSLTMappingResource.java
@@ -32,20 +32,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
-        .EMPTY_STRING;
-import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
-        .FIRST_ELEMENT_OF_THE_INPUT;
-import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
-        .NOT_XSLT_COMPATIBLE;
-import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
-        .PARAMETER_FILE_ROOT;
-import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
-        .PROPERTY_SEPERATOR;
-import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
-        .RUN_TIME_PROPERTIES;
-import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
-        .XSLT_COMPATIBLE_DEFAULT;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.EMPTY_STRING;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.FIRST_ELEMENT_OF_THE_INPUT;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.NOT_XSLT_COMPATIBLE;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.PARAMETER_FILE_ROOT;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.PROPERTY_SEPERATOR;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.RUN_TIME_PROPERTIES;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.XSLT_COMPATIBLE_DEFAULT;
 
 /**
  * This class contains required resources for the xslt transformation
@@ -59,8 +52,8 @@ public class XSLTMappingResource {
 
 
     public XSLTMappingResource(String content) throws SAXException,
-            IOException,
-            ParserConfigurationException {
+                                                      IOException,
+                                                      ParserConfigurationException {
         this.content = content;
         this.runTimeProperties = new HashMap<>();
         Document document = getDocument();
@@ -97,7 +90,7 @@ public class XSLTMappingResource {
      * @throws ParserConfigurationException
      */
     private Document getDocument() throws SAXException, IOException,
-            ParserConfigurationException {
+                                          ParserConfigurationException {
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
         DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
         return documentBuilder.parse(getInputSource());
@@ -122,7 +115,7 @@ public class XSLTMappingResource {
                         int currentIndex = 0;
                         while (currentIndex < properties.length) {
                             runTimeProperties.put(properties[currentIndex],
-                                    properties[currentIndex + 1]);
+                                                  properties[currentIndex + 1]);
                             currentIndex += 2;
                         }
                     }

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/utils/DataMapperEngineConstants.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/utils/DataMapperEngineConstants.java
@@ -58,4 +58,11 @@ public class DataMapperEngineConstants {
     public static final String ENCODE_CHAR_HYPHEN = "_EnC0DeCHaRHyPh3n_";
     public static final String HYPHEN = "-";
     public static final String PREFIX_LIST_SEPERATOR = ",";
+    public static final String EMPTY_STRING = "";
+    public static final String PARAMETER_FILE_ROOT = "xsl:stylesheet";
+    public static final String RUN_TIME_PROPERTIES = "xmlns:runTimeProperties";
+    public static final String NOT_XSLT_COMPATIBLE = "xmlns:notXSLTCompatible";
+    public static final String PROPERTY_SEPERATOR = ",";
+    public static final String FIRST_ELEMENT_OF_THE_INPUT = "xmlns:firstElementOfTheInput";
+    public static final String XSLT_COMPATIBLE_DEFAULT = "false";
 }

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
@@ -337,7 +337,7 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
                     usingXSLTMapping = false;
                 }
             }
-            if (xsltMappingResource == null || xsltMappingResource.isNotXSLTCompatible()) {
+            if (xsltMappingResource == null || !xsltMappingResource.isXsltCompatible()) {
                 usingXSLTMapping = false;
             }
         }

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
@@ -374,15 +374,13 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
                         .getPropertyValue(ORG_APACHE_SYNAPSE_DATAMAPPER_EXECUTOR_POOL_SIZE, null);
 
                 MappingHandler mappingHandler = new MappingHandler(mappingResource, inputType, outputType,
-
                         dmExecutorPoolSize);
 
                 propertiesMap = getPropertiesMap(mappingResource.getPropertiesList(), synCtx);
 
                 /* execute mapping on the input stream */
                 outputResult = mappingHandler.doMap(getInputStream(synCtx, inputType,
-                                                                   mappingResource.getInputSchema
-                                                                           ().getName()),
+                                                                   mappingResource.getInputSchema().getName()),
                                                     propertiesMap);
             }
 

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
@@ -65,26 +65,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
-        .AXIS2_CLIENT_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
-        .AXIS2_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
-        .DEFAULT_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
-        .EMPTY_STRING;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
-        .FUNCTION_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
-        .OPERATIONS_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
-        .SYNAPSE_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
-        .TRANSPORT_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
-        .TRANSPORT_HEADERS;
-import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
-        .ORG_APACHE_SYNAPSE_DATAMAPPER_EXECUTOR_POOL_SIZE;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.AXIS2_CLIENT_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.AXIS2_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.DEFAULT_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.EMPTY_STRING;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.FUNCTION_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.OPERATIONS_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.SYNAPSE_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.TRANSPORT_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.TRANSPORT_HEADERS;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.ORG_APACHE_SYNAPSE_DATAMAPPER_EXECUTOR_POOL_SIZE;
 
 /**
  * By using the input schema, output schema and mapping configuration,
@@ -333,7 +323,7 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
      */
     private void checkForXSLTTransformation(MessageContext synCtx) {
         if (xsltStyleSheetKey != null && (InputOutputDataType.XML.toString().equals(inputType) &&
-                InputOutputDataType.XML.toString().equals(outputType))) {
+                                          InputOutputDataType.XML.toString().equals(outputType))) {
             usingXSLTMapping = true;
             if (xsltMappingResource == null) {
                 String xsltKey = xsltStyleSheetKey.evaluateValue(synCtx);
@@ -342,8 +332,7 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
                 } catch (SAXException | IOException |
                         ParserConfigurationException e) {
                     handleException("DataMapper mediator xslt mapping resource generation " +
-                                    "failed", e,
-                            synCtx);
+                                    "failed", e, synCtx);
                     usingXSLTMapping = false;
                 }
             }
@@ -372,10 +361,12 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
                     }
                 }
                 outputResult = xsltMappingHandler.doMap(getPropertiesMapForXSLT
-                                (xsltMappingResource.getRunTimeProperties(), synCtx),
-                        getInputStream
-                                (synCtx, inputType,
-                                        xsltMappingResource.getName()));
+                                                                (xsltMappingResource
+                                                                         .getRunTimeProperties(),
+                                                                 synCtx),
+                                                        getInputStream
+                                                                (synCtx, inputType,
+                                                                 xsltMappingResource.getName()));
             }else {
                 Map<String, Map<String, Object>> propertiesMap;
 
@@ -389,10 +380,10 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
                 propertiesMap = getPropertiesMap(mappingResource.getPropertiesList(), synCtx);
 
                 /* execute mapping on the input stream */
-                outputResult = mappingHandler
-                        .doMap(getInputStream(synCtx, inputType, mappingResource.getInputSchema()
-                                        .getName()),
-                                propertiesMap);
+                outputResult = mappingHandler.doMap(getInputStream(synCtx, inputType,
+                                                                   mappingResource.getInputSchema
+                                                                           ().getName()),
+                                                    propertiesMap);
             }
 
             if (InputOutputDataType.CSV.toString().equals(outputType) &&
@@ -669,8 +660,7 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
                         break;
                     default:
                         log.warn(property.getValue() + " scope is not found. Setting it to an " +
-                                "empty " +
-                                "value.");
+                                 "empty value.");
                         value = EMPTY_STRING;
                 }
                 if (value == null) {

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
@@ -52,6 +52,10 @@ import org.wso2.carbon.mediator.datamapper.engine.core.mapper.XSLTMappingResourc
 import org.wso2.carbon.mediator.datamapper.engine.utils.InputOutputDataType;
 import org.xml.sax.SAXException;
 
+import javax.xml.namespace.QName;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.transform.TransformerException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -60,21 +64,27 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
-import javax.xml.namespace.QName;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.transform.TransformerException;
 
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.AXIS2_CLIENT_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.AXIS2_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.DEFAULT_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.EMPTY_STRING;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.FUNCTION_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.OPERATIONS_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.SYNAPSE_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.TRANSPORT_CONTEXT;
-import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.TRANSPORT_HEADERS;
-import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.ORG_APACHE_SYNAPSE_DATAMAPPER_EXECUTOR_POOL_SIZE;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
+        .AXIS2_CLIENT_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
+        .AXIS2_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
+        .DEFAULT_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
+        .EMPTY_STRING;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
+        .FUNCTION_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
+        .OPERATIONS_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
+        .SYNAPSE_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
+        .TRANSPORT_CONTEXT;
+import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants
+        .TRANSPORT_HEADERS;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants
+        .ORG_APACHE_SYNAPSE_DATAMAPPER_EXECUTOR_POOL_SIZE;
 
 /**
  * By using the input schema, output schema and mapping configuration,

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
@@ -47,7 +47,10 @@ import org.wso2.carbon.mediator.datamapper.engine.core.exceptions.SchemaExceptio
 import org.wso2.carbon.mediator.datamapper.engine.core.exceptions.WriterException;
 import org.wso2.carbon.mediator.datamapper.engine.core.mapper.MappingHandler;
 import org.wso2.carbon.mediator.datamapper.engine.core.mapper.MappingResource;
+import org.wso2.carbon.mediator.datamapper.engine.core.mapper.XSLTMappingHandler;
+import org.wso2.carbon.mediator.datamapper.engine.core.mapper.XSLTMappingResource;
 import org.wso2.carbon.mediator.datamapper.engine.utils.InputOutputDataType;
+import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -58,7 +61,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLStreamException;
+import javax.xml.transform.TransformerException;
 
 import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.AXIS2_CLIENT_CONTEXT;
 import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.AXIS2_CONTEXT;
@@ -86,9 +91,14 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
     private Value mappingConfigurationKey = null;
     private Value inputSchemaKey = null;
     private Value outputSchemaKey = null;
+    private Value xsltStyleSheetKey = null;
     private String inputType = null;
     private String outputType = null;
     private MappingResource mappingResource = null;
+    private boolean usingXSLTMapping = false;
+    private XSLTMappingResource xsltMappingResource = null;
+    private XSLTMappingHandler xsltMappingHandler = null;
+    private final Object xsltHandlerLock = new Object();
 
     /**
      * Returns registry resources as input streams to create the MappingResourceLoader object
@@ -149,6 +159,23 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
      */
     public void setInputSchemaKey(Value dataMapperInSchemaKey) {
         this.inputSchemaKey = dataMapperInSchemaKey;
+    }
+
+    /**
+     * Sets the registry key in order to pick the input schema
+     *
+     * @param dataMapperXsltStyleSheetKey registry key for the input schema
+     */
+    public void setXsltStyleSheetKey(Value dataMapperXsltStyleSheetKey) {
+        this.xsltStyleSheetKey = dataMapperXsltStyleSheetKey;
+    }
+
+    /**
+     *
+     * @return dataMapperXsltStyleSheetKey registry key for the input schema
+     */
+    public Value getXsltStyleSheetKey() {
+        return xsltStyleSheetKey;
     }
 
     /**
@@ -240,7 +267,9 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
             }
         }
 
-        if (mappingResource == null) {
+        checkForXSLTTransformation(synCtx);
+
+        if (mappingResource == null && !usingXSLTMapping) {
             String configKey = mappingConfigurationKey.evaluateValue(synCtx);
             String inSchemaKey = inputSchemaKey.evaluateValue(synCtx);
             String outSchemaKey = outputSchemaKey.evaluateValue(synCtx);
@@ -287,6 +316,34 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
     }
 
     /**
+     * this method check for possibility in xslt based message transformation
+     * initialize the xslt resources if possible to use xslt based message transformation
+     *
+     * @param synCtx message context
+     */
+    private void checkForXSLTTransformation(MessageContext synCtx) {
+        if (xsltStyleSheetKey != null && (InputOutputDataType.XML.toString().equals(inputType) &&
+                InputOutputDataType.XML.toString().equals(outputType))) {
+            usingXSLTMapping = true;
+            if (xsltMappingResource == null) {
+                String xsltKey = xsltStyleSheetKey.evaluateValue(synCtx);
+                try {
+                    xsltMappingResource = getXsltMappingResource(synCtx, xsltKey);
+                } catch (SAXException | IOException |
+                        ParserConfigurationException e) {
+                    handleException("DataMapper mediator xslt mapping resource generation " +
+                                    "failed", e,
+                            synCtx);
+                    usingXSLTMapping = false;
+                }
+            }
+            if (xsltMappingResource == null || xsltMappingResource.isNotXSLTCompatible()) {
+                usingXSLTMapping = false;
+            }
+        }
+    }
+
+    /**
      * Does message conversion and gives the output message as the final result
      *
      * @param synCtx      the message synCtx
@@ -295,21 +352,38 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
      */
     private void transform(MessageContext synCtx, String configKey, String inSchemaKey) {
         try {
-            String outputResult = null;
-            Map<String, Map<String, Object>> propertiesMap;
+            String outputResult;
+            if (usingXSLTMapping) {
+                if (xsltMappingHandler == null) {
+                    synchronized (xsltHandlerLock) {
+                        if (xsltMappingHandler == null) {
+                            xsltMappingHandler = new XSLTMappingHandler(this.xsltMappingResource);
+                        }
+                    }
+                }
+                outputResult = xsltMappingHandler.doMap(getPropertiesMapForXSLT
+                                (xsltMappingResource.getRunTimeProperties(), synCtx),
+                        getInputStream
+                                (synCtx, inputType,
+                                        xsltMappingResource.getName()));
+            }else {
+                Map<String, Map<String, Object>> propertiesMap;
 
-            String dmExecutorPoolSize = SynapsePropertiesLoader
-                    .getPropertyValue(ORG_APACHE_SYNAPSE_DATAMAPPER_EXECUTOR_POOL_SIZE, null);
+                String dmExecutorPoolSize = SynapsePropertiesLoader
+                        .getPropertyValue(ORG_APACHE_SYNAPSE_DATAMAPPER_EXECUTOR_POOL_SIZE, null);
 
-            MappingHandler mappingHandler = new MappingHandler(mappingResource, inputType, outputType,
-                    dmExecutorPoolSize);
+                MappingHandler mappingHandler = new MappingHandler(mappingResource, inputType, outputType,
 
-            propertiesMap = getPropertiesMap(mappingResource.getPropertiesList(), synCtx);
+                        dmExecutorPoolSize);
 
-            /* execute mapping on the input stream */
-            outputResult = mappingHandler
-                    .doMap(getInputStream(synCtx, inputType, mappingResource.getInputSchema().getName()),
-                            propertiesMap);
+                propertiesMap = getPropertiesMap(mappingResource.getPropertiesList(), synCtx);
+
+                /* execute mapping on the input stream */
+                outputResult = mappingHandler
+                        .doMap(getInputStream(synCtx, inputType, mappingResource.getInputSchema()
+                                        .getName()),
+                                propertiesMap);
+            }
 
             if (InputOutputDataType.CSV.toString().equals(outputType) &&
                     !InputOutputDataType.CSV.toString().equals(inputType)) {
@@ -359,7 +433,7 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
 
             }
         } catch (ReaderException | InterruptedException | XMLStreamException | SchemaException
-                | IOException | JSException | WriterException e) {
+                | IOException | JSException | WriterException | TransformerException e) {
             handleException("DataMapper mediator : mapping failed", e, synCtx);
         }
     }
@@ -463,6 +537,26 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
     }
 
     /**
+     * When Data mapper mediator has been invoked initially, this creates a new xslt mapping
+     * resource
+     *
+     * @param synCtx message context
+     * @param xsltKey the location of the xslt stylesheet
+     * @return
+     * @throws SAXException
+     * @throws IOException
+     * @throws ParserConfigurationException
+     */
+    private XSLTMappingResource getXsltMappingResource(MessageContext synCtx, String xsltKey)
+            throws SAXException, IOException,
+            ParserConfigurationException {
+
+        String content = synCtx.getEntry(xsltKey).toString();
+        return new XSLTMappingResource(content);
+
+    }
+
+    /**
      * Retrieve property values and insert into a map
      *
      * @param propertiesNamesList Required properties
@@ -515,6 +609,69 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
         }
 
         return propertiesMap;
+    }
+
+    /**
+     * Retrive property values and return as a map
+     *
+     * @param properties Required properties
+     * @param synCtx Message context
+     * @return Map with values of each property
+     */
+    private Map<String, Object> getPropertiesMapForXSLT(Map<String, String> properties,
+                                                        MessageContext
+                                                                synCtx) {
+        Map<String, Object> propertyValues = new HashMap<>();
+
+        if (!properties.isEmpty()) {
+            Object value;
+            org.apache.axis2.context.MessageContext axis2MsgCtx = ((Axis2MessageContext) synCtx)
+                    .getAxis2MessageContext();
+
+            HashMap functionProperties = new HashMap();
+            Stack<TemplateContext> templeteContextStack = ((Stack) synCtx
+                    .getProperty(SynapseConstants.SYNAPSE__FUNCTION__STACK));
+            if (templeteContextStack != null && !templeteContextStack.isEmpty()) {
+                TemplateContext templateContext = templeteContextStack.peek();
+                functionProperties.putAll(templateContext.getMappedValues());
+            }
+            for (Map.Entry<String, String> property : properties.entrySet()) {
+                switch (property.getValue()) {
+                    case DEFAULT_CONTEXT:
+                    case SYNAPSE_CONTEXT:
+                        value = synCtx.getProperty(property.getKey());
+                        break;
+                    case TRANSPORT_CONTEXT:
+                        value = ((Map) axis2MsgCtx.getProperty(TRANSPORT_HEADERS)).get(property
+                                .getKey());
+                        break;
+                    case AXIS2_CONTEXT:
+                        value = axis2MsgCtx.getProperty(property.getKey());
+                        break;
+                    case AXIS2_CLIENT_CONTEXT:
+                        value = axis2MsgCtx.getOptions().getProperty(property.getKey());
+                        break;
+                    case OPERATIONS_CONTEXT:
+                        value = axis2MsgCtx.getOperationContext().getProperty(property.getKey());
+                        break;
+                    case FUNCTION_CONTEXT:
+                        value = functionProperties.get(property.getKey());
+                        break;
+                    default:
+                        log.warn(property.getValue() + " scope is not found. Setting it to an " +
+                                "empty " +
+                                "value.");
+                        value = EMPTY_STRING;
+                }
+                if (value == null) {
+                    log.warn(property.getKey() + " not found. Setting it to an empty value.");
+                    value = EMPTY_STRING;
+                }
+                propertyValues.put(property.getValue() + "_" + property.getKey(), value);
+            }
+        }
+
+        return propertyValues;
     }
 
     /**

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorConstants.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorConstants.java
@@ -28,6 +28,7 @@ public class DataMapperMediatorConstants {
     public static final String OUTPUT_SCHEMA = "outputSchema";
     public static final String INPUT_TYPE = "inputType";
     public static final String OUTPUT_TYPE = "outputType";
+    public static final String XSLT_STYLE_SHEET = "xsltStyleSheet";
 
     /* Names of the different contexts used in the ESB */
     public static final String DEFAULT_CONTEXT = "DEFAULT";

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorFactory.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorFactory.java
@@ -73,8 +73,11 @@ public class DataMapperMediatorFactory extends AbstractMediatorFactory {
                 element.getAttribute(new QName(DataMapperMediatorConstants.OUTPUT_SCHEMA));
         OMAttribute inputTypeAttribute = element.getAttribute(new QName(DataMapperMediatorConstants.INPUT_TYPE));
         OMAttribute outputTypeAttribute = element.getAttribute(new QName(DataMapperMediatorConstants.OUTPUT_TYPE));
+        OMAttribute xsltStyleSheetKeyAttribute = element.getAttribute(new QName
+                (DataMapperMediatorConstants.XSLT_STYLE_SHEET));
 
-		/*
+
+        /*
          * ValueFactory for creating dynamic or static Value and provide methods
 		 * to create value objects
 		 */
@@ -113,6 +116,12 @@ public class DataMapperMediatorFactory extends AbstractMediatorFactory {
             datamapperMediator.setOutputType(outputTypeAttribute.getAttributeValue());
         } else {
             handleException("The output DataType is required for the DataMapper mediator");
+        }
+
+        if (xsltStyleSheetKeyAttribute != null) {
+            Value xsltStyleSheetKeyValue = keyFac.createValue(xsltStyleSheetKeyAttribute
+                    .getLocalName(), element);
+            datamapperMediator.setXsltStyleSheetKey(xsltStyleSheetKeyValue);
         }
 
         processAuditStatus(datamapperMediator, element);

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorSerializer.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorSerializer.java
@@ -85,6 +85,14 @@ public class DataMapperMediatorSerializer extends AbstractMediatorSerializer {
             handleException("Invalid DataMapper mediator. OutputSchema registry key is required");
         }
 
+        if (dataMapperMediator.getXsltStyleSheetKey() != null) {
+            ValueSerializer keySerializer = new ValueSerializer();
+            keySerializer
+                    .serializeValue(dataMapperMediator.getXsltStyleSheetKey(),
+                            DataMapperMediatorConstants.XSLT_STYLE_SHEET,
+                            dataMapperElement);
+        }
+
         dataMapperElement.addAttribute(fac.createOMAttribute(DataMapperMediatorConstants.INPUT_TYPE, nullNS,
                                                              dataMapperMediator.getInputType()));
 

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorSerializer.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorSerializer.java
@@ -89,8 +89,8 @@ public class DataMapperMediatorSerializer extends AbstractMediatorSerializer {
             ValueSerializer keySerializer = new ValueSerializer();
             keySerializer
                     .serializeValue(dataMapperMediator.getXsltStyleSheetKey(),
-                            DataMapperMediatorConstants.XSLT_STYLE_SHEET,
-                            dataMapperElement);
+                                    DataMapperMediatorConstants.XSLT_STYLE_SHEET,
+                                    dataMapperElement);
         }
 
         dataMapperElement.addAttribute(fac.createOMAttribute(DataMapperMediatorConstants.INPUT_TYPE, nullNS,


### PR DESCRIPTION
## Purpose

Adding capability for the data mapper mediator to transform input XML messages to output XML messages using an XSLT engine to increase the performance. Previously all the message transformations were done using a JavaScript engine. Under the modification, only the xml to xml mapping will be handled using the xslt engine.

Related Issue: https://github.com/wso2/product-ei/issues/2745

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Increase the performance of XML to XML message transformaion in datamapper mediator.

Related Issue : https://github.com/wso2/product-ei/issues/2745

## Documentation

https://github.com/wso2/product-ei/issues/2746

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

All the datamapper mediators created up to version 6.4.0 will be supported.