### PR TITLE
Fix RabbitMQ IEP recovery upon mediation exceptions

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQConnectionConsumer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQConnectionConsumer.java
@@ -165,6 +165,7 @@ public class RabbitMQConnectionConsumer {
             }
 
             boolean successful = false;
+            boolean mediationError = false;
 
             RabbitMQMessage message = null;
             try {
@@ -178,6 +179,10 @@ public class RabbitMQConnectionConsumer {
                 idle = false;
                 try {
                     successful = injectHandler.invoke(message, inboundName);
+                } catch (Exception e) {         //we need to handle any exception upon injecting to mediation
+                    successful = false;
+                    mediationError = true;
+                    log.error("Error while mediating message", e);
                 } finally {
                     if (successful) {
                         try {
@@ -196,6 +201,18 @@ public class RabbitMQConnectionConsumer {
                             channel.basicRecover();
                         } catch (IOException e) {
                             log.error("Error while trying to roll back transaction", e);
+                        }
+                    }
+
+                    /*
+                     * Upon a mediation error, re-try with a fixed delay. Polling messages cannot be given up
+                     * as there is no way for the user to start the polling task back
+                     */
+                    if (mediationError) {
+                        try {
+                            Thread.sleep(2000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
                         }
                     }
                 }


### PR DESCRIPTION
## Purpose

When injecting sequence is defined as a registry sequence, when a temporary DB outage happened and recovered, inbound EP no longer works. This PR fixes the issue. 


## Goals

Fix: https://github.com/wso2/product-ei/issues/2777

## Approach

When Registry DB is disconnected, after cache timeout, the injecting sequence is not found, hence an exception is thrown. Upon the exception, inbound endpoint will handle the exception and delay the next re-try by 2 seconds. It will never give up retrying as there is no way to enable inbound endpoint again in production setup. 
 

## User stories

Automatically recover inbound EP when registry DB outage (or any mediation exception) happened. 

## Release note

N/A

## Documentation
N/A

## Training
N/A

## Certification

N/A - there is no outside visible feature

## Marketing

Tolerate to DB outages 

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)

No impact 

## Test environment

JDK 8, Linux environment 
 
## Learning
N/A