### PR TITLE
Fix wso2/product-ei/issues/3048

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRequestProcessorImpl.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRequestProcessorImpl.java
@@ -167,6 +167,7 @@ public abstract class InboundRequestProcessorImpl implements InboundRequestProce
                 InboundRunner inboundRunner = (InboundRunner)entry.getValue();
 
                 inboundRunner.terminate();
+                thread.interrupt();
                 try {
                     thread.join();
                 } catch (InterruptedException e) {


### PR DESCRIPTION
## Purpose
> If the JMS inbound configuration property coordination is set to false in a CApp, a delay is observed when undeploying it. Interrupt runner thread at undeployment on CApp.

