### PR TITLE
Fix for Issue #2740 Message Processor PoisonMessage handling

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.message.processor/src/main/java/org/wso2/carbon/message/processor/service/MessageProcessorAdminService.java
+++ b/components/mediation-admin/org.wso2.carbon.message.processor/src/main/java/org/wso2/carbon/message/processor/service/MessageProcessorAdminService.java
@@ -767,7 +767,7 @@ public class MessageProcessorAdminService extends AbstractServiceBusAdmin {
      * @param processorName message processor name.
      * @return <code>message</code> returns message received from the queue as a string.
      */
-    public String getMessage(String processorName) throws AxisFault {
+    public String browseMessage(String processorName) throws AxisFault {
         SynapseConfiguration configuration = getSynapseConfiguration();
         MessageConsumer messageConsumer = getMessageConsumer(configuration,processorName);
         String message = null;
@@ -776,9 +776,10 @@ public class MessageProcessorAdminService extends AbstractServiceBusAdmin {
             message = getMessageAsString(messageConsumer);
         } catch (AxisFault e) {
             handleException(log, "Failed to get message from the queue :", e);
+        } finally {
+            messageConsumer.cleanup();
         }
 
-        messageConsumer.cleanup();
         return message;
     }
 
@@ -810,9 +811,9 @@ public class MessageProcessorAdminService extends AbstractServiceBusAdmin {
             popMessageFromQueue(messageConsumer);
         } catch (SynapseException e) {
             handleException(log, "Failed to pop message from the queue: ", e);
+        } finally {
+            messageConsumer.cleanup();
         }
-
-        messageConsumer.cleanup();
     }
 
     private  void popMessageFromQueue(MessageConsumer messageConsumer) throws AxisFault {
@@ -839,9 +840,9 @@ public class MessageProcessorAdminService extends AbstractServiceBusAdmin {
             popAndRedirectMessageToStore(messageProducer, messageConsumer);
         } catch (AxisFault e) {
             handleException(log, "Failed to redirect message to " + storeName + " :", e);
+        } finally {
+            messageConsumer.cleanup();
         }
-
-        messageConsumer.cleanup();
     }
 
     private void popAndRedirectMessageToStore(MessageProducer messageProducer, MessageConsumer messageConsumer)

--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/java/org/wso2/carbon/message/processor/ui/MessageProcessorAdminServiceClient.java
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/java/org/wso2/carbon/message/processor/ui/MessageProcessorAdminServiceClient.java
@@ -436,11 +436,11 @@ public class MessageProcessorAdminServiceClient {
      * @return <code>message</code> Returns message from the queue as a string
      * @throws Exception
      */
-    public String getMessage(String processorName) throws Exception {
+    public String browseMessage(String processorName) throws Exception {
         String message = null;
         try {
             if (processorName != null) {
-                message = stub.getMessage(processorName);
+                message = stub.browseMessage(processorName);
             }
         } catch (Exception e) {
             handleException(e);
@@ -471,7 +471,6 @@ public class MessageProcessorAdminServiceClient {
      * @param storeName Name of store to redirect the message
      * @throws Exception
      */
-
     public void popAndRedirectMessage(String processorName, String storeName) throws Exception {
         try {
             if (processorName != null) {

--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/java/org/wso2/carbon/message/processor/ui/MessageProcessorAdminServiceClient.java
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/java/org/wso2/carbon/message/processor/ui/MessageProcessorAdminServiceClient.java
@@ -428,4 +428,59 @@ public class MessageProcessorAdminServiceClient {
         log.error(message);
         throw new Exception(message);
     }
+
+    /**
+     * Get the message from the associated queue
+     *
+     * @param processorName The MessageProcessor name
+     * @return <code>message</code> Returns message from the queue as a string
+     * @throws Exception
+     */
+    public String getMessage(String processorName) throws Exception {
+        String message = null;
+        try {
+            if (processorName != null) {
+                message = stub.getMessage(processorName);
+            }
+        } catch (Exception e) {
+            handleException(e);
+        }
+        return message;
+    }
+
+    /**
+     * Pop the message from the associated queue
+     *
+     * @param processorName The MessageProcessor name
+     * @throws Exception
+     */
+    public void popMessage(String processorName) throws Exception {
+        try {
+            if (processorName != null) {
+                stub.popMessage(processorName);
+            }
+        } catch (Exception e) {
+            handleException(e);
+        }
+    }
+
+    /**
+     * Pop the message from the associated queue and redirect to specified queue
+     *
+     * @param processorName MessageProcessor name
+     * @param storeName Name of store to redirect the message
+     * @throws Exception
+     */
+
+    public void popAndRedirectMessage(String processorName, String storeName) throws Exception {
+        try {
+            if (processorName != null) {
+                stub.popAndRedirectMessage(processorName, storeName);
+            }
+        } catch (Exception e) {
+            handleException(e);
+        }
+
+    }
+
 }

--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/index.jsp
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/index.jsp
@@ -184,6 +184,9 @@
         });
     }
 
+    function viewMessage(name) {
+      document.location.href = "manageMessage.jsp?" + "messageProcessorName=" + name;
+    }
 </script>
 
 <div id="middle">
@@ -313,14 +316,15 @@
             %>
             <td>
                 <% if (mspData.getArtifactContainerName() != null) { %>
-                <a onclick="editCAppProcessor('<%= type%>','<%= mspData.getName()%>')" href="#"
-                   class="icon-link"
-                   style="background-image:url(../admin/images/edit.gif);"><fmt:message
-                        key="edit"/></a>
-                <a href="#" onclick="#"
-                   id="delete_link" class="icon-link"
-                   style="color:gray;background-image:url(../admin/images/delete.gif);"><fmt:message
-                        key="delete"/></a>
+               <a onclick="editCAppProcessor('<%= type%>','<%= mspData.getName()%>')" href="#"
+                  class="icon-link"
+                  style="background-image:url(../admin/images/edit.gif);"><fmt:message
+                  key="edit"/></a>
+               <a href="#" onclick="#"
+                  id="delete_link" class="icon-link"
+                  style="color:gray;background-image:url(../admin/images/delete.gif);"><fmt:message
+                  key="delete"/></a>
+
                 <% } else { %>
                 <a onclick="editRow('<%= type%>','<%=mspData.getName()%>')" href="#"
                    class="icon-link"
@@ -348,14 +352,15 @@
             %>
             <td>
                 <% if (mspData.getArtifactContainerName() != null) { %>
-                <a onclick="editCAppProcessor('<%= type%>','<%= mspData.getName()%>')" href="#"
-                   class="icon-link"
-                   style="background-image:url(../admin/images/edit.gif);"><fmt:message
-                        key="edit"/></a>
-                <a href="#" onclick="#"
-                   id="delete_link" class="icon-link"
-                   style="color:gray;background-image:url(../admin/images/delete.gif);"><fmt:message
-                        key="delete"/></a>
+               <a onclick="editCAppProcessor('<%= type%>','<%= mspData.getName()%>')" href="#"
+                  class="icon-link"
+                  style="background-image:url(../admin/images/edit.gif);"><fmt:message
+                  key="edit"/></a>
+               <a href="#" onclick="#"
+                  id="delete_link" class="icon-link"
+                  style="color:gray;background-image:url(../admin/images/delete.gif);"><fmt:message
+                  key="delete"/></a>
+
                 <% } else { %>
                 <a onclick="editRow('<%= type%>', '<%=mspData.getName()%>')" href="#"
                    class="icon-link"
@@ -372,6 +377,11 @@
                     <a href="#" class="icon-link" id="activate_link"
                        style="background-image:none !important; margin-left: 0px !important; padding-left: 0px !important;"
                        onclick="activateRow('<%= mspData.getName()%>')"><fmt:message key="activate"/></a>
+                    <span class="icon-text"
+                      style="background-image:none !important; margin-left: 0px !important; padding-left: 0px !important;">|</span>
+                    <a href="#" class="icon-link" id="activate_link"
+                       style="background-image:none !important; margin-left: 0px !important; padding-left: 0px !important;"
+                       onclick="viewMessage('<%= mspData.getName()%>')">View Message</a>
                 <span class="icon-text"
                       style="background-image:none !important; margin-left: 0px !important; padding-left: 0px !important;">]</span>
 
@@ -469,7 +479,7 @@
 
         <tr>
             <td style="width:155px;">
-                <a 
+                <a
                    href="manageMessageForwardingProcessor.jsp"  class="icon-link"
                    style="background: url(../admin/images/add.gif)  no-repeat;">
                     <fmt:message key="scheduled.message.forwarding.processor"/>
@@ -493,7 +503,7 @@
 
         <tr>
             <td style="width:155px;">
-                <a 
+                <a
                    href="manageMessageSamplingProcessor.jsp" class="icon-link"
                    style="background: url(../admin/images/add.gif)  no-repeat;">
                     <fmt:message key="message.sampling.processor"/>
@@ -505,7 +515,7 @@
         </tr>
         <tr>
             <td style="width:155px;">
-                <a 
+                <a
                    href="manageCustomMessageProcessor.jsp" class="icon-link"
                    style="background: url(../admin/images/add.gif) no-repeat;">
                     <fmt:message key="custom.message.processor"/>
@@ -516,6 +526,7 @@
             </td>
         </tr>
     </table>
+
 </div>
 </div>
 </div>

--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/js/customModal.js
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/js/customModal.js
@@ -1,3 +1,21 @@
+/*
+*  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
 if( typeof CARBON ==="undefined" || CARBON) {
     var CARBON = {};
 }

--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/js/customModal.js
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/js/customModal.js
@@ -1,0 +1,134 @@
+if( typeof CARBON ==="undefined" || CARBON) {
+    var CARBON = {};
+}
+
+var pageLoaded = false;
+
+/**
+ * Encode html value using jQuery.
+ * @method htmlEncode
+ * @param {String} value html value to be encoded
+ */
+function htmlEncode(value){
+  return jQuery('<div/>').text(value).html();
+}
+
+jQuery(document).ready(function() {
+    pageLoaded = true;
+});
+
+CARBON.showConfirmationDialog = function(message, handleYes, handleNo, closeCallback){
+    /* This function always assume that your second parameter is handleYes function and third parameter is handleNo function.
+     * If you are not going to provide handleYes function and want to give handleNo callback please pass null as the second
+     * parameter.
+     */
+    var strDialog = "<div id='dialog' title='WSO2 Carbon'><div id='messagebox-confirm'><p>" +
+                    htmlEncode(message) + "</p></div></div>";
+
+    handleYes = handleYes || function(){return true;};
+
+    handleNo = handleNo || function(){return false;};
+    var func = function() {
+	    jQuery("#dcontainer").html(strDialog);
+
+	    jQuery("#dialog").dialog({
+	        close:function() {
+	            jQuery(this).dialog('destroy').remove();
+	            jQuery("#dcontainer").empty();
+	            if (closeCallback && typeof closeCallback === "function") {
+	                closeCallback();
+	            }
+	            return false;
+	        },
+	        buttons:{
+	            "Yes":function() {
+	                jQuery(this).dialog("destroy").remove();
+	                jQuery("#dcontainer").empty();
+	                handleYes();
+	            },
+	            "No":function(){
+	                jQuery(this).dialog("destroy").remove();
+	                jQuery("#dcontainer").empty();
+	                handleNo();
+	            }
+	        },
+	        height:160,
+	        width:450,
+	        minHeight:160,
+	        minWidth:330,
+	        modal:true
+	    });
+    };
+    if (!pageLoaded) {
+        jQuery(document).ready(func);
+    } else {
+        func();
+    }
+    return false;
+};
+
+CARBON.showCustomModal = function( message, title, windowHeight, okButton, callback, windowWidth) {
+    var strDialog = "<div id='dialog' title='" + title + "'><div id='popupDialog'></div>" + htmlEncode(message) + "</div>";
+    var requiredWidth = 750;
+    if (windowWidth) {
+        requiredWidth = windowWidth;
+    }
+    var func = function() { 
+    jQuery("#dcontainer").html(strDialog);
+
+    if (okButton) {
+        jQuery("#dialog").dialog({
+            close:function() {
+                jQuery(this).dialog('destroy').remove();
+                jQuery("#dcontainer").empty();
+                return false;
+            },
+            buttons:{
+                "Redirect":function() {
+                    if (callback && typeof callback === "function")
+                        callback();
+                    jQuery(this).dialog("destroy").remove();
+                    jQuery("#dcontainer").empty();
+                    return false;
+                },
+
+                "Cancel":function() {
+                    jQuery(this).dialog("destroy").remove();
+                    jQuery("#dcontainer").empty();
+                    //handleCancel();
+                }
+            },
+            height:windowHeight,
+            width:requiredWidth,
+            minHeight:windowHeight,
+            minWidth:requiredWidth,
+            modal:true
+        });
+    } else {
+        jQuery("#dialog").dialog({
+            close:function() {
+                jQuery(this).dialog('destroy').remove();
+                jQuery("#dcontainer").empty();
+                return false;
+            },
+            height:windowHeight,
+            width:requiredWidth,
+            minHeight:windowHeight,
+            minWidth:requiredWidth,
+            modal:true
+        });
+    }
+	
+	jQuery('.ui-dialog-titlebar-close').click(function(){
+				jQuery('#dialog').dialog("destroy").remove();
+                jQuery("#dcontainer").empty();
+				jQuery("#dcontainer").html('');
+		});
+	
+    };
+    if (!pageLoaded) {
+        jQuery(document).ready(func);
+    } else {
+        func();
+    }
+};

--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageMessage.jsp
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageMessage.jsp
@@ -120,9 +120,9 @@
         
         if( processorName != null ) {
             try {
-                msg = client.getMessage(processorName);
+                msg = client.browseMessage(processorName);
             } catch (Throwable e) {
-                msg = "ERROR : " + e.getMessage();
+                msg = "ERROR : " + e.browseMessage();
                 CarbonUIMessage.sendCarbonUIMessage(msg,CarbonUIMessage.ERROR, request);
             }
         }

--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageMessage.jsp
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageMessage.jsp
@@ -1,0 +1,343 @@
+<%--
+ ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+--%>
+
+<%@ page contentType="text/html" pageEncoding="UTF-8" import="org.apache.axis2.context.ConfigurationContext" %>
+<%@ page import="org.wso2.carbon.CarbonConstants" %>
+<%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
+<%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
+<%@ page import="org.wso2.carbon.utils.ServerConstants" %>
+<%@ page import="java.util.Iterator" %>
+<%@ page import="org.wso2.carbon.message.processor.ui.MessageProcessorAdminServiceClient" %>
+<%@ page import="org.wso2.carbon.message.processor.service.xsd.MessageProcessorMetaData" %>
+<%@ page import="org.apache.axiom.om.OMElement" %>
+<%@ page import="org.apache.axiom.om.util.AXIOMUtil" %>
+<%@ page import="org.wso2.carbon.utils.xml.XMLPrettyPrinter" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="java.util.HashMap" %>
+<%@ page import="org.apache.commons.lang.StringEscapeUtils" %>
+
+<%@ page import="org.wso2.carbon.message.processor.ui.utils.MessageProcessorData" %>
+<%@ page import="org.wso2.carbon.message.processor.ui.MessageStoreAdminServiceClient" %>
+<%@ page import="org.owasp.encoder.Encode" %>
+
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib uri="http://wso2.org/projects/carbon/taglibs/carbontags.jar" prefix="carbon" %>
+
+<script src="../editarea/edit_area_full.js" type="text/javascript"></script>
+<script type="text/javascript" src="js/messageStore-util.js"></script>
+<script type="text/javascript" src="js/customModal.js"></script>
+
+<fmt:bundle basename="org.wso2.carbon.message.processor.ui.i18n.Resources">
+
+    <carbon:jsi18n resourceBundle="org.wso2.carbon.message.processor.ui.i18n.Resources"
+    request="<%=request%>"/>
+
+    <carbon:breadcrumb
+        label="Message Management"
+        resourceBundle="org.wso2.carbon.message.processor.ui.i18n.Resources"
+        topPage="false"
+    request="<%=request%>"/>
+
+    <script type="text/javascript" src="localentrycommons.js"></script>
+    <link type="text/css" href="../dialog/js/jqueryui/tabs/ui.all.css" rel="stylesheet"/>
+    <script type="text/javascript" src="../dialog/js/jqueryui/tabs/jquery-1.2.6.min.js"></script>
+    <script type="text/javascript" src="../dialog/js/jqueryui/tabs/jquery-ui-1.6.custom.min.js"></script>
+    <script type="text/javascript" src="../dialog/js/jqueryui/tabs/jquery.cookie.js"></script>
+    <script src="../editarea/edit_area_full.js" type="text/javascript"></script>
+
+    <%
+
+        String url = CarbonUIUtil.getServerURL(this.getServletConfig().getServletContext(),session);
+        ConfigurationContext configContext =
+            (ConfigurationContext)config.getServletContext().getAttribute(CarbonConstants.CONFIGURATION_CONTEXT);
+        String cookie = (String) session.getAttribute(ServerConstants.ADMIN_SERVICE_COOKIE);
+
+        MessageProcessorAdminServiceClient client = new MessageProcessorAdminServiceClient(cookie,url,configContext);
+        String processorName = request.getParameter("messageProcessorName");
+        String msg = null;
+        String messageStoreName = request.getParameter("messageProcessorName");
+
+        String[] messageProcessorNames = client.getMessageProcessorNames();
+        String origin = request.getParameter("origin");
+        MessageProcessorData processorData = null;
+        Boolean loadEditArea = true;
+
+        if (messageStoreName != null) {
+            session.setAttribute("edit" + messageStoreName, "true");
+            for (String name : messageProcessorNames) {
+                if (name != null && name.equals(messageStoreName)) {
+                    processorData = client.getMessageProcessor(name);
+                }
+            }
+        } else if (origin != null && !"".equals(origin)) {
+            String mpString = (String) session.getAttribute("messageProcessorConfiguration");
+            String mpName = (String) session.getAttribute("mpName");
+            String mpProvider = (String) session.getAttribute("mpProvider");
+            String mpStore = (String) session.getAttribute("mpStore");
+
+            session.removeAttribute("messageProcessorConfiguration");
+            session.removeAttribute("mpName");
+            session.removeAttribute("mpProvider");
+            session.removeAttribute("mpStore");
+
+            mpString = mpString.replaceAll("\\s\\s+|\\n|\\r", ""); // remove the pretty printing from the string
+            OMElement messageProcessorElement = AXIOMUtil.stringToOM(mpString);
+            processorData = new MessageProcessorData(messageProcessorElement.toString());
+            processorData.setName(mpName);
+            processorData.setClazz(mpProvider);
+            processorData.setMessageStore(mpStore);
+        }
+
+        MessageStoreAdminServiceClient messageStoreClient =
+            new MessageStoreAdminServiceClient(cookie, url, configContext);
+        String[] messageStores = messageStoreClient.getMessageStoreNames();
+        
+        String storeList = "";
+        
+        // Creating a string with all the stores with a delimiter in between
+        for(String storeName : messageStores) {
+            storeList += storeName + "#";
+        }
+    
+        //Get rid of that last #
+        if(storeList.length() > 0) {
+            storeList = storeList.substring(0, storeList.length() - 1);
+        }   
+        
+        if( processorName != null ) {
+            try {
+                msg = client.getMessage(processorName);
+            } catch (Throwable e) {
+                msg = "ERROR : " + e.getMessage();
+                CarbonUIMessage.sendCarbonUIMessage(msg,CarbonUIMessage.ERROR, request);
+            }
+        }
+
+        if(msg!=null) {
+            msg = msg.replace("<","&lt");
+            msg = msg.replace(">","&gt");
+        }
+    %>
+
+    <style>
+        pre {
+            overflow-x: auto;
+            white-space: pre-wrap;
+            white-space: -moz-pre-wrap;
+            white-space: -pre-wrap;
+            white-space: -o-pre-wrap;
+            word-wrap: break-word;
+        }
+    </style>
+
+    <div id = "middle">
+        <h2><%=processorName%> : Message Management</h2>
+
+        <!-- No messages in the Queue -->
+        <% if(msg == null) { %>
+        <!-- Empty Queue -->
+        <div id="workArea">
+            <form name="Submit" id="Submit" action="ServiceCaller.jsp" method="POST">
+                <table class="styledLeft">
+                    <thead>
+                        <tr>
+                            <th>
+                                <span style="float: left; position: relative; margin-top: 2px;">
+                                    Message Processor Payload
+                                </span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tr>
+                        <td>
+                            <textarea id="Payload" name="Payload"
+                               style="border: 0px solid rgb(204, 204, 204); width: 99%; height: 275px; margin-top: 5px;"
+                               rows="30"> Subscribed Queue is Empty
+                            </textarea>
+                        </td>
+                    </tr>
+
+                    <!-- Operations -->
+                    <tr>
+                        <td class="buttonRow">
+                            <input type="button" value="Pop Message" class="button"
+                                   disabled/>
+                            <input type="button" value="Redirect Message" class="button"
+                                   disabled/>
+                            <input type="button" value="<fmt:message key="cancel"/>"
+                                   class="button" onclick="javascript:document.location.href = 'index.jsp'"/>
+                        </td>
+                    </tr>
+                </table>
+
+            </form>
+        </div>
+
+        <!-- Error occurs -->
+        <% } else if(msg.contains("ERROR")) { %>
+
+        <!-- Payload -->
+        <div id="workArea">
+            <form name="Submit" id="Submit" action="ServiceCaller.jsp" method="POST">
+                <table class="styledLeft">
+                    <thead>
+                        <tr>
+                            <th>
+                                <span style="float: left; position: relative; margin-top: 2px;">
+                                    Message Processor Payload
+                                </span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tr>
+                        <td>
+                            <textarea id="Payload" name="Payload"
+                               style="border: 0px solid rgb(204, 204, 204); width: 99%; height: 275px; margin-top: 5px;"
+                               rows="30"><%=msg%>. Message Broker may be inactive
+                            </textarea>
+                        </td>
+                    </tr>  
+
+                    <!-- Operations -->
+                    <tr>
+                        <td class="buttonRow">
+                            <input type="button" value="Pop Message" class="button"
+                                   disabled/>
+                            <input type="button" value="Redirect Message" class="button"
+                                   disabled/>
+                            <input type="button" value="<fmt:message key="cancel"/>"
+                                   class="button" onclick="javascript:document.location.href = 'index.jsp'"/>
+                        </td>
+                    </tr>
+                </table>
+
+            </form>
+        </div>
+
+        <!-- Display message -->
+        <% } else { %>
+
+        <!-- Payload -->
+        <div id="workArea">
+            <form name="Submit" id="Submit" action="ServiceCaller.jsp" method="POST">
+                <table class="styledLeft">
+                    <thead>
+                        <tr>
+                            <th>
+                                <span style="float: left; position: relative; margin-top: 2px;">
+                                    Message Processor Payload
+                                </span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tr>
+                        <td>
+                            <textarea id="Payload" name="Payload"
+                               style="border: 0px solid rgb(204, 204, 204); width: 99%; height: 275px; margin-top: 5px;"
+                               rows="30"><%=msg%>
+                            </textarea>
+                        </td>
+                    </tr>
+
+                    <!-- Operations -->
+                    <tr>
+                        <td class="buttonRow">
+                            <input type="button" value="Pop Message" class="button"
+                                   onclick="popMessage('<%=processorName%>')"/>
+                            <input type="button" value="Redirect Message" class="button"
+                                   onclick="redirectMessage('<%=processorName%>')"/>
+                            <input type="button" value="<fmt:message key="cancel"/>"
+                                   class="button" onclick="javascript:document.location.href = 'index.jsp'"/>
+                        </td>
+                    </tr>
+                </table>
+            </form>
+        </div>
+
+
+        <% } %>
+
+
+
+        <script type="text/javascript">
+            function popMessage(name) {
+                CARBON.showConfirmationDialog("Do you want to pop the message?", function () {
+                    jQuery.ajax({
+                        type: "POST",
+                        url: "popMessageFromQueue.jsp",
+                        data: {"processorName": name},
+                        success: function (result, status, xhr) {
+                            if (status == "success") {
+                                CARBON.showConfirmationDialog("Message successfully popped from Queue",
+                                function() {
+                                    javascript:document.location.href = 'index.jsp';
+                                });
+                            }
+                        }
+                    });
+                });
+            }
+
+            function redirectMessage(processorName) {
+
+                data = '<%=storeList%>'; 
+                data = jQuery.trim(data);
+                
+                data = data.split("#");
+               
+                storeList = '<div id="target" style="margin: 0 auto; width: 80%;">Redirect to : <select id="storeName" style="margin-top: 10px;">';
+                for (var i = 0; i < data.length; i++) {
+                    storeList += '<option value="' + data[i] + '">' + data[i] + '</option>';
+                }
+       
+                storeList += '</select><P style="margin-top: 5px;">Message will be redirected to the chosen message store</P></div>';
+
+                CARBON.showCustomModal("", "Select a store to redirect the message ", 130, true,
+                        function () {
+                            //Getting the selected store
+                            var storeName = jQuery('#storeName').val();
+
+                            jQuery.ajax({
+                                type: "POST",
+                                url: "redirectMessage.jsp",
+                                data: {"processorName": processorName, "storeName": storeName},
+                                success: function (result, status, xhr) {
+                                    CARBON.showConfirmationDialog("Message successfully redirected to " + storeName,
+                                    function() {
+                                        javascript:document.location.href = 'index.jsp';
+                                    });
+                                }
+                            });
+                        }, 500
+                );
+                $("#popupDialog").after(storeList);
+            } //End of showPopUp Function
+
+
+            editAreaLoader.init({
+                id: "Payload"		// text area id
+                , syntax: "xml"	       // syntax to be uses for highlighting
+                , start_highlight: true    // to display with highlight mode on start-up
+                , toolbar: "search, go_to_line, fullscreen, |, select_font,|, change_smooth_selection, highlight, reset_highlight, word_wrap"
+                , is_editable: false
+                , EA_load_callback: 'modifyToolbar'
+            });
+        </script>
+    </div>
+
+</fmt:bundle>
+

--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/popMessageFromQueue.jsp
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/popMessageFromQueue.jsp
@@ -1,0 +1,54 @@
+<%--
+ ~ Copyright (c) 2009, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+--%>
+
+<%@ page import="org.apache.axiom.om.OMElement" %>
+<%@ page import="org.apache.axiom.om.util.AXIOMUtil" %>
+<%@ page import="org.wso2.carbon.message.processor.ui.utils.MessageProcessorData" %>
+<%@ page contentType="text/html" pageEncoding="UTF-8" %>
+<%@ page import="org.apache.axis2.context.ConfigurationContext" %>
+<%@ page import="org.wso2.carbon.CarbonConstants" %>
+<%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
+<%@ page import="org.wso2.carbon.utils.ServerConstants" %>
+<%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
+<%@ page import="java.util.ResourceBundle" %>
+<%@ page import="org.wso2.carbon.message.processor.ui.MessageProcessorAdminServiceClient" %>
+
+<body>
+<%
+    //ignore methods other than post
+    if (!request.getMethod().equalsIgnoreCase("POST")) {
+        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        return;
+    }
+
+    String url = CarbonUIUtil.getServerURL(this.getServletConfig().getServletContext(),session);
+    ConfigurationContext configContext =(ConfigurationContext)config.getServletContext().getAttribute(CarbonConstants.CONFIGURATION_CONTEXT);
+    String cookie = (String) session.getAttribute(ServerConstants.ADMIN_SERVICE_COOKIE);
+    String msg = null;
+
+    MessageProcessorAdminServiceClient client = new MessageProcessorAdminServiceClient(cookie,url,configContext);
+    String processorName = request.getParameter("processorName");
+
+    if( processorName != null ) {
+        try {
+            client.popMessage(processorName);
+        } catch (Throwable e) {
+            msg = "Could not pop the message from the queue" + e;
+            CarbonUIMessage.sendCarbonUIMessage(msg,CarbonUIMessage.ERROR,request);
+        }
+    }
+%>
+</body>

--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/redirectMessage.jsp
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/redirectMessage.jsp
@@ -1,0 +1,59 @@
+<%--
+  ~ Copyright (c) 2009, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ --%>
+
+ <%@ page import="org.apache.axiom.om.OMElement" %>
+ <%@ page import="org.apache.axiom.om.util.AXIOMUtil" %>
+ <%@ page import="org.wso2.carbon.message.processor.ui.utils.MessageProcessorData" %>
+ <%@ page contentType="text/html" pageEncoding="UTF-8" %>
+ <%@ page import="org.apache.axis2.context.ConfigurationContext" %>
+ <%@ page import="org.wso2.carbon.CarbonConstants" %>
+ <%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
+ <%@ page import="org.wso2.carbon.utils.ServerConstants" %>
+ <%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
+ <%@ page import="java.util.ResourceBundle" %>
+ <%@ page import="org.wso2.carbon.message.processor.ui.MessageProcessorAdminServiceClient" %>
+
+ <body>
+ <%
+     //ignore methods other than post
+     if ( !request.getMethod().equalsIgnoreCase("POST") ) {
+         response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+         return;
+     }
+
+     String url = CarbonUIUtil.getServerURL(this.getServletConfig().getServletContext(),session);
+     ConfigurationContext configContext = (ConfigurationContext)config.getServletContext().getAttribute(CarbonConstants.CONFIGURATION_CONTEXT);
+     String cookie = (String) session.getAttribute(ServerConstants.ADMIN_SERVICE_COOKIE);
+     String msg = null;
+
+     MessageProcessorAdminServiceClient client = new MessageProcessorAdminServiceClient(cookie,url,configContext);
+     String processorName = request.getParameter("processorName");
+     String storeName = request.getParameter("storeName");
+
+     if ( processorName != null && storeName != null) {
+         try {
+             client.popAndRedirectMessage(processorName,storeName);
+         } catch (Throwable e) {
+             msg = "Could not redirect the message to the store : " + storeName + "." + e;
+             CarbonUIMessage.sendCarbonUIMessage(msg, CarbonUIMessage.ERROR, request);
+         }
+     } else {
+         msg = "Message Processor / Store not defined. Got Null";
+         CarbonUIMessage.sendCarbonUIMessage(msg, CarbonUIMessage.ERROR, request);
+     }
+
+ %>
+ </body>

--- a/service-stubs/mediation-admin/org.wso2.carbon.message.processor.stub/src/main/resources/MessageProcessorAdminService.wsdl
+++ b/service-stubs/mediation-admin/org.wso2.carbon.message.processor.stub/src/main/resources/MessageProcessorAdminService.wsdl
@@ -12,20 +12,6 @@
         </xs:schema>
         <xs:schema xmlns:ax2263="http://service.processor.message.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.synapse/xsd">
             <xs:import namespace="http://service.processor.message.carbon.wso2.org/xsd"/>
-            <xs:element name="getMessage">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
             <xs:element name="getSize">
                 <xs:complexType>
                     <xs:sequence>
@@ -54,6 +40,13 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="deactivate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="activate">
                 <xs:complexType>
                     <xs:sequence>
@@ -61,10 +54,25 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="deactivate">
+            <xs:element name="addMessageProcessor">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="xml" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getEnvelope">
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getEnvelopeResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -82,26 +90,15 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="resend">
+            <xs:element name="getDefinedEndpoints">
                 <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
-                    </xs:sequence>
+                    <xs:sequence/>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getEnvelope">
+            <xs:element name="getDefinedEndpointsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getEnvelopeResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -193,6 +190,14 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="resend">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="resendFirstMessage">
                 <xs:complexType>
                     <xs:sequence>
@@ -222,6 +227,20 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="browseMessage">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="browseMessageResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="popMessage">
                 <xs:complexType>
                     <xs:sequence>
@@ -234,25 +253,6 @@
                     <xs:sequence>
                         <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
                         <xs:element minOccurs="0" name="storeName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getDefinedEndpoints">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getDefinedEndpointsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="addMessageProcessor">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="xml" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -288,6 +288,12 @@
     <wsdl:message name="deactivateRequest">
         <wsdl:part name="parameters" element="ns:deactivate"/>
     </wsdl:message>
+    <wsdl:message name="browseMessageRequest">
+        <wsdl:part name="parameters" element="ns:browseMessage"/>
+    </wsdl:message>
+    <wsdl:message name="browseMessageResponse">
+        <wsdl:part name="parameters" element="ns:browseMessageResponse"/>
+    </wsdl:message>
     <wsdl:message name="modifyMessageProcessorRequest">
         <wsdl:part name="parameters" element="ns:modifyMessageProcessor"/>
     </wsdl:message>
@@ -297,11 +303,11 @@
     <wsdl:message name="getMessageIdsResponse">
         <wsdl:part name="parameters" element="ns:getMessageIdsResponse"/>
     </wsdl:message>
-    <wsdl:message name="resendFirstMessageRequest">
-        <wsdl:part name="parameters" element="ns:resendFirstMessage"/>
-    </wsdl:message>
     <wsdl:message name="addMessageProcessorRequest">
         <wsdl:part name="parameters" element="ns:addMessageProcessor"/>
+    </wsdl:message>
+    <wsdl:message name="resendFirstMessageRequest">
+        <wsdl:part name="parameters" element="ns:resendFirstMessage"/>
     </wsdl:message>
     <wsdl:message name="getDefinedEndpointsRequest">
         <wsdl:part name="parameters" element="ns:getDefinedEndpoints"/>
@@ -311,12 +317,6 @@
     </wsdl:message>
     <wsdl:message name="deleteFirstMessagesRequest">
         <wsdl:part name="parameters" element="ns:deleteFirstMessages"/>
-    </wsdl:message>
-    <wsdl:message name="getMessageRequest">
-        <wsdl:part name="parameters" element="ns:getMessage"/>
-    </wsdl:message>
-    <wsdl:message name="getMessageResponse">
-        <wsdl:part name="parameters" element="ns:getMessageResponse"/>
     </wsdl:message>
     <wsdl:message name="deleteMessageRequest">
         <wsdl:part name="parameters" element="ns:deleteMessage"/>
@@ -388,6 +388,10 @@
         <wsdl:operation name="deactivate">
             <wsdl:input message="tns:deactivateRequest" wsaw:Action="urn:deactivate"/>
         </wsdl:operation>
+        <wsdl:operation name="browseMessage">
+            <wsdl:input message="tns:browseMessageRequest" wsaw:Action="urn:browseMessage"/>
+            <wsdl:output message="tns:browseMessageResponse" wsaw:Action="urn:browseMessageResponse"/>
+        </wsdl:operation>
         <wsdl:operation name="modifyMessageProcessor">
             <wsdl:input message="tns:modifyMessageProcessorRequest" wsaw:Action="urn:modifyMessageProcessor"/>
         </wsdl:operation>
@@ -395,11 +399,11 @@
             <wsdl:input message="tns:getMessageIdsRequest" wsaw:Action="urn:getMessageIds"/>
             <wsdl:output message="tns:getMessageIdsResponse" wsaw:Action="urn:getMessageIdsResponse"/>
         </wsdl:operation>
-        <wsdl:operation name="resendFirstMessage">
-            <wsdl:input message="tns:resendFirstMessageRequest" wsaw:Action="urn:resendFirstMessage"/>
-        </wsdl:operation>
         <wsdl:operation name="addMessageProcessor">
             <wsdl:input message="tns:addMessageProcessorRequest" wsaw:Action="urn:addMessageProcessor"/>
+        </wsdl:operation>
+        <wsdl:operation name="resendFirstMessage">
+            <wsdl:input message="tns:resendFirstMessageRequest" wsaw:Action="urn:resendFirstMessage"/>
         </wsdl:operation>
         <wsdl:operation name="getDefinedEndpoints">
             <wsdl:input message="tns:getDefinedEndpointsRequest" wsaw:Action="urn:getDefinedEndpoints"/>
@@ -407,10 +411,6 @@
         </wsdl:operation>
         <wsdl:operation name="deleteFirstMessages">
             <wsdl:input message="tns:deleteFirstMessagesRequest" wsaw:Action="urn:deleteFirstMessages"/>
-        </wsdl:operation>
-        <wsdl:operation name="getMessage">
-            <wsdl:input message="tns:getMessageRequest" wsaw:Action="urn:getMessage"/>
-            <wsdl:output message="tns:getMessageResponse" wsaw:Action="urn:getMessageResponse"/>
         </wsdl:operation>
         <wsdl:operation name="deleteMessage">
             <wsdl:input message="tns:deleteMessageRequest" wsaw:Action="urn:deleteMessage"/>
@@ -501,6 +501,15 @@
                 <soap:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
+        <wsdl:operation name="browseMessage">
+            <soap:operation soapAction="urn:browseMessage" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
         <wsdl:operation name="modifyMessageProcessor">
             <soap:operation soapAction="urn:modifyMessageProcessor" style="document"/>
             <wsdl:input>
@@ -516,14 +525,14 @@
                 <soap:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="addMessageProcessor">
-            <soap:operation soapAction="urn:addMessageProcessor" style="document"/>
+        <wsdl:operation name="resendFirstMessage">
+            <soap:operation soapAction="urn:resendFirstMessage" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="resendFirstMessage">
-            <soap:operation soapAction="urn:resendFirstMessage" style="document"/>
+        <wsdl:operation name="addMessageProcessor">
+            <soap:operation soapAction="urn:addMessageProcessor" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -542,15 +551,6 @@
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getMessage">
-            <soap:operation soapAction="urn:getMessage" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="deleteMessage">
             <soap:operation soapAction="urn:deleteMessage" style="document"/>
@@ -681,6 +681,15 @@
                 <soap12:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
+        <wsdl:operation name="browseMessage">
+            <soap12:operation soapAction="urn:browseMessage" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
         <wsdl:operation name="modifyMessageProcessor">
             <soap12:operation soapAction="urn:modifyMessageProcessor" style="document"/>
             <wsdl:input>
@@ -696,14 +705,14 @@
                 <soap12:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="addMessageProcessor">
-            <soap12:operation soapAction="urn:addMessageProcessor" style="document"/>
+        <wsdl:operation name="resendFirstMessage">
+            <soap12:operation soapAction="urn:resendFirstMessage" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="resendFirstMessage">
-            <soap12:operation soapAction="urn:resendFirstMessage" style="document"/>
+        <wsdl:operation name="addMessageProcessor">
+            <soap12:operation soapAction="urn:addMessageProcessor" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -722,15 +731,6 @@
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getMessage">
-            <soap12:operation soapAction="urn:getMessage" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="deleteMessage">
             <soap12:operation soapAction="urn:deleteMessage" style="document"/>
@@ -861,6 +861,15 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
         </wsdl:operation>
+        <wsdl:operation name="browseMessage">
+            <http:operation location="browseMessage"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
         <wsdl:operation name="modifyMessageProcessor">
             <http:operation location="modifyMessageProcessor"/>
             <wsdl:input>
@@ -876,14 +885,14 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="addMessageProcessor">
-            <http:operation location="addMessageProcessor"/>
+        <wsdl:operation name="resendFirstMessage">
+            <http:operation location="resendFirstMessage"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="resendFirstMessage">
-            <http:operation location="resendFirstMessage"/>
+        <wsdl:operation name="addMessageProcessor">
+            <http:operation location="addMessageProcessor"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -902,15 +911,6 @@
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getMessage">
-            <http:operation location="getMessage"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="deleteMessage">
             <http:operation location="deleteMessage"/>

--- a/service-stubs/mediation-admin/org.wso2.carbon.message.processor.stub/src/main/resources/MessageProcessorAdminService.wsdl
+++ b/service-stubs/mediation-admin/org.wso2.carbon.message.processor.stub/src/main/resources/MessageProcessorAdminService.wsdl
@@ -1,187 +1,28 @@
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:ns="http://org.apache.synapse/xsd" xmlns:ax2295="http://service.processor.message.carbon.wso2.org/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:tns="http://service.processor.message.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" targetNamespace="http://service.processor.message.carbon.wso2.org">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns="http://org.apache.synapse/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://service.processor.message.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ax2262="http://service.processor.message.carbon.wso2.org/xsd" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://service.processor.message.carbon.wso2.org">
     <wsdl:documentation>MessageProcessorAdminService</wsdl:documentation>
     <wsdl:types>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://service.processor.message.carbon.wso2.org/xsd">
             <xs:complexType name="MessageProcessorMetaData">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="artifactContainerName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="isEdited" nillable="true" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="isEdited" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
         </xs:schema>
-        <xs:schema xmlns:ax2296="http://service.processor.message.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.synapse/xsd">
+        <xs:schema xmlns:ax2263="http://service.processor.message.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.synapse/xsd">
             <xs:import namespace="http://service.processor.message.carbon.wso2.org/xsd"/>
-            <xs:element name="deleteMessageProcessor">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="resend">
+            <xs:element name="getMessage">
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getEnvelope">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getEnvelopeResponse">
+            <xs:element name="getMessageResponse">
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getDefinedEndpoints">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getDefinedEndpointsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deleteFirstMessages">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deleteAllMessages">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="resendFirstMessage">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="addMessageProcessor">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="xml" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageProcessor">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageProcessorResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deleteMessage">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="modifyMessageProcessor">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="xml" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageProcessorNames">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageProcessorNamesResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="resendAll">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageProcessorDataList">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageProcessorDataListResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2295:MessageProcessorMetaData"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageIds">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageIdsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deactivate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="isActive">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="isActiveResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="activate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -213,33 +54,230 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="activate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deactivate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="isActive">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="isActiveResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="resend">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getEnvelope">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getEnvelopeResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageProcessor">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageProcessorResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteMessageProcessor">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="modifyMessageProcessor">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="xml" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageProcessorNames">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageProcessorNamesResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageIds">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageIdsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageProcessorDataList">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageProcessorDataListResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2262:MessageProcessorMetaData"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteMessage">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteFirstMessages">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteAllMessages">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="resendFirstMessage">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="messageId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="resendAll">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="validateAxis2ClientRepo">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="in" type="xs:string"></xs:element>
+                        <xs:element minOccurs="0" name="input" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element name="validateAxis2ClientRepoResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="out" type="xs:boolean"></xs:element>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="popMessage">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="popAndRedirectMessage">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="storeName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getDefinedEndpoints">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getDefinedEndpointsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="addMessageProcessor">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="xml" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
         </xs:schema>
     </wsdl:types>
-    <wsdl:message name="getSizeRequest">
-        <wsdl:part name="parameters" element="ns:getSize"/>
+    <wsdl:message name="getMessageProcessorRequest">
+        <wsdl:part name="parameters" element="ns:getMessageProcessor"/>
     </wsdl:message>
-    <wsdl:message name="getSizeResponse">
-        <wsdl:part name="parameters" element="ns:getSizeResponse"/>
+    <wsdl:message name="getMessageProcessorResponse">
+        <wsdl:part name="parameters" element="ns:getMessageProcessorResponse"/>
     </wsdl:message>
-    <wsdl:message name="resendFirstMessageRequest">
-        <wsdl:part name="parameters" element="ns:resendFirstMessage"/>
+    <wsdl:message name="popMessageRequest">
+        <wsdl:part name="parameters" element="ns:popMessage"/>
+    </wsdl:message>
+    <wsdl:message name="popAndRedirectMessageRequest">
+        <wsdl:part name="parameters" element="ns:popAndRedirectMessage"/>
     </wsdl:message>
     <wsdl:message name="deleteAllMessagesRequest">
         <wsdl:part name="parameters" element="ns:deleteAllMessages"/>
+    </wsdl:message>
+    <wsdl:message name="validateAxis2ClientRepoRequest">
+        <wsdl:part name="parameters" element="ns:validateAxis2ClientRepo"/>
+    </wsdl:message>
+    <wsdl:message name="validateAxis2ClientRepoResponse">
+        <wsdl:part name="parameters" element="ns:validateAxis2ClientRepoResponse"/>
     </wsdl:message>
     <wsdl:message name="isActiveRequest">
         <wsdl:part name="parameters" element="ns:isActive"/>
@@ -247,26 +285,11 @@
     <wsdl:message name="isActiveResponse">
         <wsdl:part name="parameters" element="ns:isActiveResponse"/>
     </wsdl:message>
+    <wsdl:message name="deactivateRequest">
+        <wsdl:part name="parameters" element="ns:deactivate"/>
+    </wsdl:message>
     <wsdl:message name="modifyMessageProcessorRequest">
         <wsdl:part name="parameters" element="ns:modifyMessageProcessor"/>
-    </wsdl:message>
-    <wsdl:message name="getMessageProcessorRequest">
-        <wsdl:part name="parameters" element="ns:getMessageProcessor"/>
-    </wsdl:message>
-    <wsdl:message name="getMessageProcessorResponse">
-        <wsdl:part name="parameters" element="ns:getMessageProcessorResponse"/>
-    </wsdl:message>
-    <wsdl:message name="getMessageProcessorNamesRequest">
-        <wsdl:part name="parameters" element="ns:getMessageProcessorNames"/>
-    </wsdl:message>
-    <wsdl:message name="getMessageProcessorNamesResponse">
-        <wsdl:part name="parameters" element="ns:getMessageProcessorNamesResponse"/>
-    </wsdl:message>
-    <wsdl:message name="getEnvelopeRequest">
-        <wsdl:part name="parameters" element="ns:getEnvelope"/>
-    </wsdl:message>
-    <wsdl:message name="getEnvelopeResponse">
-        <wsdl:part name="parameters" element="ns:getEnvelopeResponse"/>
     </wsdl:message>
     <wsdl:message name="getMessageIdsRequest">
         <wsdl:part name="parameters" element="ns:getMessageIds"/>
@@ -274,38 +297,11 @@
     <wsdl:message name="getMessageIdsResponse">
         <wsdl:part name="parameters" element="ns:getMessageIdsResponse"/>
     </wsdl:message>
-    <wsdl:message name="activateRequest">
-        <wsdl:part name="parameters" element="ns:activate"/>
+    <wsdl:message name="resendFirstMessageRequest">
+        <wsdl:part name="parameters" element="ns:resendFirstMessage"/>
     </wsdl:message>
     <wsdl:message name="addMessageProcessorRequest">
         <wsdl:part name="parameters" element="ns:addMessageProcessor"/>
-    </wsdl:message>
-    <wsdl:message name="deleteMessageProcessorRequest">
-        <wsdl:part name="parameters" element="ns:deleteMessageProcessor"/>
-    </wsdl:message>
-    <wsdl:message name="getClassNameRequest">
-        <wsdl:part name="parameters" element="ns:getClassName"/>
-    </wsdl:message>
-    <wsdl:message name="getClassNameResponse">
-        <wsdl:part name="parameters" element="ns:getClassNameResponse"/>
-    </wsdl:message>
-    <wsdl:message name="deactivateRequest">
-        <wsdl:part name="parameters" element="ns:deactivate"/>
-    </wsdl:message>
-    <wsdl:message name="resendRequest">
-        <wsdl:part name="parameters" element="ns:resend"/>
-    </wsdl:message>
-    <wsdl:message name="deleteMessageRequest">
-        <wsdl:part name="parameters" element="ns:deleteMessage"/>
-    </wsdl:message>
-    <wsdl:message name="deleteFirstMessagesRequest">
-        <wsdl:part name="parameters" element="ns:deleteFirstMessages"/>
-    </wsdl:message>
-    <wsdl:message name="getMessageProcessorDataListRequest">
-        <wsdl:part name="parameters" element="ns:getMessageProcessorDataList"/>
-    </wsdl:message>
-    <wsdl:message name="getMessageProcessorDataListResponse">
-        <wsdl:part name="parameters" element="ns:getMessageProcessorDataListResponse"/>
     </wsdl:message>
     <wsdl:message name="getDefinedEndpointsRequest">
         <wsdl:part name="parameters" element="ns:getDefinedEndpoints"/>
@@ -313,100 +309,149 @@
     <wsdl:message name="getDefinedEndpointsResponse">
         <wsdl:part name="parameters" element="ns:getDefinedEndpointsResponse"/>
     </wsdl:message>
+    <wsdl:message name="deleteFirstMessagesRequest">
+        <wsdl:part name="parameters" element="ns:deleteFirstMessages"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageRequest">
+        <wsdl:part name="parameters" element="ns:getMessage"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageResponse">
+        <wsdl:part name="parameters" element="ns:getMessageResponse"/>
+    </wsdl:message>
+    <wsdl:message name="deleteMessageRequest">
+        <wsdl:part name="parameters" element="ns:deleteMessage"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageProcessorNamesRequest">
+        <wsdl:part name="parameters" element="ns:getMessageProcessorNames"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageProcessorNamesResponse">
+        <wsdl:part name="parameters" element="ns:getMessageProcessorNamesResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getSizeRequest">
+        <wsdl:part name="parameters" element="ns:getSize"/>
+    </wsdl:message>
+    <wsdl:message name="getSizeResponse">
+        <wsdl:part name="parameters" element="ns:getSizeResponse"/>
+    </wsdl:message>
     <wsdl:message name="resendAllRequest">
         <wsdl:part name="parameters" element="ns:resendAll"/>
     </wsdl:message>
-    <wsdl:message name="validateAxis2ClientRepoRequest">
-        <wsdl:part name="parameters" element="ns:validateAxis2ClientRepo"></wsdl:part>
+    <wsdl:message name="deleteMessageProcessorRequest">
+        <wsdl:part name="parameters" element="ns:deleteMessageProcessor"/>
     </wsdl:message>
-    <wsdl:message name="validateAxis2ClientRepoResponse">
-        <wsdl:part name="parameters" element="ns:validateAxis2ClientRepoResponse"></wsdl:part>
+    <wsdl:message name="resendRequest">
+        <wsdl:part name="parameters" element="ns:resend"/>
+    </wsdl:message>
+    <wsdl:message name="activateRequest">
+        <wsdl:part name="parameters" element="ns:activate"/>
+    </wsdl:message>
+    <wsdl:message name="getEnvelopeRequest">
+        <wsdl:part name="parameters" element="ns:getEnvelope"/>
+    </wsdl:message>
+    <wsdl:message name="getEnvelopeResponse">
+        <wsdl:part name="parameters" element="ns:getEnvelopeResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getClassNameRequest">
+        <wsdl:part name="parameters" element="ns:getClassName"/>
+    </wsdl:message>
+    <wsdl:message name="getClassNameResponse">
+        <wsdl:part name="parameters" element="ns:getClassNameResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageProcessorDataListRequest">
+        <wsdl:part name="parameters" element="ns:getMessageProcessorDataList"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageProcessorDataListResponse">
+        <wsdl:part name="parameters" element="ns:getMessageProcessorDataListResponse"/>
     </wsdl:message>
     <wsdl:portType name="MessageProcessorAdminServicePortType">
-        <wsdl:operation name="getSize">
-            <wsdl:input message="tns:getSizeRequest" wsaw:Action="urn:getSize"/>
-            <wsdl:output message="tns:getSizeResponse" wsaw:Action="urn:getSizeResponse"/>
+        <wsdl:operation name="getMessageProcessor">
+            <wsdl:input message="tns:getMessageProcessorRequest" wsaw:Action="urn:getMessageProcessor"/>
+            <wsdl:output message="tns:getMessageProcessorResponse" wsaw:Action="urn:getMessageProcessorResponse"/>
         </wsdl:operation>
-        <wsdl:operation name="resendFirstMessage">
-            <wsdl:input message="tns:resendFirstMessageRequest" wsaw:Action="urn:resendFirstMessage"/>
+        <wsdl:operation name="popMessage">
+            <wsdl:input message="tns:popMessageRequest" wsaw:Action="urn:popMessage"/>
+        </wsdl:operation>
+        <wsdl:operation name="popAndRedirectMessage">
+            <wsdl:input message="tns:popAndRedirectMessageRequest" wsaw:Action="urn:popAndRedirectMessage"/>
         </wsdl:operation>
         <wsdl:operation name="deleteAllMessages">
             <wsdl:input message="tns:deleteAllMessagesRequest" wsaw:Action="urn:deleteAllMessages"/>
+        </wsdl:operation>
+        <wsdl:operation name="validateAxis2ClientRepo">
+            <wsdl:input message="tns:validateAxis2ClientRepoRequest" wsaw:Action="urn:validateAxis2ClientRepo"/>
+            <wsdl:output message="tns:validateAxis2ClientRepoResponse" wsaw:Action="urn:validateAxis2ClientRepoResponse"/>
         </wsdl:operation>
         <wsdl:operation name="isActive">
             <wsdl:input message="tns:isActiveRequest" wsaw:Action="urn:isActive"/>
             <wsdl:output message="tns:isActiveResponse" wsaw:Action="urn:isActiveResponse"/>
         </wsdl:operation>
+        <wsdl:operation name="deactivate">
+            <wsdl:input message="tns:deactivateRequest" wsaw:Action="urn:deactivate"/>
+        </wsdl:operation>
         <wsdl:operation name="modifyMessageProcessor">
             <wsdl:input message="tns:modifyMessageProcessorRequest" wsaw:Action="urn:modifyMessageProcessor"/>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessor">
-            <wsdl:input message="tns:getMessageProcessorRequest" wsaw:Action="urn:getMessageProcessor"/>
-            <wsdl:output message="tns:getMessageProcessorResponse" wsaw:Action="urn:getMessageProcessorResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessorNames">
-            <wsdl:input message="tns:getMessageProcessorNamesRequest" wsaw:Action="urn:getMessageProcessorNames"/>
-            <wsdl:output message="tns:getMessageProcessorNamesResponse" wsaw:Action="urn:getMessageProcessorNamesResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="getEnvelope">
-            <wsdl:input message="tns:getEnvelopeRequest" wsaw:Action="urn:getEnvelope"/>
-            <wsdl:output message="tns:getEnvelopeResponse" wsaw:Action="urn:getEnvelopeResponse"/>
         </wsdl:operation>
         <wsdl:operation name="getMessageIds">
             <wsdl:input message="tns:getMessageIdsRequest" wsaw:Action="urn:getMessageIds"/>
             <wsdl:output message="tns:getMessageIdsResponse" wsaw:Action="urn:getMessageIdsResponse"/>
         </wsdl:operation>
-        <wsdl:operation name="activate">
-            <wsdl:input message="tns:activateRequest" wsaw:Action="urn:activate"/>
+        <wsdl:operation name="resendFirstMessage">
+            <wsdl:input message="tns:resendFirstMessageRequest" wsaw:Action="urn:resendFirstMessage"/>
         </wsdl:operation>
         <wsdl:operation name="addMessageProcessor">
             <wsdl:input message="tns:addMessageProcessorRequest" wsaw:Action="urn:addMessageProcessor"/>
-        </wsdl:operation>
-        <wsdl:operation name="deleteMessageProcessor">
-            <wsdl:input message="tns:deleteMessageProcessorRequest" wsaw:Action="urn:deleteMessageProcessor"/>
-        </wsdl:operation>
-        <wsdl:operation name="getClassName">
-            <wsdl:input message="tns:getClassNameRequest" wsaw:Action="urn:getClassName"/>
-            <wsdl:output message="tns:getClassNameResponse" wsaw:Action="urn:getClassNameResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="deactivate">
-            <wsdl:input message="tns:deactivateRequest" wsaw:Action="urn:deactivate"/>
-        </wsdl:operation>
-        <wsdl:operation name="resend">
-            <wsdl:input message="tns:resendRequest" wsaw:Action="urn:resend"/>
-        </wsdl:operation>
-        <wsdl:operation name="deleteMessage">
-            <wsdl:input message="tns:deleteMessageRequest" wsaw:Action="urn:deleteMessage"/>
-        </wsdl:operation>
-        <wsdl:operation name="deleteFirstMessages">
-            <wsdl:input message="tns:deleteFirstMessagesRequest" wsaw:Action="urn:deleteFirstMessages"/>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessorDataList">
-            <wsdl:input message="tns:getMessageProcessorDataListRequest" wsaw:Action="urn:getMessageProcessorDataList"/>
-            <wsdl:output message="tns:getMessageProcessorDataListResponse" wsaw:Action="urn:getMessageProcessorDataListResponse"/>
         </wsdl:operation>
         <wsdl:operation name="getDefinedEndpoints">
             <wsdl:input message="tns:getDefinedEndpointsRequest" wsaw:Action="urn:getDefinedEndpoints"/>
             <wsdl:output message="tns:getDefinedEndpointsResponse" wsaw:Action="urn:getDefinedEndpointsResponse"/>
         </wsdl:operation>
+        <wsdl:operation name="deleteFirstMessages">
+            <wsdl:input message="tns:deleteFirstMessagesRequest" wsaw:Action="urn:deleteFirstMessages"/>
+        </wsdl:operation>
+        <wsdl:operation name="getMessage">
+            <wsdl:input message="tns:getMessageRequest" wsaw:Action="urn:getMessage"/>
+            <wsdl:output message="tns:getMessageResponse" wsaw:Action="urn:getMessageResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="deleteMessage">
+            <wsdl:input message="tns:deleteMessageRequest" wsaw:Action="urn:deleteMessage"/>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageProcessorNames">
+            <wsdl:input message="tns:getMessageProcessorNamesRequest" wsaw:Action="urn:getMessageProcessorNames"/>
+            <wsdl:output message="tns:getMessageProcessorNamesResponse" wsaw:Action="urn:getMessageProcessorNamesResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="getSize">
+            <wsdl:input message="tns:getSizeRequest" wsaw:Action="urn:getSize"/>
+            <wsdl:output message="tns:getSizeResponse" wsaw:Action="urn:getSizeResponse"/>
+        </wsdl:operation>
         <wsdl:operation name="resendAll">
             <wsdl:input message="tns:resendAllRequest" wsaw:Action="urn:resendAll"/>
         </wsdl:operation>
-        <wsdl:operation name="validateAxis2ClientRepo">
-            <wsdl:input message="tns:validateAxis2ClientRepoRequest" wsaw:Action="urn:validateAxis2ClientRepo" />
-            <wsdl:output message="tns:validateAxis2ClientRepoResponse" wsaw:Action="urn:validateAxis2ClientRepoResponse" />
+        <wsdl:operation name="deleteMessageProcessor">
+            <wsdl:input message="tns:deleteMessageProcessorRequest" wsaw:Action="urn:deleteMessageProcessor"/>
+        </wsdl:operation>
+        <wsdl:operation name="resend">
+            <wsdl:input message="tns:resendRequest" wsaw:Action="urn:resend"/>
+        </wsdl:operation>
+        <wsdl:operation name="activate">
+            <wsdl:input message="tns:activateRequest" wsaw:Action="urn:activate"/>
+        </wsdl:operation>
+        <wsdl:operation name="getEnvelope">
+            <wsdl:input message="tns:getEnvelopeRequest" wsaw:Action="urn:getEnvelope"/>
+            <wsdl:output message="tns:getEnvelopeResponse" wsaw:Action="urn:getEnvelopeResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="getClassName">
+            <wsdl:input message="tns:getClassNameRequest" wsaw:Action="urn:getClassName"/>
+            <wsdl:output message="tns:getClassNameResponse" wsaw:Action="urn:getClassNameResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageProcessorDataList">
+            <wsdl:input message="tns:getMessageProcessorDataListRequest" wsaw:Action="urn:getMessageProcessorDataList"/>
+            <wsdl:output message="tns:getMessageProcessorDataListResponse" wsaw:Action="urn:getMessageProcessorDataListResponse"/>
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="MessageProcessorAdminServiceSoap11Binding" type="tns:MessageProcessorAdminServicePortType">
         <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
-        <wsdl:operation name="resendFirstMessage">
-            <soap:operation soapAction="urn:resendFirstMessage" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getSize">
-            <soap:operation soapAction="urn:getSize" style="document"/>
+        <wsdl:operation name="getMessageProcessor">
+            <soap:operation soapAction="urn:getMessageProcessor" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -414,11 +459,32 @@
                 <soap:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>
+        <wsdl:operation name="popMessage">
+            <soap:operation soapAction="urn:popMessage" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="popAndRedirectMessage">
+            <soap:operation soapAction="urn:popAndRedirectMessage" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
         <wsdl:operation name="deleteAllMessages">
             <soap:operation soapAction="urn:deleteAllMessages" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="validateAxis2ClientRepo">
+            <soap:operation soapAction="urn:validateAxis2ClientRepo" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="isActive">
             <soap:operation soapAction="urn:isActive" style="document"/>
@@ -429,38 +495,17 @@
                 <soap:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>
+        <wsdl:operation name="deactivate">
+            <soap:operation soapAction="urn:deactivate" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
         <wsdl:operation name="modifyMessageProcessor">
             <soap:operation soapAction="urn:modifyMessageProcessor" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessor">
-            <soap:operation soapAction="urn:getMessageProcessor" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessorNames">
-            <soap:operation soapAction="urn:getMessageProcessorNames" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getEnvelope">
-            <soap:operation soapAction="urn:getEnvelope" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="getMessageIds">
             <soap:operation soapAction="urn:getMessageIds" style="document"/>
@@ -477,38 +522,20 @@
                 <soap:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="activate">
-            <soap:operation soapAction="urn:activate" style="document"/>
+        <wsdl:operation name="resendFirstMessage">
+            <soap:operation soapAction="urn:resendFirstMessage" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="deleteMessageProcessor">
-            <soap:operation soapAction="urn:deleteMessageProcessor" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getClassName">
-            <soap:operation soapAction="urn:getClassName" style="document"/>
+        <wsdl:operation name="getDefinedEndpoints">
+            <soap:operation soapAction="urn:getDefinedEndpoints" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
             <wsdl:output>
                 <soap:body use="literal"/>
             </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="deactivate">
-            <soap:operation soapAction="urn:deactivate" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="resend">
-            <soap:operation soapAction="urn:resend" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
         </wsdl:operation>
         <wsdl:operation name="deleteFirstMessages">
             <soap:operation soapAction="urn:deleteFirstMessages" style="document"/>
@@ -516,14 +543,8 @@
                 <soap:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="deleteMessage">
-            <soap:operation soapAction="urn:deleteMessage" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessorDataList">
-            <soap:operation soapAction="urn:getMessageProcessorDataList" style="document"/>
+        <wsdl:operation name="getMessage">
+            <soap:operation soapAction="urn:getMessage" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -531,8 +552,23 @@
                 <soap:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getDefinedEndpoints">
-            <soap:operation soapAction="urn:getDefinedEndpoints" style="document"/>
+        <wsdl:operation name="deleteMessage">
+            <soap:operation soapAction="urn:deleteMessage" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageProcessorNames">
+            <soap:operation soapAction="urn:getMessageProcessorNames" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getSize">
+            <soap:operation soapAction="urn:getSize" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -546,39 +582,89 @@
                 <soap:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="validateAxis2ClientRepo">
-            <soap:operation
-                    soapAction="http://service.processor.message.carbon.wso2.org/validateAxis2ClientRepo" />
+        <wsdl:operation name="deleteMessageProcessor">
+            <soap:operation soapAction="urn:deleteMessageProcessor" style="document"/>
             <wsdl:input>
-                <soap:body use="literal" />
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="resend">
+            <soap:operation soapAction="urn:resend" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="activate">
+            <soap:operation soapAction="urn:activate" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="getEnvelope">
+            <soap:operation soapAction="urn:getEnvelope" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
             </wsdl:input>
             <wsdl:output>
-                <soap:body use="literal" />
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getClassName">
+            <soap:operation soapAction="urn:getClassName" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageProcessorDataList">
+            <soap:operation soapAction="urn:getMessageProcessorDataList" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
     <wsdl:binding name="MessageProcessorAdminServiceSoap12Binding" type="tns:MessageProcessorAdminServicePortType">
         <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
-        <wsdl:operation name="resendFirstMessage">
-            <soap12:operation soapAction="urn:resendFirstMessage" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getSize">
-            <soap12:operation soapAction="urn:getSize" style="document"/>
+        <wsdl:operation name="getMessageProcessor">
+            <soap12:operation soapAction="urn:getMessageProcessor" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
             <wsdl:output>
                 <soap12:body use="literal"/>
             </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="popMessage">
+            <soap12:operation soapAction="urn:popMessage" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="popAndRedirectMessage">
+            <soap12:operation soapAction="urn:popAndRedirectMessage" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
         </wsdl:operation>
         <wsdl:operation name="deleteAllMessages">
             <soap12:operation soapAction="urn:deleteAllMessages" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="validateAxis2ClientRepo">
+            <soap12:operation soapAction="urn:validateAxis2ClientRepo" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="isActive">
             <soap12:operation soapAction="urn:isActive" style="document"/>
@@ -589,38 +675,17 @@
                 <soap12:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>
+        <wsdl:operation name="deactivate">
+            <soap12:operation soapAction="urn:deactivate" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
         <wsdl:operation name="modifyMessageProcessor">
             <soap12:operation soapAction="urn:modifyMessageProcessor" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessor">
-            <soap12:operation soapAction="urn:getMessageProcessor" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessorNames">
-            <soap12:operation soapAction="urn:getMessageProcessorNames" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getEnvelope">
-            <soap12:operation soapAction="urn:getEnvelope" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="getMessageIds">
             <soap12:operation soapAction="urn:getMessageIds" style="document"/>
@@ -637,38 +702,20 @@
                 <soap12:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="activate">
-            <soap12:operation soapAction="urn:activate" style="document"/>
+        <wsdl:operation name="resendFirstMessage">
+            <soap12:operation soapAction="urn:resendFirstMessage" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="deleteMessageProcessor">
-            <soap12:operation soapAction="urn:deleteMessageProcessor" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getClassName">
-            <soap12:operation soapAction="urn:getClassName" style="document"/>
+        <wsdl:operation name="getDefinedEndpoints">
+            <soap12:operation soapAction="urn:getDefinedEndpoints" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
             <wsdl:output>
                 <soap12:body use="literal"/>
             </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="deactivate">
-            <soap12:operation soapAction="urn:deactivate" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="resend">
-            <soap12:operation soapAction="urn:resend" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
         </wsdl:operation>
         <wsdl:operation name="deleteFirstMessages">
             <soap12:operation soapAction="urn:deleteFirstMessages" style="document"/>
@@ -676,14 +723,8 @@
                 <soap12:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="deleteMessage">
-            <soap12:operation soapAction="urn:deleteMessage" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessorDataList">
-            <soap12:operation soapAction="urn:getMessageProcessorDataList" style="document"/>
+        <wsdl:operation name="getMessage">
+            <soap12:operation soapAction="urn:getMessage" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -691,8 +732,23 @@
                 <soap12:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getDefinedEndpoints">
-            <soap12:operation soapAction="urn:getDefinedEndpoints" style="document"/>
+        <wsdl:operation name="deleteMessage">
+            <soap12:operation soapAction="urn:deleteMessage" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageProcessorNames">
+            <soap12:operation soapAction="urn:getMessageProcessorNames" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getSize">
+            <soap12:operation soapAction="urn:getSize" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -706,21 +762,56 @@
                 <soap12:body use="literal"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="validateAxis2ClientRepo">
-            <wsdl:input></wsdl:input>
-            <wsdl:output></wsdl:output>
+        <wsdl:operation name="deleteMessageProcessor">
+            <soap12:operation soapAction="urn:deleteMessageProcessor" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="resend">
+            <soap12:operation soapAction="urn:resend" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="activate">
+            <soap12:operation soapAction="urn:activate" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="getEnvelope">
+            <soap12:operation soapAction="urn:getEnvelope" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getClassName">
+            <soap12:operation soapAction="urn:getClassName" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageProcessorDataList">
+            <soap12:operation soapAction="urn:getMessageProcessorDataList" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
     <wsdl:binding name="MessageProcessorAdminServiceHttpBinding" type="tns:MessageProcessorAdminServicePortType">
         <http:binding verb="POST"/>
-        <wsdl:operation name="resendFirstMessage">
-            <http:operation location="resendFirstMessage"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getSize">
-            <http:operation location="getSize"/>
+        <wsdl:operation name="getMessageProcessor">
+            <http:operation location="getMessageProcessor"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -728,11 +819,32 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
+        <wsdl:operation name="popMessage">
+            <http:operation location="popMessage"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="popAndRedirectMessage">
+            <http:operation location="popAndRedirectMessage"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
         <wsdl:operation name="deleteAllMessages">
             <http:operation location="deleteAllMessages"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="validateAxis2ClientRepo">
+            <http:operation location="validateAxis2ClientRepo"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="isActive">
             <http:operation location="isActive"/>
@@ -743,38 +855,17 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
+        <wsdl:operation name="deactivate">
+            <http:operation location="deactivate"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
         <wsdl:operation name="modifyMessageProcessor">
             <http:operation location="modifyMessageProcessor"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessor">
-            <http:operation location="getMessageProcessor"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessorNames">
-            <http:operation location="getMessageProcessorNames"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getEnvelope">
-            <http:operation location="getEnvelope"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="getMessageIds">
             <http:operation location="getMessageIds"/>
@@ -791,38 +882,20 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="activate">
-            <http:operation location="activate"/>
+        <wsdl:operation name="resendFirstMessage">
+            <http:operation location="resendFirstMessage"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="deleteMessageProcessor">
-            <http:operation location="deleteMessageProcessor"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getClassName">
-            <http:operation location="getClassName"/>
+        <wsdl:operation name="getDefinedEndpoints">
+            <http:operation location="getDefinedEndpoints"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
             <wsdl:output>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="deactivate">
-            <http:operation location="deactivate"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="resend">
-            <http:operation location="resend"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
         </wsdl:operation>
         <wsdl:operation name="deleteFirstMessages">
             <http:operation location="deleteFirstMessages"/>
@@ -830,14 +903,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="deleteMessage">
-            <http:operation location="deleteMessage"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageProcessorDataList">
-            <http:operation location="getMessageProcessorDataList"/>
+        <wsdl:operation name="getMessage">
+            <http:operation location="getMessage"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -845,8 +912,23 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getDefinedEndpoints">
-            <http:operation location="getDefinedEndpoints"/>
+        <wsdl:operation name="deleteMessage">
+            <http:operation location="deleteMessage"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageProcessorNames">
+            <http:operation location="getMessageProcessorNames"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getSize">
+            <http:operation location="getSize"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -860,25 +942,61 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="validateAxis2ClientRepo">
-            <http:operation location="/validateAxis2ClientRepo" />
+        <wsdl:operation name="deleteMessageProcessor">
+            <http:operation location="deleteMessageProcessor"/>
             <wsdl:input>
-                <mime:content type="application/x-www-form-urlencoded" />
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="resend">
+            <http:operation location="resend"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="activate">
+            <http:operation location="activate"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="getEnvelope">
+            <http:operation location="getEnvelope"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
             <wsdl:output>
-                <mime:content type="text/xml" />
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getClassName">
+            <http:operation location="getClassName"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageProcessorDataList">
+            <http:operation location="getMessageProcessorDataList"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
     <wsdl:service name="MessageProcessorAdminService">
         <wsdl:port name="MessageProcessorAdminServiceHttpsSoap11Endpoint" binding="tns:MessageProcessorAdminServiceSoap11Binding">
-            <soap:address location="https://localhost:8243/services/MessageProcessorAdminService.MessageProcessorAdminServiceHttpsSoap11Endpoint"/>
+            <soap:address location="https://Mohameds-MacBook-Pro.local:8243/services/MessageProcessorAdminService.MessageProcessorAdminServiceHttpsSoap11Endpoint"/>
         </wsdl:port>
         <wsdl:port name="MessageProcessorAdminServiceHttpsSoap12Endpoint" binding="tns:MessageProcessorAdminServiceSoap12Binding">
-            <soap12:address location="https://localhost:8243/services/MessageProcessorAdminService.MessageProcessorAdminServiceHttpsSoap12Endpoint"/>
+            <soap12:address location="https://Mohameds-MacBook-Pro.local:8243/services/MessageProcessorAdminService.MessageProcessorAdminServiceHttpsSoap12Endpoint"/>
         </wsdl:port>
         <wsdl:port name="MessageProcessorAdminServiceHttpsEndpoint" binding="tns:MessageProcessorAdminServiceHttpBinding">
-            <http:address location="https://localhost:8243/services/MessageProcessorAdminService.MessageProcessorAdminServiceHttpsEndpoint"/>
+            <http:address location="https://Mohameds-MacBook-Pro.local:8243/services/MessageProcessorAdminService.MessageProcessorAdminServiceHttpsEndpoint"/>
         </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>


### PR DESCRIPTION
## Purpose
To add extra functionality to the Message Processor to manage messages. The Message Processor in the current build doesn't manage messages, which can be difficult incase of a poison message scenario. The functionality to view, pop or enqueue the message will be a useful addition to managing messages from the processor
## Goals
Add functionality to View, Pop and Enqueue the message to a different queue
## Approach
Managing the message will only work while the message processor is inactive. Clicking the view message button brings up a new page which will display the exact message sent to the end-point. Pop message will send an acknowledgment to the associated queue. Enqueue will pop and redirect the message to a different queue 