### PR TITLE
Update FTP and FTPS configuration logic in inbound endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2372,7 +2372,7 @@
         <carbon.rule.version>4.4.9</carbon.rule.version>
         <carbon.rule.imp.pkg.version>[4.4.0, 4.5.0)</carbon.rule.imp.pkg.version>
         <!-- Synapse Version -->
-        <synapse.version>2.1.7-wso2v84</synapse.version>
+        <synapse.version>2.1.7-wso2v85</synapse.version>
         <carbon.identity.entitlement.proxy.version>5.1.5</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.0.0, 6.0.0)</carbon.identity.entitlement.proxy.imp.pkg.version>
         <carbon.identity.oauth.version>6.0.53</carbon.identity.oauth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2401,7 +2401,7 @@
         <httpcore.wso2.version>4.3.3.wso2v1</httpcore.wso2.version>
         <httpcore-nio.wso2.version>4.3.3.wso2v4</httpcore-nio.wso2.version>
         <httpclient.wso2.version>4.3.6.wso2v2</httpclient.wso2.version>
-        <commons.vfs.version>2.2-wso2v4</commons.vfs.version>
+        <commons.vfs.version>2.2-wso2v5</commons.vfs.version>
         <httpcore.nio.version>4.3.3</httpcore.nio.version>
         <httpcore.version>4.3.3</httpcore.version>
         <httpclient.version>4.3.2</httpclient.version>


### PR DESCRIPTION
Use url parameters processing logic in synapse code base.
Fixes wso2/product-ei#2779

Add capability to specify url parameters for MoveAfterProcess and MoveAfterFailure parameters in inbound endpoint.
Fixes wso2/product-ei#3088

Update synapse version to 2.1.7-wso2v85

Update commons vfs version to 2.2-wso2v5