### PR TITLE
Fix undeploying faulty proxy service

### DIFF
--- a/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/SynapseAppDeployer.java
+++ b/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/SynapseAppDeployer.java
@@ -233,8 +233,10 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
                 artifactDir = getArtifactDirPath(axisConfig, artifactDirName);
             }
 
-            if (deployer != null && AppDeployerConstants.DEPLOYMENT_STATUS_DEPLOYED.
-                                            equals(artifact.getDeploymentStatus())) {
+            if (deployer != null && (
+                AppDeployerConstants.DEPLOYMENT_STATUS_DEPLOYED.equals(artifact.getDeploymentStatus()) ||
+                AppDeployerConstants.DEPLOYMENT_STATUS_FAILED.equals(artifact.getDeploymentStatus())
+               )) {
 
                 String fileName = artifact.getFiles().get(0).getName();
                 String artifactName = artifact.getName();

--- a/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/SynapseAppDeployer.java
+++ b/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/SynapseAppDeployer.java
@@ -19,6 +19,8 @@ package org.wso2.carbon.application.deployer.synapse;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMException;
+import org.apache.axiom.om.OMXMLBuilderFactory;
+import org.apache.axiom.om.OMXMLParserWrapper;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.deployment.Deployer;
@@ -39,11 +41,13 @@ import org.apache.synapse.config.xml.EntryFactory;
 import org.apache.synapse.config.xml.SynapseImportFactory;
 import org.apache.synapse.config.xml.SynapseImportSerializer;
 import org.apache.synapse.config.xml.XMLConfigConstants;
+import org.apache.synapse.config.xml.rest.APIFactory;
 import org.apache.synapse.deployers.LibraryArtifactDeployer;
 import org.apache.synapse.deployers.SynapseArtifactDeploymentStore;
 import org.apache.synapse.libraries.imports.SynapseImport;
 import org.apache.synapse.libraries.model.Library;
 import org.apache.synapse.libraries.util.LibDeployerUtils;
+import org.apache.synapse.rest.API;
 import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 import org.wso2.carbon.application.deployer.AppDeployerConstants;
 import org.wso2.carbon.application.deployer.AppDeployerUtils;
@@ -63,14 +67,18 @@ import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Paths;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -242,6 +250,24 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
                 String artifactName = artifact.getName();
                 String artifactPath = artifact.getExtractedPath() + File.separator + fileName;
                 File artifactInRepo = new File(artifactDir + File.separator + fileName);
+
+                // In case of an API, there may have a version strategy and the name of the API will have
+                // that version in his name in the synapse config (ex: MyAPI:v1 instead of MyAPI)
+                if (SynapseAppDeployerConstants.API_TYPE.equals(artifact.getType())){
+                    String fullFilePath = Paths.get(artifact.getExtractedPath(), fileName).toString();
+                    try {
+                        // To create the API, we must first read it's configuration fron the artifact file
+                        InputStream in = new FileInputStream(fullFilePath);
+                        OMXMLParserWrapper builder = OMXMLBuilderFactory.createOMBuilder(in);
+                        OMElement artifactConfig = builder.getDocumentElement();
+                        in.close();
+                        // Create the API to get the real name
+                        API api = APIFactory.createAPI(artifactConfig, new Properties());
+                        artifactName = api.getName();
+                    } catch (Exception e) {
+                        log.warn("Could not find the complete API name (with version), artifact file doesn't exist : " + fullFilePath, e);
+                    }
+                }
 
                 try {
                     if (SynapseAppDeployerConstants.MEDIATOR_TYPE.endsWith(artifact.getType())) {


### PR DESCRIPTION
When a proxy service is deployed with a faulty security policy reference, the proxy service is correctly initialized and added to the synapse configuration. The build then fails when building the axis2 service.

The proxy service is marked as failed and not removed from the synapse configuration. When redeploying the same service, it is picked up as already deployed, but the proxy service doesn't work.

This fixes this problem by also undeploying failed proxy services so they are removed from the synapse configuration.

Fixes https://github.com/wso2/product-ei/issues/2525