### PR TITLE
Allow valid characters for secure vault key

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.mediation.security.ui/src/main/resources/web/mediation_secure_vault/js/properties.js
+++ b/components/mediation-ui/org.wso2.carbon.mediation.security.ui/src/main/resources/web/mediation_secure_vault/js/properties.js
@@ -292,7 +292,7 @@ function validateEmptySV(fld, fldName) {
 function validateForInputSV(fld, fldName) {
   	var error = "";
   	// This regex includes patterns for characters which should not include in the vault key
-	var illegalChars = /[~!@#$%^&*()\\\/+=\:;<>'"?[\]{}|\s,]/;
+	var illegalChars = /[&<>'"]/;
 	if (illegalChars.test(fld.value)) {
 		error = "The " + fldName + " has illegal characters";
 	}


### PR DESCRIPTION
Previuous PR
[wso2/carbon-mediation#851](https://github.com/wso2/carbon-mediation/pull/851) changed the secure vault filtering to filter !@#$%^&*()/+=:;<>'"?[]{}|\s, charachters from the key string. But, XML only need to filter & < > " ' characters. ESB versions had validation for key name starts with standard english character or number with any character in middle.

Fix https://github.com/wso2/product-ei/issues/3177