### PR TITLE
Fix surefire plugin version in AS4 connector

### DIFF
--- a/components/mediation-connector/org.wso2.carbon.mediation.connector.as4/pom.xml
+++ b/components/mediation-connector/org.wso2.carbon.mediation.connector.as4/pom.xml
@@ -218,7 +218,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
                 <inherited>false</inherited>
                 <configuration>
                     <!-- <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m -Xdebug


### PR DESCRIPTION
This fix is needed for AS4 connector tests to work. Now the surefire pluging version is inherited from the parent pom.