### PR TITLE
Fix undeployment of versioned APIs

### DIFF
--- a/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/SynapseAppDeployer.java
+++ b/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/SynapseAppDeployer.java
@@ -19,6 +19,8 @@ package org.wso2.carbon.application.deployer.synapse;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMException;
+import org.apache.axiom.om.OMXMLBuilderFactory;
+import org.apache.axiom.om.OMXMLParserWrapper;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.deployment.Deployer;
@@ -39,11 +41,13 @@ import org.apache.synapse.config.xml.EntryFactory;
 import org.apache.synapse.config.xml.SynapseImportFactory;
 import org.apache.synapse.config.xml.SynapseImportSerializer;
 import org.apache.synapse.config.xml.XMLConfigConstants;
+import org.apache.synapse.config.xml.rest.APIFactory;
 import org.apache.synapse.deployers.LibraryArtifactDeployer;
 import org.apache.synapse.deployers.SynapseArtifactDeploymentStore;
 import org.apache.synapse.libraries.imports.SynapseImport;
 import org.apache.synapse.libraries.model.Library;
 import org.apache.synapse.libraries.util.LibDeployerUtils;
+import org.apache.synapse.rest.API;
 import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 import org.wso2.carbon.application.deployer.AppDeployerConstants;
 import org.wso2.carbon.application.deployer.AppDeployerUtils;
@@ -63,14 +67,18 @@ import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Paths;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -240,6 +248,24 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
                 String artifactName = artifact.getName();
                 String artifactPath = artifact.getExtractedPath() + File.separator + fileName;
                 File artifactInRepo = new File(artifactDir + File.separator + fileName);
+
+                // In case of an API, there may have a version strategy and the name of the API will have
+                // that version in his name in the synapse config (ex: MyAPI:v1 instead of MyAPI)
+                if (SynapseAppDeployerConstants.API_TYPE.equals(artifact.getType())){
+                    String fullFilePath = Paths.get(artifact.getExtractedPath(), fileName).toString();
+                    try {
+                        // To create the API, we must first read it's configuration fron the artifact file
+                        InputStream in = new FileInputStream(fullFilePath);
+                        OMXMLParserWrapper builder = OMXMLBuilderFactory.createOMBuilder(in);
+                        OMElement artifactConfig = builder.getDocumentElement();
+                        in.close();
+                        // Create the API to get the real name
+                        API api = APIFactory.createAPI(artifactConfig, new Properties());
+                        artifactName = api.getName();
+                    } catch (Exception e) {
+                        log.warn("Could not find the complete API name (with version), artifact file doesn't exist : " + fullFilePath, e);
+                    }
+                }
 
                 try {
                     if (SynapseAppDeployerConstants.MEDIATOR_TYPE.endsWith(artifact.getType())) {


### PR DESCRIPTION
## Purpose
Fixes the issue of APIs with a versioning strategy relying inside a Capp being not undeployed when undeploying the Capp.
Resolves: https://github.com/wso2/product-ei/issues/3340
Related to: https://github.com/wso2/carbon-mediation/pull/1125
