### PR TITLE
Move identity entitlement stub dependency to carbon commons

### DIFF
--- a/components/mediators/entitlement/org.wso2.carbon.identity.entitlement.mediator/pom.xml
+++ b/components/mediators/entitlement/org.wso2.carbon.identity.entitlement.mediator/pom.xml
@@ -53,7 +53,7 @@
             <artifactId>org.wso2.carbon.logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.commons</groupId>
             <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
         </dependency>
         <dependency>
@@ -97,7 +97,7 @@
 			    !org.pache.axis2.databinding.utils.writer,
                             !org.wso2.carbon.identity.entitlement.mediator.*,
 			    org.wso2.carbon.identity.entitlement.proxy.*,
-                            org.wso2.carbon.identity.entitlement.stub.*;version="${carbon.identity.imp.pkg.version}",
+                            org.wso2.carbon.identity.entitlement.stub.*;version="${carbon.commons.imp.pkg.version}",
                             org.wso2.carbon.authenticator.stub.*;version="${carbon.kernel.imp.pkg.version}",
                             *; resolution:=optional
                         </Import-Package>

--- a/features/mediator-features/entitlement-mediator-feature/org.wso2.carbon.identity.entitlement.mediator.feature/pom.xml
+++ b/features/mediator-features/entitlement-mediator-feature/org.wso2.carbon.identity.entitlement.mediator.feature/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.identity.entitlement.proxy</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.commons</groupId>
             <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
         </dependency>
         <dependency>
@@ -73,9 +73,8 @@
                             </adviceFile>
                             <bundles>
                                 <bundleDef>libthrift.wso2:libthrift</bundleDef>
-                                <bundleDef>org.wso2.carbon.identity.agent.entitlement.mediator:org.wso2.carbon.identity.entitlement.proxy</bundleDef>
                                 <bundleDef>org.wso2.carbon.mediation:org.wso2.carbon.identity.entitlement.mediator</bundleDef>
-                                <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.entitlement.stub</bundleDef>
+                                <bundleDef>org.wso2.carbon.commons:org.wso2.carbon.identity.entitlement.stub</bundleDef>
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.authenticator.stub</bundleDef>
                                 <bundleDef>slf4j.wso2:slf4j</bundleDef>
                             </bundles>

--- a/pom.xml
+++ b/pom.xml
@@ -652,9 +652,9 @@
                 <version>${carbon.identity.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <groupId>org.wso2.carbon.commons</groupId>
                 <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
-                <version>${carbon.identity.version}</version>
+                <version>${carbon.commons.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>


### PR DESCRIPTION
This is done to remove duplicate jars :- https://github.com/wso2/product-ei/issues/2061

Related PR https://github.com/wso2/carbon-commons/pull/345

