### PR TITLE
Add feature to expose statistical data from ESB to Prometheus

### DIFF
--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/pom.xml
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.mediation</groupId>
+        <artifactId>data-agents</artifactId>
+        <version>4.6.138-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.prometheus.publisher</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Prometheus - Data Publisher</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Axis2Module>${project.artifactId}-${project.version}</Axis2Module>
+                        <Export-Package>
+                            org.wso2.carbon.prometheus.publisher.*
+                        </Export-Package>
+                        <Import-Package>
+                            org.wso2.carbon.inbound.endpoint.internal.http.api,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>jsr311-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.mediation</groupId>
+            <artifactId>org.wso2.carbon.inbound.endpoint</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.mediation</groupId>
+            <artifactId>org.wso2.carbon.integrator.core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/model/PrometheusMetric.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/model/PrometheusMetric.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.prometheus.publisher.model;
+
+import org.wso2.carbon.prometheus.publisher.util.PrometheusPublisherConstants;
+
+/**
+ * Model class for metrics in Prometheus format
+ */
+public class PrometheusMetric {
+
+    private static final String DELIMITER = " ";
+    private static final String NEW_LINE = "\n";
+    private String metricName;
+    private String help;
+    private String type;
+    private Double metricValue;
+    private String propertyString;
+
+    /**
+     * Formats the metric data into Prometheus format
+     *
+     * @param metric Metric object
+     * @return Formatted metric string
+     */
+    public static String formatMetric(PrometheusMetric metric) {
+
+        if (metricDataExist(metric)) {
+            return formatMetricHelp(metric) +
+                    formatMetricType(metric) +
+                    metric.getMetricName() +
+                    metric.getPropertyString() +
+                    DELIMITER +
+                    metric.getMetricValue()
+                    + NEW_LINE;
+        }
+        return "";
+    }
+
+    private static boolean metricDataExist(PrometheusMetric metric) {
+
+        return valuesExist(metric.getMetricName()) && metric.getMetricValue() != null;
+    }
+
+    private static boolean valuesExist(String value) {
+
+        return value != null && !value.isEmpty();
+    }
+
+    private static String formatMetricHelp(PrometheusMetric metric) {
+
+        if (metric.getHelp() != null && !metric.getHelp().isEmpty()) {
+            return PrometheusPublisherConstants.PROMETHEUS_HELP_TAG + metric.getMetricName() +
+                    DELIMITER + metric.getHelp() + NEW_LINE;
+        }
+        return "";
+    }
+
+    private static String formatMetricType(PrometheusMetric metric) {
+
+        if (metric.getType() != null && !metric.getType().isEmpty()) {
+            return PrometheusPublisherConstants.PROMETHEUS_TYPE_TAG + metric.getMetricName() +
+                    DELIMITER + metric.getType() + NEW_LINE;
+        }
+        return "";
+    }
+
+    public String getMetricName() {
+
+        return metricName;
+    }
+
+    public void setMetricName(String metricName) {
+
+        this.metricName = metricName;
+    }
+
+    public String getHelp() {
+
+        return help;
+    }
+
+    public void setHelp(String help) {
+
+        this.help = help;
+    }
+
+    public String getType() {
+
+        return type;
+    }
+
+    public void setType(String type) {
+
+        this.type = type;
+    }
+
+    public Double getMetricValue() {
+
+        return metricValue;
+    }
+
+    public void setMetricValue(Double metricValue) {
+
+        this.metricValue = metricValue;
+    }
+
+    public String getPropertyString() {
+
+        return propertyString;
+    }
+
+    public void setPropertyString(String propertyString) {
+
+        this.propertyString = propertyString;
+    }
+}

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/publisher/MetricCollector.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/publisher/MetricCollector.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.prometheus.publisher.publisher;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.prometheus.publisher.model.PrometheusMetric;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+/**
+ * Scrapes, collects and formats JMS metric data into Prometheus format
+ */
+class MetricCollector {
+
+    private static final Log LOGGER = LogFactory.getLog(MetricCollector.class);
+
+    private static final String SYNAPSE_DOMAIN_NAME = "org.apache.synapse:*";
+    private static final String METRIC_TYPE_UNTYPED = "untyped";
+    private static final String SEPARATOR = "_";
+    private static final Pattern PROPERTY_PATTERN = Pattern.compile(
+            "([^,=:*?]+)" + // Name - non-empty, anything but comma, equals, colon, star, or question mark
+                    "=" +  // Equals
+                    "(" + // Either
+                    "\"" + // Quoted
+                    "(?:" + // A possibly empty sequence of
+                    "[^\\\\\"]*" + // Greedily match anything but backslash or quote
+                    "(?:\\\\.)?" + // Greedily see if we can match an escaped sequence
+                    ")*" +
+                    "\"" +
+                    "|" + // Or
+                    "[^,=:\"]*" + // Unquoted - can be empty, anything but comma, equals, colon, or quote
+                    ")");
+
+    /**
+     * Collects metric data from JMX MBeans
+     *
+     * @return Metric data in Prometheus format
+     */
+    List<String> collect() {
+
+        List<PrometheusMetric> metricList = new ArrayList<>();
+        Map<ObjectName, LinkedHashMap<String, String>> keyPropertiesPerBean = new ConcurrentHashMap<>();
+
+        try {
+
+            MBeanServer beanServer = ManagementFactory.getPlatformMBeanServer();
+
+            Set<ObjectName> mBeanNames = new HashSet<>();
+
+            // get filtered MBean names for Synapse domain
+            ObjectName synapseFilterName = new ObjectName(SYNAPSE_DOMAIN_NAME);
+            for (ObjectInstance instance : beanServer.queryMBeans(synapseFilterName, null)) {
+                mBeanNames.add(instance.getObjectName());
+            }
+
+            // scrape each MBean
+            for (ObjectName beanName : mBeanNames) {
+                List<PrometheusMetric> metrics = scrapeBean(beanServer, beanName, keyPropertiesPerBean);
+                if (metrics != null && !metrics.isEmpty()) {
+                    metricList.addAll(metrics);
+                }
+            }
+
+            // sort metrics so that related metrics are grouped together
+            if (!metricList.isEmpty()) {
+                Collections.sort(metricList, new Comparator<PrometheusMetric>() {
+                    @Override
+                    public int compare(final PrometheusMetric object1, final PrometheusMetric object2) {
+
+                        return object1.getMetricName().compareTo(object2.getMetricName());
+                    }
+                });
+
+                // remove help and type tags for metrics with same name
+                for (int i = 1; i < metricList.size(); i++) {
+                    if (metricList.get(i).getMetricName().equals(metricList.get(i - 1).getMetricName())) {
+                        metricList.get(i).setHelp("");
+                        metricList.get(i).setType("");
+                    }
+                }
+
+                // convert metric data into Prometheus format
+                List<String> metrics = new ArrayList<>();
+                for (PrometheusMetric metric : metricList) {
+                    metrics.add(PrometheusMetric.formatMetric(metric));
+                }
+
+                return metrics;
+            }
+
+        } catch (MalformedObjectNameException e) {
+            LOGGER.error("Error in retrieving metric data from JMX MBeans: ", e);
+        }
+        return Collections.emptyList();
+    }
+
+    private List<PrometheusMetric> scrapeBean(MBeanServer beanServer, ObjectName beanName, Map<ObjectName,
+            LinkedHashMap<String, String>> keyPropertiesPerBean) {
+
+        try {
+            // get attributes of each bean
+            MBeanInfo beanInfo = beanServer.getMBeanInfo(beanName);
+            MBeanAttributeInfo[] beanAttributes = beanInfo.getAttributes();
+            Map<String, MBeanAttributeInfo> attributeMap = new HashMap<>();
+            for (MBeanAttributeInfo attribute : beanAttributes) {
+                if (attribute.isReadable()) {
+                    attributeMap.put(attribute.getName(), attribute);
+                }
+            }
+            AttributeList attributes = beanServer.getAttributes(beanName,
+                    attributeMap.keySet().toArray(new String[0]));
+
+            List<PrometheusMetric> metrics = new ArrayList<>();
+
+            // process bean attributes
+            for (Attribute attribute : attributes.asList()) {
+                MBeanAttributeInfo attributeInfo = attributeMap.get(attribute.getName());
+                PrometheusMetric metric = processBeanValue(toSnakeAndLowerCase(beanName.getDomain()),
+                        toSnakeAndLowerCase(attributeInfo.getName()),
+                        attributeInfo.getDescription(), attribute.getValue(),
+                        getKeyPropertyList(keyPropertiesPerBean, beanName));
+                if (metric != null) {
+                    metrics.add(metric);
+                }
+            }
+            return metrics;
+        } catch (ReflectionException | IntrospectionException | InstanceNotFoundException e) {
+            LOGGER.error("Error in scraping bean - " + beanName.toString(), e);
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Convert metric name into Prometheus format
+     *
+     * @param attrName Metric name
+     * @return Formatted name
+     */
+    private String toSnakeAndLowerCase(String attrName) {
+
+        if (attrName == null || attrName.isEmpty()) {
+            return attrName;
+        }
+        char firstChar = attrName.subSequence(0, 1).charAt(0);
+        boolean prevCharIsUpperCaseOrUnderscore = Character.isUpperCase(firstChar) || firstChar == '_';
+        StringBuilder resultBuilder =
+                new StringBuilder(attrName.length()).append(Character.toLowerCase(firstChar));
+        for (char attrChar : attrName.substring(1).toCharArray()) {
+            boolean charIsUpperCase = Character.isUpperCase(attrChar);
+            if (attrChar == '.' || attrChar == '-') {
+                resultBuilder.append("_");
+            } else {
+                if (!prevCharIsUpperCaseOrUnderscore && charIsUpperCase) {
+                    resultBuilder.append("_");
+                }
+                resultBuilder.append(Character.toLowerCase(attrChar));
+            }
+            prevCharIsUpperCaseOrUnderscore = charIsUpperCase || attrChar == '_';
+        }
+        return resultBuilder.toString();
+    }
+
+    private PrometheusMetric processBeanValue(String domain, String attributeName, String attributeDesc,
+                                              Object attributeValue, LinkedHashMap<String, String> beanProperties) {
+
+        String beanName = "MBean attribute " + domain + SEPARATOR + attributeName;
+        if (attributeValue == null) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(beanName + " has value null");
+            }
+        } else if (attributeValue instanceof Number || attributeValue instanceof String ||
+                attributeValue instanceof Boolean) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Recording MBean attribute " + domain + SEPARATOR + attributeName);
+            }
+            return recordBean(domain, attributeName, attributeDesc, attributeValue, beanProperties);
+        } else if (attributeValue.getClass().isArray()) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(beanName + " value is not supported");
+            }
+        } else {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(beanName + " is not exported");
+            }
+        }
+        return null;
+    }
+
+    private PrometheusMetric recordBean(String domain, String attributeName, String attributeDesc,
+                                        Object attributeValue, LinkedHashMap<String, String> beanProperties) {
+
+        if (isDoubleParsable(attributeValue.toString())) {
+            PrometheusMetric prometheusMetric = new PrometheusMetric();
+            prometheusMetric.setMetricName(toSnakeAndLowerCase(formatMetricName(domain, attributeName,
+                    beanProperties)));
+            prometheusMetric.setType(METRIC_TYPE_UNTYPED);
+            prometheusMetric.setHelp(attributeDesc);
+            prometheusMetric.setMetricValue(Double.valueOf(attributeValue.toString()));
+
+            StringBuilder propString = new StringBuilder();
+            propString.append("{");
+            int i = 0;
+            for (Map.Entry entry : beanProperties.entrySet()) {
+                propString.append(entry.getKey()).append("=\"").append(entry.getValue()).append("\"");
+                if (i < beanProperties.size() - 1) {
+                    propString.append(", ");
+                } else if (i == beanProperties.size() - 1) {
+                    propString.append("}");
+                }
+                i++;
+            }
+            prometheusMetric.setPropertyString(propString.toString());
+            return prometheusMetric;
+        }
+        return null;
+    }
+
+    private String formatMetricName(String domain, String attributeName,
+                                    LinkedHashMap<String, String> beanProperties) {
+
+        StringBuilder name = new StringBuilder();
+        name.append(domain);
+        if (beanProperties.size() > 0) {
+            name.append(SEPARATOR);
+            name.append(beanProperties.values().iterator().next());
+        }
+        name.append(SEPARATOR).append(attributeName);
+        return name.toString();
+    }
+
+    private boolean isDoubleParsable(String value) {
+
+        final String Digits = "(\\p{Digit}+)";
+        final String HexDigits = "(\\p{XDigit}+)";
+        // an exponent is 'e' or 'E' followed by an optionally
+        // signed decimal integer.
+        final String Exp = "[eE][+-]?" + Digits;
+        final String fpRegex =
+                ("[\\x00-\\x20]*" + // Optional leading "whitespace"
+                        "[+-]?(" +         // Optional sign character
+                        "NaN|" +           // "NaN" string
+                        "Infinity|" +      // "Infinity" string
+
+                        // A decimal floating-point string representing a finite positive
+                        // number without a leading sign has at most five basic pieces:
+                        // Digits . Digits ExponentPart FloatTypeSuffix
+                        //
+                        // Since this method allows integer-only strings as input
+                        // in addition to strings of floating-point literals, the
+                        // two sub-patterns below are simplifications of the grammar
+                        // productions from the Java Language Specification, 2nd
+                        // edition, section 3.10.2.
+
+                        // Digits ._opt Digits_opt ExponentPart_opt FloatTypeSuffix_opt
+                        "(((" + Digits + "(\\.)?(" + Digits + "?)(" + Exp + ")?)|" +
+
+                        // . Digits ExponentPart_opt FloatTypeSuffix_opt
+                        "(\\.(" + Digits + ")(" + Exp + ")?)|" +
+
+                        // Hexadecimal strings
+                        "((" +
+                        // 0[xX] HexDigits ._opt BinaryExponent FloatTypeSuffix_opt
+                        "(0[xX]" + HexDigits + "(\\.)?)|" +
+
+                        // 0[xX] HexDigits_opt . HexDigits BinaryExponent FloatTypeSuffix_opt
+                        "(0[xX]" + HexDigits + "?(\\.)" + HexDigits + ")" +
+
+                        ")[pP][+-]?" + Digits + "))" +
+                        "[fFdD]?))" +
+                        // Optional trailing "whitespace"
+                        "[\\x00-\\x20]*");
+
+        return Pattern.matches(fpRegex, value);
+    }
+
+    /**
+     * Returns the list of labels and their values of each metric, which are the key properties of mBeans
+     *
+     * @param mBeanName Bean name
+     * @return Map of key properties and their values
+     */
+    private LinkedHashMap<String, String> getKeyPropertyList(Map<ObjectName, LinkedHashMap<String, String>>
+                                                                     keyPropertiesPerBean, ObjectName mBeanName) {
+
+        LinkedHashMap<String, String> keyProperties = keyPropertiesPerBean.get(mBeanName);
+        if (keyProperties == null) {
+            keyProperties = new LinkedHashMap<>();
+            String properties = mBeanName.getKeyPropertyListString();
+            Matcher match = PROPERTY_PATTERN.matcher(properties);
+            while (match.lookingAt()) {
+                keyProperties.put(match.group(1), match.group(2));
+                properties = properties.substring(match.end());
+                if (properties.startsWith(",")) {
+                    properties = properties.substring(1);
+                }
+                match.reset(properties);
+            }
+            keyPropertiesPerBean.put(mBeanName, keyProperties);
+        }
+        return keyProperties;
+    }
+}

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/publisher/MetricPublisher.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/publisher/MetricPublisher.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.prometheus.publisher.publisher;
+
+import java.util.List;
+
+/**
+ * Retrieves metric data from the single instance of MetricCollector
+ */
+public class MetricPublisher {
+
+    /**
+     * @return Metric data list
+     */
+    public List<String> getMetrics() {
+
+        return new MetricCollector().collect();
+    }
+}

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/service/MetricAPI.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/service/MetricAPI.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.prometheus.publisher.service;
+
+import org.wso2.carbon.inbound.endpoint.internal.http.api.APIResource;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPI;
+
+/**
+ * Internal API class for API exposing metric data
+ */
+public class MetricAPI implements InternalAPI {
+
+    private String name;
+
+    @Override
+    public APIResource[] getResources() {
+
+        APIResource[] resources = new APIResource[1];
+        resources[0] = new MetricResource("/metrics");
+        return resources;
+    }
+
+    @Override
+    public String getContext() {
+
+        return "/metric-service";
+    }
+
+    @Override
+    public String getName() {
+
+        return this.name;
+    }
+
+    @Override
+    public void setName(String name) {
+
+        this.name = name;
+    }
+}

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/service/MetricResource.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/service/MetricResource.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.prometheus.publisher.service;
+
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMElement;
+import org.apache.axis2.Constants;
+import org.apache.axis2.transport.base.BaseConstants;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.commons.util.MiscellaneousUtil;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.APIResource;
+import org.wso2.carbon.integrator.core.handler.BasicAuthConstants;
+import org.wso2.carbon.prometheus.publisher.publisher.MetricPublisher;
+import org.wso2.carbon.prometheus.publisher.util.PrometheusPublisherConstants;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import javax.xml.namespace.QName;
+
+/**
+ * Resource class for endpoint exposing metric data
+ */
+public class MetricResource extends APIResource {
+
+    private static Log log = LogFactory.getLog(MetricResource.class);
+    private MetricPublisher metricPublisher;
+
+    public MetricResource(String urlTemplate) {
+
+        super(urlTemplate);
+        metricPublisher = new MetricPublisher();
+    }
+
+    @Override
+    public Set<String> getMethods() {
+
+        Set<String> methods = new HashSet<>();
+        methods.add("GET");
+        return methods;
+    }
+
+    @Override
+    public boolean invoke(MessageContext synCtx) {
+
+        buildMessage(synCtx);
+        synCtx.setProperty("Success", true);
+
+        OMElement textRootElem =
+                OMAbstractFactory.getOMFactory().createOMElement(BaseConstants.DEFAULT_TEXT_WRAPPER);
+
+        if (isPublishingEnabled()) {
+
+            if (log.isDebugEnabled()) {
+                log.debug("Retrieving metric data to be published to Prometheus");
+            }
+
+            List<String> metrics = metricPublisher.getMetrics();
+
+            if (metrics != null && !metrics.isEmpty()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Retrieving metric data successful");
+                }
+                textRootElem.setText(String.join("", metrics));
+            } else {
+                textRootElem.setText("");
+                log.info("No metrics retrieved to be published to Prometheus");
+            }
+        } else {
+            textRootElem.setText("");
+        }
+
+        synCtx.getEnvelope().getBody().addChild(textRootElem);
+
+        org.apache.axis2.context.MessageContext axisCtx =
+                ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+        axisCtx.setProperty(Constants.Configuration.MESSAGE_TYPE, "text/plain");
+        axisCtx.setProperty(Constants.Configuration.CONTENT_TYPE, "text/plain");
+        axisCtx.removeProperty(BasicAuthConstants.NO_ENTITY_BODY);
+
+        return true;
+    }
+
+    /**
+     * Reads config data from prometheus-conf.xml
+     */
+    private boolean isPublishingEnabled() {
+
+        OMElement apiConfig = MiscellaneousUtil.loadXMLConfig(PrometheusPublisherConstants.PROMETHEUS_CONFIG_FILE);
+        QName root = new QName(PrometheusPublisherConstants.STAT_CONFIG_ELEMENT);
+        QName enableElement = new QName(PrometheusPublisherConstants.PROMETHEUS_PUBLISHING_ENABLED);
+
+        if (apiConfig != null) {
+            if (!root.toString().equals(apiConfig.getLocalName())) {
+                log.error("Invalid Prometheus configuration file");
+                return false;
+            }
+            Iterator iterator = apiConfig.getChildrenWithName(enableElement);
+            if (iterator.hasNext()) {
+                OMElement enabled = (OMElement) iterator.next();
+                return Boolean.parseBoolean(enabled.getText());
+            }
+        }
+        return false;
+    }
+}

--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/util/PrometheusPublisherConstants.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.prometheus.publisher/src/main/java/org/wso2/carbon/prometheus/publisher/util/PrometheusPublisherConstants.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.prometheus.publisher.util;
+
+/**
+ * Constants required in exposing metric data
+ */
+public class PrometheusPublisherConstants {
+
+    private PrometheusPublisherConstants() {
+
+    }
+
+    public static final String PROMETHEUS_CONFIG_FILE = "prometheus-conf.xml";
+
+    public static final String STAT_CONFIG_ELEMENT = "PrometheusPublishingConfig";
+    public static final String PROMETHEUS_PUBLISHING_ENABLED = "Enabled";
+
+    public static final String PROMETHEUS_HELP_TAG = "# HELP ";
+    public static final String PROMETHEUS_TYPE_TAG = "# TYPE ";
+}

--- a/components/mediation-monitor/mediation-data-publisher/pom.xml
+++ b/components/mediation-monitor/mediation-data-publisher/pom.xml
@@ -35,6 +35,7 @@
                 <!-- DAS Publisher modules -->
                 <module>org.wso2.carbon.das.data.publisher.util</module>
                 <module>org.wso2.carbon.das.messageflow.data.publisher</module>
+                <module>org.wso2.carbon.prometheus.publisher</module>
             </modules>
 
 </project>

--- a/features/mediation-monitor-features/mediation-data-publisher-features/pom.xml
+++ b/features/mediation-monitor-features/mediation-data-publisher-features/pom.xml
@@ -33,6 +33,7 @@
 
     <modules>
         <module>messageflow</module>
+        <module>prometheus-publisher-feature</module>
     </modules>
 
 </project>

--- a/features/mediation-monitor-features/mediation-data-publisher-features/prometheus-publisher-feature/pom.xml
+++ b/features/mediation-monitor-features/mediation-data-publisher-features/prometheus-publisher-feature/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>data-agents-features</artifactId>
+        <groupId>org.wso2.carbon.mediation</groupId>
+        <version>4.6.138-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.prometheus.publisher.feature</artifactId>
+    <packaging>pom</packaging>
+    <name>WSO2 Carbon - Prometheus Publisher Feature</name>
+    <url>http://wso2.org</url>
+
+    <description>
+        This feature contains the core bundles required for publishing statistical data to Prometheus
+    </description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>carbon-p2-plugin</artifactId>
+                <version>${carbon.p2.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>4-p2-feature-generation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>p2-feature-gen</goal>
+                        </goals>
+                        <configuration>
+                            <id>org.wso2.carbon.prometheus.publisher</id>
+                            <propertiesFile>../../../../etc/feature.properties</propertiesFile>
+                            <bundles>
+                                <bundleDef>
+                                    org.wso2.carbon.mediation:org.wso2.carbon.prometheus.publisher:${carbon.mediation.version}
+                                </bundleDef>
+                            </bundles>
+
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -584,6 +584,12 @@
                 <artifactId>org.wso2.carbon.core.services</artifactId>
                 <version>${carbon.kernel.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.base</artifactId>
+                <version>${carbon.kernel.version}</version>
+                <scope>compile</scope>
+            </dependency>
             <!--5 Carbon-Registry -->
             <dependency>
                 <groupId>org.wso2.carbon.registry</groupId>
@@ -1968,6 +1974,11 @@
                 <version>${javax.ws.rs.version}</version>
             </dependency>
             <dependency>
+                <groupId>javax.ws.rs</groupId>
+                <artifactId>jsr311-api</artifactId>
+                <version>${javax.jsr311.api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.orbit.com.jcraft</groupId>
                 <artifactId>jsch</artifactId>
                 <version>${jsch.wso2.version}</version>
@@ -2511,6 +2522,7 @@
         <javax.servlet.http.imp.pkg.version>[2.4.0, 3.0.0)</javax.servlet.http.imp.pkg.version>
         <javax.xml.stream.imp.pkg.version>[1.0.1, 1.1.0)</javax.xml.stream.imp.pkg.version>
         <javax.xml.soap.imp.pkg.version>[1.0.0, 1.1.0)</javax.xml.soap.imp.pkg.version>
+        <javax.jsr311.api.version>1.1.1</javax.jsr311.api.version>
         <!--<org.apache.commons.logging.version>[1.1.0, 1.2.0)</org.apache.commons.logging.version>-->
         <org.apache.commons.logging.version>1.1.1</org.apache.commons.logging.version>
         <project.scm.id>wso2-scm-server</project.scm.id>


### PR DESCRIPTION
## Purpose
> Enable ESB to expose statistical data to Prometheus.

## Related PRs: 
> [#3399](https://github.com/wso2/product-ei/pull/3399)

## Related Issue: 
> [#3229](https://github.com/wso2/product-ei/issues/3229) 