### PR TITLE
Add Internal HTTP API framework 

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/pom.xml
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/pom.xml
@@ -118,6 +118,7 @@
                             org.wso2.carbon.inbound.endpoint.protocol.http.multitenancy,
                             org.wso2.carbon.inbound.endpoint.protocol.generic,
                             org.wso2.carbon.inbound.endpoint.protocol.hl7,
+                            org.wso2.carbon.inbound.endpoint.internal.http.api,
                             org.wso2.carbon.inbound.endpoint
                         </Export-Package>
                         <Import-Package>

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/EndpointListenerLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/EndpointListenerLoader.java
@@ -96,9 +96,8 @@ public class EndpointListenerLoader {
             }
         }
 
-        int internalInboundPort = ConfigurationLoader.getInternalInboundPort();
+        int internalInboundPort = HTTPEndpointManager.getInstance().getInternalInboundPort();
         if (internalInboundPort != -1) {
-            HTTPEndpointManager.getInstance().setInternalInboundPort(internalInboundPort);
             HTTPEndpointManager.getInstance().startListener(
                     internalInboundPort, InboundHttpConstants.INTERNAL_INBOUND_ENDPOINT_NAME, null);
 

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/EndpointListenerLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/EndpointListenerLoader.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.inbound.endpoint.persistence.service.InboundEndpointPersi
 import org.wso2.carbon.inbound.endpoint.protocol.generic.GenericInboundListener;
 import org.wso2.carbon.inbound.endpoint.protocol.hl7.management.HL7EndpointManager;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpConstants;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
 import org.wso2.carbon.inbound.endpoint.protocol.http.management.HTTPEndpointManager;
 import org.wso2.carbon.inbound.endpoint.protocol.websocket.management.WebsocketEndpointManager;
 import org.wso2.carbon.utils.ConfigurationContextService;
@@ -94,7 +95,14 @@ public class EndpointListenerLoader {
                 }
             }
         }
-        
+
+        int internalInboundPort = ConfigurationLoader.getInternalInboundPort();
+        if (internalInboundPort != -1) {
+            HTTPEndpointManager.getInstance().setInternalInboundPort(internalInboundPort);
+            HTTPEndpointManager.getInstance().startListener(
+                    internalInboundPort, InboundHttpConstants.INTERNAL_INBOUND_ENDPOINT_NAME, null);
+
+        }
         //Load tenats required for polling inbound protocols
         Map<String, Set<String>> mPollingEndpoints =
 		                                  InboundEndpointsDataStore.getInstance().getAllPollingingEndpointData();

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/APIResource.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/APIResource.java
@@ -40,14 +40,14 @@ public abstract class APIResource {
      *
      * @return the supported HTTP methods
      */
-    abstract Set<String> getMethods();
+    abstract public Set<String> getMethods();
 
     /**
      * Invokes the API Resource.
      *
      * @param synCtx the Synapse Message Context
      */
-    abstract void invoke(MessageContext synCtx);
+    abstract public void invoke(MessageContext synCtx);
 
     /**
      * Constructor for creating an API Resource.

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/APIResource.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/APIResource.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.inbound.endpoint.internal.http.api;
+
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.rest.dispatch.DispatcherHelper;
+import org.apache.synapse.rest.dispatch.URITemplateHelper;
+
+import java.util.Set;
+
+/**
+ * {@code APIResource} is the abstract implementation of a Resource in an Internal API.
+ *
+ * An {@link InternalAPI} must have one or more Resources. So if we want to register an internal api into EI,
+ * we need to create one or more Resources extending this abstract class and make it accessible through
+ * {@link InternalAPI#getResources()} method.
+ *
+ */
+public abstract class APIResource {
+
+    private DispatcherHelper dispatcherHelper;
+
+    /**
+     * Gets the HTTP methods supported by this Resource.
+     *
+     * @return the supported HTTP methods
+     */
+    abstract Set<String> getMethods();
+
+    /**
+     * Invokes the API Resource.
+     *
+     * @param synCtx the Synapse Message Context
+     */
+    abstract void invoke(MessageContext synCtx);
+
+    /**
+     * Constructor for creating an API Resource.
+     *
+     * @param urlTemplate   the url template of the Resource
+     */
+    public APIResource(String urlTemplate) {
+        dispatcherHelper = new URITemplateHelper(urlTemplate);
+    }
+
+    /**
+     * Gets the {@link DispatcherHelper} related to the the Resource.
+     *
+     * @return the DispatcherHelper
+     */
+    final DispatcherHelper getDispatcherHelper() {
+        return dispatcherHelper;
+    }
+
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/APIResource.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/APIResource.java
@@ -49,8 +49,9 @@ public abstract class APIResource {
      * Invokes the API Resource.
      *
      * @param synCtx the Synapse Message Context
+     * @return whether to continue post invocation tasks
      */
-    public abstract void invoke(MessageContext synCtx);
+    public abstract boolean invoke(MessageContext synCtx);
 
     /**
      * Constructor for creating an API Resource.

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/APIResource.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/APIResource.java
@@ -18,8 +18,11 @@
 package org.wso2.carbon.inbound.endpoint.internal.http.api;
 
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.dispatch.DispatcherHelper;
 import org.apache.synapse.rest.dispatch.URITemplateHelper;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
 
 import java.util.Set;
 
@@ -40,14 +43,14 @@ public abstract class APIResource {
      *
      * @return the supported HTTP methods
      */
-    abstract public Set<String> getMethods();
+    public abstract Set<String> getMethods();
 
     /**
      * Invokes the API Resource.
      *
      * @param synCtx the Synapse Message Context
      */
-    abstract public void invoke(MessageContext synCtx);
+    public abstract void invoke(MessageContext synCtx);
 
     /**
      * Constructor for creating an API Resource.
@@ -63,8 +66,21 @@ public abstract class APIResource {
      *
      * @return the DispatcherHelper
      */
-    final DispatcherHelper getDispatcherHelper() {
+    public final DispatcherHelper getDispatcherHelper() {
         return dispatcherHelper;
+    }
+
+    /**
+     * Builds the message by consuming the input stream.
+     *
+     * @param synCtx the Synapse Message Context
+     */
+    public final void buildMessage(MessageContext synCtx) {
+        try {
+            RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext(), false);
+        } catch (Exception e) {
+            throw new SynapseException("Error while building the message. " + e.getMessage(), e);
+        }
     }
 
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
@@ -49,10 +49,10 @@ public class ConfigurationLoader {
     private static final QName CLASS_Q = new QName("class");
     private static final QName NAME_ATT = new QName("name");
 
-    public static List<InternalAPI> loadInternalAPIs() {
+    public static List<InternalAPI> loadInternalAPIs(String apiFilePath) {
 
         List<InternalAPI> internalApis = new ArrayList<>();
-        OMElement apiConfig = MiscellaneousUtil.loadXMLConfig(Constants.INTERNAL_APIS_FILE);
+        OMElement apiConfig = MiscellaneousUtil.loadXMLConfig(apiFilePath);
         if (apiConfig != null) {
 
             if (!ROOT_Q.equals(apiConfig.getQName())) {

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
@@ -112,15 +112,21 @@ public class ConfigurationLoader {
 
         File synapseProperties = Paths.get(CarbonUtils.getCarbonConfigDirPath(), "synapse.properties").toFile();
         Properties properties = new Properties();
-        InputStream inputStream;
+        InputStream inputStream = null;
         try {
             inputStream = new FileInputStream(synapseProperties);
             properties.load(inputStream);
-            inputStream.close();
         } catch (FileNotFoundException e) {
             handleException("synapse.properties file not found", e);
         } catch (IOException e) {
             handleException("Error while reading synapse.properties file", e);
+        } finally {
+            if (inputStream != null) {
+                try {
+                    inputStream.close();
+                } catch (IOException ignored) {
+                }
+            }
         }
         int internalInboundPort = Constants.DEFAULT_INTERNAL_HTTP_API_PORT;
 

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.inbound.endpoint.internal.http.api;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.commons.util.MiscellaneousUtil;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import javax.xml.namespace.QName;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * {@code ConfigurationLoader} contains utilities to load configuration file content required for Internal APIs
+ * implementation.
+ */
+public class ConfigurationLoader {
+
+    private static Log log = LogFactory.getLog(ConfigurationLoader.class);
+
+    private static final QName ROOT_Q = new QName("apis");
+    private static final QName HANDLER_Q = new QName("api");
+    private static final QName CLASS_Q = new QName("class");
+    private static final QName NAME_ATT = new QName("name");
+
+    public static List<InternalAPI> loadInternalAPIs() {
+
+        List<InternalAPI> internalApis = new ArrayList<>();
+        OMElement apiConfig = MiscellaneousUtil.loadXMLConfig(Constants.INTERNAL_APIS_FILE);
+        if (apiConfig != null) {
+
+            if (!ROOT_Q.equals(apiConfig.getQName())) {
+                handleException("Invalid internal api configuration file");
+            }
+
+            Iterator iterator = apiConfig.getChildrenWithName(HANDLER_Q);
+            while (iterator.hasNext()) {
+                OMElement handlerElem = (OMElement) iterator.next();
+
+                String name = null;
+                if (handlerElem.getAttribute(NAME_ATT) != null) {
+                    name = handlerElem.getAttributeValue(NAME_ATT);
+                } else {
+                    handleException("Name not defined in one or more handlers");
+                }
+
+                if (handlerElem.getAttribute(CLASS_Q) != null) {
+                    String className = handlerElem.getAttributeValue(CLASS_Q);
+                    if (!"".equals(className)) {
+                        InternalAPI internalApi = createAPI(className);
+                        if (internalApi != null) {
+                            internalApis.add(internalApi);
+                            internalApi.setName(name);
+                        }
+                    } else {
+                        handleException("Class name is null for Internal InternalAPI name : " + name);
+                    }
+                } else {
+                    handleException("Class name not defined for Internal InternalAPI named : " + name);
+                }
+            }
+        }
+        return internalApis;
+    }
+
+    private static InternalAPI createAPI(String classFQName) {
+
+        Object obj = null;
+        try {
+            obj = Class.forName(classFQName).newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            handleException("Error creating Internal InternalAPI for class name : " + classFQName, e);
+        }
+
+        if (obj instanceof InternalAPI) {
+            return (InternalAPI) obj;
+        } else {
+            handleException("Error creating Internal InternalAPI. The InternalAPI should be of type " +
+                    "InternalAPI");
+        }
+        return null;
+    }
+
+
+    public static int getInternalInboundPort() {
+
+        File synapseProperties = Paths.get(CarbonUtils.getCarbonConfigDirPath(), "synapse.properties").toFile();
+        Properties properties = new Properties();
+        InputStream inputStream;
+        try {
+            inputStream = new FileInputStream(synapseProperties);
+            properties.load(inputStream);
+            inputStream.close();
+        } catch (FileNotFoundException e) {
+            handleException("synapse.properties file not found", e);
+        } catch (IOException e) {
+            handleException("Error while reading synapse.properties file", e);
+        }
+        int internalInboundPort = Constants.DEFAULT_INTERNAL_HTTP_API_PORT;
+
+        String internalInboundEnabledProperty = properties.getProperty(Constants.INTERNAL_HTTP_API_ENABLED);
+        if (internalInboundEnabledProperty == null) {
+            return -1;
+        }
+        boolean internalInboundEnabled = Boolean.parseBoolean(internalInboundEnabledProperty);
+        if (!internalInboundEnabled) {
+            return -1;
+        }
+
+        String internalInboundPortProperty =
+                properties.getProperty(Constants.INTERNAL_HTTP_API_PORT);
+        if (internalInboundPortProperty != null) {
+            try {
+                internalInboundPort = Integer.parseInt(internalInboundPortProperty);
+            } catch (Exception ex) {
+                handleException(Constants.INTERNAL_HTTP_API_PORT + " is not in proper format", ex);
+            }
+        }
+        return internalInboundPort;
+    }
+
+    private static void handleException(String msg) {
+        log.error(msg);
+        throw new SynapseException(msg);
+    }
+
+    private static void handleException(String msg, Exception ex) {
+        log.error(msg, ex);
+        throw new SynapseException(msg, ex);
+    }
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
@@ -72,7 +72,7 @@ public class ConfigurationLoader {
 
                 if (handlerElem.getAttribute(CLASS_Q) != null) {
                     String className = handlerElem.getAttributeValue(CLASS_Q);
-                    if (!"".equals(className)) {
+                    if (!className.isEmpty()) {
                         InternalAPI internalApi = createAPI(className);
                         if (internalApi != null) {
                             internalApis.add(internalApi);

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
@@ -25,6 +25,6 @@ public class Constants {
     static final String INTERNAL_HTTP_API_PORT = "internal.http.api.port";
     static final int DEFAULT_INTERNAL_HTTP_API_PORT = 9091;
     static final String INTERNAL_HTTP_API_ENABLED = "internal.http.api.enabled";
-    static final String INTERNAL_APIS_FILE = "internal-apis.xml";
+    public static final String INTERNAL_APIS_FILE = "internal-apis.xml";
 
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.inbound.endpoint.internal.http.api;
+
+/**
+ * {@code Constants} contains constants related to internal http api implementation.
+ */
+public class Constants {
+
+    static final String INTERNAL_HTTP_API_PORT = "internal.http.api.port";
+    static final int DEFAULT_INTERNAL_HTTP_API_PORT = 9091;
+    static final String INTERNAL_HTTP_API_ENABLED = "internal.http.api.enabled";
+    static final String INTERNAL_APIS_FILE = "internal-apis.xml";
+
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/InternalAPI.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/InternalAPI.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.inbound.endpoint.internal.http.api;
+
+/**
+ * {@code InternalAPI} is the interface that need to be implemented in order to register an internal API into EI.
+ */
+public interface InternalAPI {
+
+    /**
+     * Gets the API Resources.
+     *
+     * @return the array of API Resources
+     */
+    APIResource[] getResources();
+
+    /**
+     * Gets the API context.
+     *
+     * @return the API context
+     */
+    String getContext();
+
+    /**
+     * Gets the API name.
+     *
+     * @return the name of the API
+     */
+    String getName();
+
+    /**
+     * Sets the name of the API
+     *
+     * @param name name of the API
+     */
+    void setName(String name);
+
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/InternalAPIDispatcher.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/InternalAPIDispatcher.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.inbound.endpoint.internal.http.api;
+
+import org.apache.axis2.Constants;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.core.axis2.Axis2Sender;
+import org.apache.synapse.rest.RESTConstants;
+import org.apache.synapse.rest.RESTUtils;
+import org.apache.synapse.rest.dispatch.DispatcherHelper;
+import org.apache.synapse.rest.dispatch.URITemplateHelper;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@code InternalAPIDispatcher} takes care of dispatching messages received over the internal inbound endpoint into
+ * relevant {@link InternalAPI}.
+ */
+public class InternalAPIDispatcher {
+
+    private static Log log = LogFactory.getLog(InternalAPIDispatcher.class);
+
+    private List<InternalAPI> internalApis;
+
+    public InternalAPIDispatcher(List<InternalAPI> internalApis) {
+       this.internalApis = internalApis;
+    }
+
+    /**
+     * Dispatches the message into relevant internal API.
+     *
+     * @param synCtx the Synapse Message Context.
+     */
+    public void dispatch(MessageContext synCtx) {
+        InternalAPI internalApi = findAPI(synCtx);
+        if (internalApi == null) {
+            log.warn("No Internal InternalAPI found to dispatch the message");
+            return;
+        }
+
+        APIResource resource = findResource(synCtx, internalApi);
+        if (resource == null) {
+            log.warn("No matching Resource found in " + internalApi.getName() + " InternalAPI to dispatch the message");
+            return;
+        }
+
+        resource.invoke(synCtx);
+        respond(synCtx);
+    }
+
+    /* Finds the API that the message should be dispatched to */
+    private InternalAPI findAPI(MessageContext synCtx) {
+        for (InternalAPI internalApi : internalApis) {
+            String context = internalApi.getContext();
+            String path = RESTUtils.getFullRequestPath(synCtx);
+            if (path.startsWith(context + "/") || path.startsWith(context + "?") || context.equals(path)) {
+                return internalApi;
+            }
+        }
+        return null;
+    }
+
+    /* Finds the Resource that the message should be dispatched to */
+    private APIResource findResource(MessageContext synCtx, InternalAPI internalApi) {
+
+        String method = (String) synCtx.getProperty(Constants.Configuration.HTTP_METHOD);
+
+        for (APIResource resource : internalApi.getResources()) {
+            if (!resource.getMethods().contains(method)) {
+                continue;
+            }
+            String url = RESTUtils.getSubRequestPath(synCtx);
+            DispatcherHelper helper = resource.getDispatcherHelper();
+            URITemplateHelper templateHelper = (URITemplateHelper) helper;
+            Map<String, String> variables = new HashMap<>();
+            if (templateHelper.getUriTemplate().matches(url, variables)) {
+                for (Map.Entry<String, String> entry : variables.entrySet()) {
+                    synCtx.setProperty(RESTConstants.REST_URI_VARIABLE_PREFIX + entry.getKey(),
+                            entry.getValue());
+                }
+                return resource;
+            }
+        }
+        return null;
+    }
+
+    /* Sends the respond back to the client */
+    private void respond(MessageContext synCtx) {
+        synCtx.setTo(null);
+        synCtx.setResponse(true);
+        Axis2MessageContext axis2smc = (Axis2MessageContext) synCtx;
+        org.apache.axis2.context.MessageContext axis2MessageCtx = axis2smc.getAxis2MessageContext();
+        axis2MessageCtx.getOperationContext()
+                .setProperty(Constants.RESPONSE_WRITTEN, "SKIP");
+        Axis2Sender.sendBack(synCtx);
+    }
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/InternalAPIDispatcher.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/InternalAPIDispatcher.java
@@ -54,13 +54,14 @@ public class InternalAPIDispatcher {
     public void dispatch(MessageContext synCtx) {
         InternalAPI internalApi = findAPI(synCtx);
         if (internalApi == null) {
-            log.warn("No Internal InternalAPI found to dispatch the message");
+            log.warn("No Internal API found to dispatch the message");
             return;
         }
 
         APIResource resource = findResource(synCtx, internalApi);
         if (resource == null) {
-            log.warn("No matching Resource found in " + internalApi.getName() + " InternalAPI to dispatch the message");
+            log.warn("No matching Resource found in " + internalApi.getName() +
+                    " InternalAPI to dispatch the message");
             return;
         }
 

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/InternalAPIDispatcher.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/InternalAPIDispatcher.java
@@ -49,24 +49,23 @@ public class InternalAPIDispatcher {
     /**
      * Dispatches the message into relevant internal API.
      *
-     * @param synCtx the Synapse Message Context.
+     * @param synCtx the Synapse Message Context
+     * @return whether to continue with post dispatching actions
      */
-    public void dispatch(MessageContext synCtx) {
+    public boolean dispatch(MessageContext synCtx) {
         InternalAPI internalApi = findAPI(synCtx);
         if (internalApi == null) {
             log.warn("No Internal API found to dispatch the message");
-            return;
+            return false;
         }
 
         APIResource resource = findResource(synCtx, internalApi);
         if (resource == null) {
             log.warn("No matching Resource found in " + internalApi.getName() +
                     " InternalAPI to dispatch the message");
-            return;
+            return false;
         }
-
-        resource.invoke(synCtx);
-        respond(synCtx);
+        return resource.invoke(synCtx);
     }
 
     /* Finds the API that the message should be dispatched to */
@@ -109,16 +108,5 @@ public class InternalAPIDispatcher {
             }
         }
         return null;
-    }
-
-    /* Sends the respond back to the client */
-    private void respond(MessageContext synCtx) {
-        synCtx.setTo(null);
-        synCtx.setResponse(true);
-        Axis2MessageContext axis2smc = (Axis2MessageContext) synCtx;
-        org.apache.axis2.context.MessageContext axis2MessageCtx = axis2smc.getAxis2MessageContext();
-        axis2MessageCtx.getOperationContext()
-                .setProperty(Constants.RESPONSE_WRITTEN, "SKIP");
-        Axis2Sender.sendBack(synCtx);
     }
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
@@ -67,6 +67,6 @@ public class InboundHttpConstants {
     /** Parameter name for preferred ciphers in inbound endpoint configs **/
     public static final String PREFERRED_CIPHERS = "PreferredCiphers";
 
-    public static final String INTERNAL_INBOUND_ENDPOINT_NAME = "INTERNAL_INBOUND_ENDPOINT_NAME";
+    public static final String INTERNAL_INBOUND_ENDPOINT_NAME = "EI_INTERNAL_INBOUND_ENDPOINT";
 
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
@@ -67,4 +67,6 @@ public class InboundHttpConstants {
     /** Parameter name for preferred ciphers in inbound endpoint configs **/
     public static final String PREFERRED_CIPHERS = "PreferredCiphers";
 
+    public static final String INTERNAL_INBOUND_ENDPOINT_NAME = "INTERNAL_INBOUND_ENDPOINT_NAME";
+
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
@@ -79,7 +79,6 @@ public class InboundHttpServerWorker extends ServerWorker {
         this.port = port;
         this.tenantDomain = tenantDomain;
         restHandler = new RESTRequestHandler();
-
         isInternalInboundEndpoint = (HTTPEndpointManager.getInstance().getInternalInboundPort() == port);
     }
 
@@ -100,6 +99,11 @@ public class InboundHttpServerWorker extends ServerWorker {
                 String method = request.getRequest() != null ? request.getRequest().
                         getRequestLine().getMethod().toUpperCase() : "";
                 processHttpRequestUri(axis2MsgContext, method);
+
+                if (isInternalInboundEndpoint) {
+                    HTTPEndpointManager.getInstance().getInternalAPIDispatcher().dispatch(synCtx);
+                    return;
+                }
 
                 String endpointName =
                         HTTPEndpointManager.getInstance().getEndpointName(port, tenantDomain);
@@ -136,11 +140,6 @@ public class InboundHttpServerWorker extends ServerWorker {
                 }
 
                 dispatchPattern = HTTPEndpointManager.getInstance().getPattern(tenantDomain, port);
-
-                if (isInternalInboundEndpoint) {
-                    HTTPEndpointManager.getInstance().getInternalAPIDispatcher().dispatch(synCtx);
-                    return;
-                }
 
                 boolean continueDispatch = true;
                 if (dispatchPattern != null) {

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
@@ -68,6 +68,7 @@ public class InboundHttpServerWorker extends ServerWorker {
     private RESTRequestHandler restHandler;
     private Pattern dispatchPattern;
     private Matcher patternMatcher;
+    private boolean isInternalInboundEndpoint;
 
     public InboundHttpServerWorker(int port, String tenantDomain,
                                    SourceRequest sourceRequest,
@@ -78,6 +79,8 @@ public class InboundHttpServerWorker extends ServerWorker {
         this.port = port;
         this.tenantDomain = tenantDomain;
         restHandler = new RESTRequestHandler();
+
+        isInternalInboundEndpoint = (HTTPEndpointManager.getInstance().getInternalInboundPort() == port);
     }
 
     public void run() {
@@ -133,6 +136,11 @@ public class InboundHttpServerWorker extends ServerWorker {
                 }
 
                 dispatchPattern = HTTPEndpointManager.getInstance().getPattern(tenantDomain, port);
+
+                if (isInternalInboundEndpoint) {
+                    HTTPEndpointManager.getInstance().getInternalAPIDispatcher().dispatch(synCtx);
+                    return;
+                }
 
                 boolean continueDispatch = true;
                 if (dispatchPattern != null) {

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
@@ -31,6 +31,8 @@ import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpConfiguration;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpConstants;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpSourceHandler;
 import org.wso2.carbon.inbound.endpoint.protocol.http.config.WorkerPoolConfiguration;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPIDispatcher;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -57,8 +59,13 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
     private ConcurrentHashMap<String, ConcurrentHashMap<Integer, Pattern>> dispatchPatternMap =
             new ConcurrentHashMap<String, ConcurrentHashMap<Integer, Pattern>>();
 
+    private int internalInboundPort = -1;
+
+    private InternalAPIDispatcher internalAPIDispatcher;
+
     private HTTPEndpointManager() {
         super();
+        internalAPIDispatcher = new InternalAPIDispatcher(ConfigurationLoader.loadInternalAPIs());
     }
 
     public static HTTPEndpointManager getInstance() {
@@ -408,4 +415,15 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
         }
     }
 
+    public InternalAPIDispatcher getInternalAPIDispatcher() {
+        return internalAPIDispatcher;
+    }
+
+    public int getInternalInboundPort() {
+        return internalInboundPort;
+    }
+
+    public void setInternalInboundPort(int internalInboundPort) {
+        this.internalInboundPort = internalInboundPort;
+    }
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
@@ -26,6 +26,7 @@ import org.apache.synapse.transport.passthru.config.SourceConfiguration;
 import org.apache.synapse.transport.passthru.core.ssl.SSLConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.inbound.endpoint.common.AbstractInboundEndpointManager;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.Constants;
 import org.wso2.carbon.inbound.endpoint.persistence.InboundEndpointInfoDTO;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpConfiguration;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpConstants;
@@ -67,7 +68,8 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
         super();
         internalInboundPort = ConfigurationLoader.getInternalInboundPort();
         if (internalInboundPort != -1) {
-            internalAPIDispatcher = new InternalAPIDispatcher(ConfigurationLoader.loadInternalAPIs());
+            internalAPIDispatcher =
+                    new InternalAPIDispatcher(ConfigurationLoader.loadInternalAPIs(Constants.INTERNAL_APIS_FILE));
         }
     }
 

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
@@ -59,13 +59,16 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
     private ConcurrentHashMap<String, ConcurrentHashMap<Integer, Pattern>> dispatchPatternMap =
             new ConcurrentHashMap<String, ConcurrentHashMap<Integer, Pattern>>();
 
-    private int internalInboundPort = -1;
+    private int internalInboundPort;
 
     private InternalAPIDispatcher internalAPIDispatcher;
 
     private HTTPEndpointManager() {
         super();
-        internalAPIDispatcher = new InternalAPIDispatcher(ConfigurationLoader.loadInternalAPIs());
+        internalInboundPort = ConfigurationLoader.getInternalInboundPort();
+        if (internalInboundPort != -1) {
+            internalAPIDispatcher = new InternalAPIDispatcher(ConfigurationLoader.loadInternalAPIs());
+        }
     }
 
     public static HTTPEndpointManager getInstance() {
@@ -421,9 +424,5 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
 
     public int getInternalInboundPort() {
         return internalInboundPort;
-    }
-
-    public void setInternalInboundPort(int internalInboundPort) {
-        this.internalInboundPort = internalInboundPort;
     }
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/ConfigurationLoaderTestCase.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/ConfigurationLoaderTestCase.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package internal.http.api;
+
+import junit.framework.Assert;
+import org.junit.Test;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPI;
+
+import java.net.URL;
+import java.util.List;
+
+public class ConfigurationLoaderTestCase {
+
+    /**
+     * Test loading of internal apis from the internal-apis.xml file.
+     */
+    @Test
+    public void testLoadInternalAPIs() {
+        URL url = getClass().getResource("internal-apis.xml");
+        Assert.assertNotNull("Configuration file not found", url);
+
+        List<InternalAPI> apis = ConfigurationLoader.loadInternalAPIs("internal/http/api/internal-apis.xml");
+        Assert.assertEquals("Expected number of APIs not found", 1, apis.size());
+        Assert.assertEquals("Loaded API name is not correct", "SampleAPI" , apis.get(0).getName());
+        Assert.assertEquals("Loaded API context is not correct", "/foo" , apis.get(0).getContext());
+    }
+
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/DispatcherTestCase.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/DispatcherTestCase.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package internal.http.api;
+
+import junit.framework.Assert;
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.Constants;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.config.SynapseConfiguration;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
+import org.apache.synapse.core.axis2.MessageContextCreatorForAxis2;
+import org.junit.Test;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPI;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPIDispatcher;
+
+import java.util.List;
+
+public class DispatcherTestCase {
+
+    /**
+     * Test request dispatching of internal apis.
+     */
+    @Test
+    public void testDispatching() throws Exception {
+        List<InternalAPI> apis = ConfigurationLoader.loadInternalAPIs("internal/http/api/internal-apis.xml");
+        Assert.assertEquals("Expected API not loaded", 1, apis.size());
+
+        InternalAPIDispatcher internalAPIDispatcher = new InternalAPIDispatcher(apis);
+        MessageContext synCtx = createMessageContext();
+        setRequestProperties(synCtx, "/foo/bar", "GET");
+
+        boolean dispatchingCompleted = internalAPIDispatcher.dispatch(synCtx);
+        Assert.assertTrue("Dispatcher failed to find correct API or Resource", dispatchingCompleted);
+        Assert.assertTrue("Correct resource not invoked", (Boolean) synCtx.getProperty("Success"));
+    }
+
+    private MessageContext createMessageContext() throws AxisFault {
+        SynapseConfiguration synConfig = new SynapseConfiguration();
+        AxisConfiguration axisConfig = new AxisConfiguration();
+        synConfig.setAxisConfiguration(axisConfig);
+
+        org.apache.axis2.context.MessageContext axis2Ctx = new org.apache.axis2.context.MessageContext();
+        ConfigurationContext cfgCtx = new ConfigurationContext(axisConfig);
+        axis2Ctx.setConfigurationContext(cfgCtx);
+
+        MessageContextCreatorForAxis2.setSynConfig(synConfig);
+        MessageContextCreatorForAxis2.setSynEnv(new Axis2SynapseEnvironment(synConfig));
+        return MessageContextCreatorForAxis2.getSynapseMessageContext(axis2Ctx);
+    }
+
+    private void setRequestProperties(MessageContext synCtx, String path, String method) {
+        org.apache.axis2.context.MessageContext axis2Ctx = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+        axis2Ctx.setProperty(Constants.Configuration.TRANSPORT_IN_URL, path);
+        axis2Ctx.setProperty(Constants.Configuration.HTTP_METHOD, method);
+    }
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/SampleInternalAPI.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/SampleInternalAPI.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package internal.http.api;
+
+import org.wso2.carbon.inbound.endpoint.internal.http.api.APIResource;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPI;
+
+public class SampleInternalAPI implements InternalAPI {
+
+    private String name;
+
+    @Override
+    public APIResource[] getResources() {
+        APIResource[] resources = new APIResource[1];
+        resources[0] = new SampleResource("/bar");
+        return resources;
+    }
+
+    @Override
+    public String getContext() {
+        return "/foo";
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/SampleResource.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/SampleResource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package internal.http.api;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.APIResource;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class SampleResource extends APIResource {
+
+    private static Log log = LogFactory.getLog(SampleResource.class);
+
+    @Override
+    public Set<String> getMethods() {
+        Set<String> methods = new HashSet<String>();
+        methods.add("GET");
+        methods.add("POST");
+        return methods;
+    }
+
+    @Override
+    public boolean invoke(MessageContext messageContext) {
+        log.info("Sample Resource Invoked");
+        buildMessage(messageContext);
+        log.info("Message : " + messageContext.getEnvelope());
+        messageContext.setProperty("Success", true);
+        return true;
+    }
+
+    public SampleResource(String urlTemplate) {
+        super(urlTemplate);
+    }
+
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/resources/internal/http/api/internal-apis.xml
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/resources/internal/http/api/internal-apis.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<apis>
+  <api name="SampleAPI" class="internal.http.api.SampleInternalAPI"/>
+</apis>


### PR DESCRIPTION
## Purpose
We often find various components and extensions in EI, expose their functionality as HTTP APIs.
To build an API at the moment we are using MSF4J. But we already have a built-in HTTP transport that is used to serve HTTP traffic to the ESB server. 
Purpose of this PR is to introduce a framework to leverage that built-in HTTP transport to expose APIs needed by other components. 

## Approach
Implementation was done using the HTTP Inbound concept. A default internal inbound called EI_INTERNAL_INBOUND_ENDPOINT is used to serve the traffic for these internal APIs. 
EI_INTERNAL_INBOUND_ENDPOINT is a hidden inbound endpoint that will not appear in the synapse configuration.

To enable this inbound endpoint we need to put the following to the synapse.properties file.
`internal.http.api.enabled=true`

Inbound port can be configured using 
`internal.http.api.port` parameter in the same configuration file. 
Default port is 9091.

Users who want to expose an HTTP API, need to implement the following interface in their Java code.
org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPI

And need to register it using a configuration file called "internal-apis.xml" located in conf directory.
Format of the file would be as follows
`<apis>
  <api name="SampleAPI" class="internal.http.api.SampleInternalAPI"/>
</apis>`

Here, class is the full qualified class name of the API implementation. 
Please see the test case for more details.

## Documentation
No update needed for the user documentation. 

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
Included in the PR

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
Included as a test case

## Related PRs


## Migrations (if applicable)
N/A

## Test environment
JDK 8
 
## Learning
N/A