### PR TITLE
validate `forwardTo` values in executors

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.priority.executors.ui/src/main/resources/web/executors/design_executors.jsp
+++ b/components/mediation-ui/org.wso2.carbon.priority.executors.ui/src/main/resources/web/executors/design_executors.jsp
@@ -309,7 +309,7 @@
     <h2><fmt:message key="priority.design.text"/></h2>
 
     <div id="workArea">
-        <form name="main_form" id="main_form" action="save_design.jsp">
+        <form name="main_form" id="main_form" action="save_design.jsp" method="post">
         <table class="styledLeft noBorders" cellspacing="0" style="width:100%">
             <thead>
             <tr>

--- a/components/mediation-ui/org.wso2.carbon.priority.executors.ui/src/main/resources/web/executors/save_design.jsp
+++ b/components/mediation-ui/org.wso2.carbon.priority.executors.ui/src/main/resources/web/executors/save_design.jsp
@@ -25,6 +25,8 @@
 
 <%
 
+    final String LIST_EXECUTORS = "list_executors.jsp";
+    final String PRIORITY_SOURCE = "priority_source.jsp";
     PriorityAdminClient client = new PriorityAdminClient(getServletConfig(), session);
 //    String executorName = request.getParameter("name");
     String action = request.getParameter("action");
@@ -108,7 +110,9 @@
 <script type="text/javascript">
     <% if (forwardTo == null) { %>
         document.location.href = 'list_executors.jsp?action=<%=Encode.forHtml(action)%>&mode=<%=Encode.forHtml(mode)%>';
-    <% } else { %>
+    <% } else if (LIST_EXECUTORS.equals(forwardTo) || PRIORITY_SOURCE.equals(forwardTo)) { %>
         document.location.href = '<%=Encode.forHtml(forwardTo)%>' + '?action=<%=Encode.forHtml(action)%>&mode=<%=Encode.forHtml(mode)%>';
+    <% } else { %>
+        CARBON.showErrorDialog("Invalid Redirect URL");
     <% } %>
 </script>


### PR DESCRIPTION
Validate values passed to `fowardTo` parameter to prevent open redirects,
and change form submission method of save_executor to `POST`.