### PR TITLE
Add new setter to mappingResource in datamapper

### DIFF
--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
@@ -245,6 +245,16 @@ public class DataMapperMediator extends AbstractMediator implements ManagedLifec
     }
 
     /**
+     * Set a pre-built mapping resource
+     * This method is used by data-mapper test feature in EI-Tooling
+     *
+     * @param mappingResource prebuilt mapping resource
+     */
+    public void setMappingResource(MappingResource mappingResource) {
+        this.mappingResource = mappingResource;
+    }
+
+    /**
      * Get the values from the message context to do the data mapping
      *
      * @param synCtx current message for the mediation


### PR DESCRIPTION

## Purpose
> Enable to add mapping resource from outside

## Goals
> This setter is used in EI-Tooling to inject a pre-built mappingResourse to datamapper.

## Approach
> Add new setter
