### PR TITLE
Enable the internal API if only the relevant system property is set & Return 404 if not found

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
@@ -66,6 +66,9 @@ public class ConfigurationLoader {
                 String name = null;
                 if (handlerElem.getAttribute(NAME_ATT) != null) {
                     name = handlerElem.getAttributeValue(NAME_ATT);
+                    if (name == null || name.isEmpty()) {
+                        handleException("Name not specified in one or more handlers");
+                    }
                     if (!Boolean.parseBoolean(System.getProperty(Constants.PREFIX_TO_ENABLE_INTERNAL_APIS + name))) {
                         continue;
                     }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
@@ -66,6 +66,9 @@ public class ConfigurationLoader {
                 String name = null;
                 if (handlerElem.getAttribute(NAME_ATT) != null) {
                     name = handlerElem.getAttributeValue(NAME_ATT);
+                    if (!Boolean.parseBoolean(System.getProperty(Constants.PREFIX_TO_ENABLE_INTERNAL_APIS + name))) {
+                        continue;
+                    }
                 } else {
                     handleException("Name not defined in one or more handlers");
                 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
@@ -26,5 +26,6 @@ public class Constants {
     static final int DEFAULT_INTERNAL_HTTP_API_PORT = 9191;
     static final String INTERNAL_HTTP_API_ENABLED = "internal.http.api.enabled";
     public static final String INTERNAL_APIS_FILE = "internal-apis.xml";
+    public static final String PREFIX_TO_ENABLE_INTERNAL_APIS = "enable";
 
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
@@ -424,12 +424,6 @@ public class InboundHttpServerWorker extends ServerWorker {
     }
 
     /**
-     * Sends the respond back to the client.
-     *
-     * @param synCtx the MessageContext
-     */
-
-    /**
      *Sends the respond back to the client.
      * @param synCtx the MessageContext
      * @param result the result of API Call

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
@@ -105,9 +105,8 @@ public class InboundHttpServerWorker extends ServerWorker {
 
                 if (isInternalInboundEndpoint) {
                     doPreInjectTasks(axis2MsgContext, (Axis2MessageContext) synCtx, method);
-                    boolean executePostDispatchActions =
-                            HTTPEndpointManager.getInstance().getInternalAPIDispatcher().dispatch(synCtx);
-                    respond(synCtx, executePostDispatchActions);
+                    boolean result = HTTPEndpointManager.getInstance().getInternalAPIDispatcher().dispatch(synCtx);
+                    respond(synCtx, result);
                     return;
                 }
 

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/ConfigurationLoaderTestCase.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/ConfigurationLoaderTestCase.java
@@ -20,6 +20,7 @@ package internal.http.api;
 import junit.framework.Assert;
 import org.junit.Test;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.Constants;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPI;
 
 import java.net.URL;
@@ -32,6 +33,7 @@ public class ConfigurationLoaderTestCase {
      */
     @Test
     public void testLoadInternalAPIs() {
+        System.setProperty(Constants.PREFIX_TO_ENABLE_INTERNAL_APIS + "SampleAPI", "true");
         URL url = getClass().getResource("internal-apis.xml");
         Assert.assertNotNull("Configuration file not found", url);
 


### PR DESCRIPTION
## Purpose

The relevant internal API is enabled only if the system property is set.

System Property Name :- enable + <API_NAME>

Also this PR enable to send 404 if the Internal API is not found.