### PR TITLE
Honour port offset in internal APIs if it is specified & Start Endpoint Listener if at least one API is enabled.

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint.persistence/src/main/java/org/wso2/carbon/inbound/endpoint/persistence/PersistenceUtils.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint.persistence/src/main/java/org/wso2/carbon/inbound/endpoint/persistence/PersistenceUtils.java
@@ -324,7 +324,7 @@ public class PersistenceUtils {
     }
 
     /**
-     * Used to get the port offset value of server
+     * Used to get the port offset value of server.
      *
      * @return port offset of server
      */

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint.persistence/src/main/java/org/wso2/carbon/inbound/endpoint/persistence/PersistenceUtils.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint.persistence/src/main/java/org/wso2/carbon/inbound/endpoint/persistence/PersistenceUtils.java
@@ -331,16 +331,12 @@ public class PersistenceUtils {
     public static int getPortOffset() {
 
         ServerConfiguration carbonConfig = ServerConfiguration.getInstance();
-        String portOffset = System
-                .getProperty(PORT_OFFSET_SYSTEM_VAR, carbonConfig.getFirstProperty(PORT_OFFSET_CONFIG));
-        try {
-            if (portOffset != null) {
-                return Integer.parseInt(portOffset.trim());
-            } else {
-                return 0;
-            }
-        } catch (NumberFormatException e) {
-            log.error("Invalid Port Offset: " + portOffset + ". Default value 0 will be used.", e);
+        String portOffsetInCarbonXML = carbonConfig.getFirstProperty(PORT_OFFSET_CONFIG);
+        String portOffset = System.getProperty(PORT_OFFSET_SYSTEM_VAR, portOffsetInCarbonXML);
+
+        if (portOffset != null) {
+            return Integer.parseInt(portOffset.trim());
+        } else {
             return 0;
         }
 

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint.persistence/src/main/java/org/wso2/carbon/inbound/endpoint/persistence/PersistenceUtils.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint.persistence/src/main/java/org/wso2/carbon/inbound/endpoint/persistence/PersistenceUtils.java
@@ -316,22 +316,34 @@ public class PersistenceUtils {
         //Read the property of web socket endpoint ws.use.port.offset
         boolean usePortOffset = Boolean.valueOf(properties.getProperty(WEBSOCKET_USE_PORT_OFFSET));
         if (usePortOffset) {
-            //if its true return port offset according to the below
-            ServerConfiguration carbonConfig = ServerConfiguration.getInstance();
-            String portOffset = System.getProperty(PORT_OFFSET_SYSTEM_VAR,
-                    carbonConfig.getFirstProperty(PORT_OFFSET_CONFIG));
-            try {
-                if ((portOffset != null)) {
-                    return Integer.parseInt(portOffset.trim());
-                } else {
-                    return 0;
-                }
-            } catch (NumberFormatException e) {
-                log.error("Invalid Port Offset: " + portOffset + ". Default value 0 will be used.", e);
-                return 0;
-            }
+            //if its true return port offset accordingly
+            return getPortOffset();
         }
         // else return the 0 as it not need to have port offset
         return 0;
     }
+
+    /**
+     * Used to get the port offset value of server
+     *
+     * @return port offset of server
+     */
+    public static int getPortOffset() {
+
+        ServerConfiguration carbonConfig = ServerConfiguration.getInstance();
+        String portOffset = System
+                .getProperty(PORT_OFFSET_SYSTEM_VAR, carbonConfig.getFirstProperty(PORT_OFFSET_CONFIG));
+        try {
+            if (portOffset != null) {
+                return Integer.parseInt(portOffset.trim());
+            } else {
+                return 0;
+            }
+        } catch (NumberFormatException e) {
+            log.error("Invalid Port Offset: " + portOffset + ". Default value 0 will be used.", e);
+            return 0;
+        }
+
+    }
+
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/EndpointListenerLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/EndpointListenerLoader.java
@@ -98,9 +98,8 @@ public class EndpointListenerLoader {
 
         int internalInboundPort = HTTPEndpointManager.getInstance().getInternalInboundPort();
         if (internalInboundPort != -1) {
-            HTTPEndpointManager.getInstance().startListener(
-                    internalInboundPort, InboundHttpConstants.INTERNAL_INBOUND_ENDPOINT_NAME, null);
-
+            HTTPEndpointManager.getInstance().startListener(internalInboundPort + PersistenceUtils.getPortOffset(),
+                    InboundHttpConstants.INTERNAL_INBOUND_ENDPOINT_NAME, null);
         }
         //Load tenats required for polling inbound protocols
         Map<String, Set<String>> mPollingEndpoints =

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/EndpointListenerLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/EndpointListenerLoader.java
@@ -95,11 +95,8 @@ public class EndpointListenerLoader {
             }
         }
 
-        int internalInboundPort = HTTPEndpointManager.getInstance().getInternalInboundPort();
-        if (internalInboundPort != -1 && HTTPEndpointManager.getInstance().isAnyInternalApiEnabled()) {
-            HTTPEndpointManager.getInstance().startListener(internalInboundPort + PersistenceUtils.getPortOffset(),
-                    InboundHttpConstants.INTERNAL_INBOUND_ENDPOINT_NAME, null);
-        }
+        loadInternalInboundApis();
+
         //Load tenats required for polling inbound protocols
         Map<String, Set<String>> mPollingEndpoints =
 		                                  InboundEndpointsDataStore.getInstance().getAllPollingingEndpointData();
@@ -108,6 +105,14 @@ public class EndpointListenerLoader {
         ConfigurationContext mainConfigCtx = configurationContext.getServerConfigContext();
         for (String tenantDomain : mPollingEndpoints.keySet()) {
             TenantAxisUtils.getTenantConfigurationContext(tenantDomain, mainConfigCtx);
+        }
+    }
+
+    private static void loadInternalInboundApis() {
+        int internalInboundPort = HTTPEndpointManager.getInstance().getInternalInboundPort();
+        if (internalInboundPort != -1 && HTTPEndpointManager.getInstance().isAnyInternalApiEnabled()) {
+            HTTPEndpointManager.getInstance().startListener(internalInboundPort + PersistenceUtils.getPortOffset(),
+                                                            InboundHttpConstants.INTERNAL_INBOUND_ENDPOINT_NAME, null);
         }
     }
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/EndpointListenerLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/EndpointListenerLoader.java
@@ -26,7 +26,6 @@ import org.wso2.carbon.inbound.endpoint.persistence.service.InboundEndpointPersi
 import org.wso2.carbon.inbound.endpoint.protocol.generic.GenericInboundListener;
 import org.wso2.carbon.inbound.endpoint.protocol.hl7.management.HL7EndpointManager;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpConstants;
-import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
 import org.wso2.carbon.inbound.endpoint.protocol.http.management.HTTPEndpointManager;
 import org.wso2.carbon.inbound.endpoint.protocol.websocket.management.WebsocketEndpointManager;
 import org.wso2.carbon.utils.ConfigurationContextService;
@@ -97,7 +96,7 @@ public class EndpointListenerLoader {
         }
 
         int internalInboundPort = HTTPEndpointManager.getInstance().getInternalInboundPort();
-        if (internalInboundPort != -1) {
+        if (internalInboundPort != -1 && HTTPEndpointManager.getInstance().isAnyInternalApiEnabled()) {
             HTTPEndpointManager.getInstance().startListener(internalInboundPort + PersistenceUtils.getPortOffset(),
                     InboundHttpConstants.INTERNAL_INBOUND_ENDPOINT_NAME, null);
         }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
@@ -65,14 +65,15 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
 
     private InternalAPIDispatcher internalAPIDispatcher;
 
-    private List<InternalAPI> internalAPIList = null;
+    private boolean internalApiEnabled;
 
     private HTTPEndpointManager() {
         super();
         internalInboundPort = ConfigurationLoader.getInternalInboundPort();
         if (internalInboundPort != -1) {
-            internalAPIList = ConfigurationLoader.loadInternalAPIs(Constants.INTERNAL_APIS_FILE);
+            List<InternalAPI> internalAPIList = ConfigurationLoader.loadInternalAPIs(Constants.INTERNAL_APIS_FILE);
             internalAPIDispatcher = new InternalAPIDispatcher(internalAPIList);
+            internalApiEnabled = internalAPIList != null && internalAPIList.isEmpty();
         }
     }
 
@@ -437,6 +438,6 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
      * @return - whether any internal API is enabled.
      */
     public boolean isAnyInternalApiEnabled() {
-        return internalAPIList != null && internalAPIList.size() > 0;
+        return internalApiEnabled;
     }
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
@@ -27,6 +27,7 @@ import org.apache.synapse.transport.passthru.core.ssl.SSLConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.inbound.endpoint.common.AbstractInboundEndpointManager;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.Constants;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPI;
 import org.wso2.carbon.inbound.endpoint.persistence.InboundEndpointInfoDTO;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpConfiguration;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpConstants;
@@ -64,12 +65,14 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
 
     private InternalAPIDispatcher internalAPIDispatcher;
 
+    private List<InternalAPI> internalAPIList = null;
+
     private HTTPEndpointManager() {
         super();
         internalInboundPort = ConfigurationLoader.getInternalInboundPort();
         if (internalInboundPort != -1) {
-            internalAPIDispatcher =
-                    new InternalAPIDispatcher(ConfigurationLoader.loadInternalAPIs(Constants.INTERNAL_APIS_FILE));
+            internalAPIList = ConfigurationLoader.loadInternalAPIs(Constants.INTERNAL_APIS_FILE);
+            internalAPIDispatcher = new InternalAPIDispatcher(internalAPIList);
         }
     }
 
@@ -426,5 +429,9 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
 
     public int getInternalInboundPort() {
         return internalInboundPort;
+    }
+
+    public boolean isAnyInternalApiEnabled() {
+        return internalAPIList != null && internalAPIList.size() > 0;
     }
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
@@ -431,6 +431,11 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
         return internalInboundPort;
     }
 
+    /**
+     * Checks whether at least one internal API is enabled.
+     *
+     * @return - whether any internal API is enabled.
+     */
     public boolean isAnyInternalApiEnabled() {
         return internalAPIList != null && internalAPIList.size() > 0;
     }


### PR DESCRIPTION

This PR is added to check the port offset and start the internal APIs with port offset if it is specified.

Also starts the Internal Endpoint Listener only if at least one API is enabled.