### PR TITLE
Remove packing commons-text from carbon-mediation.

### DIFF
--- a/features/synapse-features/org.apache.synapse.wso2.feature/pom.xml
+++ b/features/synapse-features/org.apache.synapse.wso2.feature/pom.xml
@@ -92,10 +92,6 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-        </dependency>
-        <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>accessors-smart</artifactId>
         </dependency>
@@ -146,7 +142,6 @@
                                 <!--<bundleDef>org.wso2.orbit.joda-time:joda-time:${joda-time.version}</bundleDef>-->
                                 <bundleDef>com.google.guava:guava:${google.guava.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.com.github.fge:json-schema-validator-all</bundleDef>
-                                <bundleDef>org.apache.commons:commons-text:${commons-text.version}</bundleDef>
                             </bundles>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -336,11 +336,6 @@
             </dependency>
             <!--3 Apache -->
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-                <version>${commons-text.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons.wso2</groupId>
                 <artifactId>commons-vfs2</artifactId>
                 <version>${commons.vfs.version}</version>
@@ -2546,7 +2541,6 @@
         <esotericsoftware.minlog.version>1.3.0</esotericsoftware.minlog.version>
         <orbit.version.snakeyaml>1.16.0.wso2v1</orbit.version.snakeyaml>
         <orbit.snakeyaml.import.version.range>[1.16.0.wso2v1, 2.0.0)</orbit.snakeyaml.import.version.range>
-        <commons-text.version>1.6</commons-text.version>
         <!-- OWASP encoder versions -->
         <owasp.encoder.wso2.version>1.2.0.wso2v1</owasp.encoder.wso2.version>
         <owasp.encoder.wso2.imp.pkg.version>[1.2.0,1.3.0)</owasp.encoder.wso2.imp.pkg.version>


### PR DESCRIPTION
commons-text is packed with kernel itself.

Reverting https://github.com/wso2/carbon-mediation/pull/1137/commits/c7daa7100e56e2f961db1b42d5adb26a640a990d