### PR TITLE
Add HTTPS Listner for Internal Apis

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
@@ -22,6 +22,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.commons.util.MiscellaneousUtil;
+import org.apache.synapse.transport.passthru.core.ssl.SSLConfiguration;
+import org.wso2.carbon.inbound.endpoint.persistence.PersistenceUtils;
 import org.wso2.carbon.utils.CarbonUtils;
 
 import javax.xml.namespace.QName;
@@ -44,58 +46,122 @@ public class ConfigurationLoader {
 
     private static Log log = LogFactory.getLog(ConfigurationLoader.class);
 
-    private static final QName ROOT_Q = new QName("apis");
-    private static final QName HANDLER_Q = new QName("api");
+    private static final QName ROOT_Q = new QName("internalApis");
+    private static final QName API_Q = new QName("api");
     private static final QName CLASS_Q = new QName("class");
     private static final QName NAME_ATT = new QName("name");
+    private static final QName PROTOCOL_Q = new QName("protocol");
 
-    public static List<InternalAPI> loadInternalAPIs(String apiFilePath) {
+    private static final String APIS = "apis";
+    private static final String SSL_CONFIG = "sslConfig";
+    private static final String KEYSTORE_ATT = "keystore";
+    private static final String TRUSTSTORE_ATT = "truststore";
+    private static final String SSL_VERIFY_CLIENT_ATT = "sslVerifyClient";
+    private static final String SSL_PROTOCOL_ATT = "sslProtocol";
+    private static final String HTTPS_PROTOCOLS_ATT = "httpsProtocols";
+    private static final String CERTIFICATE_REVOCATION_VERIFIER_ATT = "certificateRevocationVerifier";
+    private static final String PREFERRED_CIPHERS_ATT = "preferredCiphers";
 
-        List<InternalAPI> internalApis = new ArrayList<>();
+    private static SSLConfiguration sslConfiguration;
+    private static boolean sslConfiguredSuccessfully;
+
+    private static List<InternalAPI> internalHttpApiList = new ArrayList<>();
+    private static List<InternalAPI> internalHttpsApiList = new ArrayList<>();
+
+    private static String internalInboundHttpPortProperty;
+    private static String internalInboundHttpsPortProperty;
+
+    private static final int PORT_OFFSET = PersistenceUtils.getPortOffset();
+
+    public static void loadInternalApis(String apiFilePath) {
+
         OMElement apiConfig = MiscellaneousUtil.loadXMLConfig(apiFilePath);
+
         if (apiConfig != null) {
 
             if (!ROOT_Q.equals(apiConfig.getQName())) {
                 handleException("Invalid internal api configuration file");
             }
 
-            Iterator iterator = apiConfig.getChildrenWithName(HANDLER_Q);
-            while (iterator.hasNext()) {
-                OMElement handlerElem = (OMElement) iterator.next();
+            Iterator apiIterator = apiConfig.getChildrenWithLocalName(APIS);
 
-                String name = null;
-                if (handlerElem.getAttribute(NAME_ATT) != null) {
-                    name = handlerElem.getAttributeValue(NAME_ATT);
-                    if (name == null || name.isEmpty()) {
-                        handleException("Name not specified in one or more handlers");
-                    }
-                    if (!Boolean.parseBoolean(System.getProperty(Constants.PREFIX_TO_ENABLE_INTERNAL_APIS + name))) {
-                        continue;
-                    }
-                } else {
-                    handleException("Name not defined in one or more handlers");
-                }
+            if (apiIterator.hasNext()) {
 
-                if (handlerElem.getAttribute(CLASS_Q) != null) {
-                    String className = handlerElem.getAttributeValue(CLASS_Q);
-                    if (!className.isEmpty()) {
-                        InternalAPI internalApi = createAPI(className);
-                        if (internalApi != null) {
-                            internalApis.add(internalApi);
-                            internalApi.setName(name);
+                OMElement apis = (OMElement) apiIterator.next();
+                Iterator apiList = apis.getChildrenWithName(API_Q);
+                if (apiList != null) {
+
+                    Iterator sslConfigIterator = apiConfig.getChildrenWithLocalName(SSL_CONFIG);
+                    if (sslConfigIterator.hasNext()) {
+                        sslConfiguration = setSslConfig((OMElement) sslConfigIterator.next());
+                    }
+
+                    while (apiList.hasNext()) {
+
+                        OMElement apiElement = (OMElement) apiList.next();
+                        String name = null;
+
+                        if (apiElement.getAttribute(NAME_ATT) != null) {
+                            name = apiElement.getAttributeValue(NAME_ATT);
+                            if (name == null || name.isEmpty()) {
+                                handleException("Name not specified in one or more handlers");
+                            }
+                            if (!Boolean.parseBoolean(
+                                    System.getProperty(Constants.PREFIX_TO_ENABLE_INTERNAL_APIS + name))) {
+                                continue;
+                            }
+                        } else {
+                            handleException("Name not defined in one or more handlers");
                         }
-                    } else {
-                        handleException("Class name is null for Internal InternalAPI name : " + name);
+
+                        if (apiElement.getAttribute(CLASS_Q) != null) {
+
+                            String className = apiElement.getAttributeValue(CLASS_Q);
+                            if (!className.isEmpty()) {
+
+                                InternalAPI internalApi = createApi(className);
+                                internalApi.setName(name);
+
+                                if (apiElement.getAttribute(PROTOCOL_Q) != null) {
+
+                                    String protocols = apiElement.getAttributeValue(PROTOCOL_Q);
+                                    if (!protocols.isEmpty()) {
+
+                                        String[] protocolList = protocols.split(" ");
+                                        for (String protocol : protocolList) {
+                                            switch (protocol) {
+                                            case "http":
+                                                internalHttpApiList.add(internalApi);
+                                                break;
+                                            case "https":
+                                                internalHttpsApiList.add(internalApi);
+                                                break;
+                                            default:
+                                                handleException("Unsupported Protocol found for Internal API");
+                                            }
+                                        }
+
+                                    } else {
+                                        log.warn("No protocol specified for InternalAPI : " + name
+                                                + ". Hence it will not be enabled.");
+                                    }
+                                } else {
+                                    log.warn("Protocol not defined for InternalAPI : " + name
+                                            + ". Hence it will not be enabled.");
+                                }
+                            } else {
+                                handleException("Class name is null for Internal InternalAPI name : " + name);
+                            }
+                        } else {
+                            handleException("Class name not defined for Internal InternalAPI named : " + name);
+                        }
                     }
-                } else {
-                    handleException("Class name not defined for Internal InternalAPI named : " + name);
                 }
             }
         }
-        return internalApis;
     }
 
-    private static InternalAPI createAPI(String classFQName) {
+    private static InternalAPI createApi(String classFQName) {
 
         Object obj = null;
         try {
@@ -107,54 +173,34 @@ public class ConfigurationLoader {
         if (obj instanceof InternalAPI) {
             return (InternalAPI) obj;
         } else {
-            handleException("Error creating Internal InternalAPI. The InternalAPI should be of type " +
-                    "InternalAPI");
+            handleException("Error creating Internal InternalAPI. The InternalAPI should be of type InternalAPI");
         }
         return null;
     }
 
+    public static int getInternalInboundHttpPort() {
 
-    public static int getInternalInboundPort() {
+        return getPort(Constants.INTERNAL_HTTP_API_PORT, internalInboundHttpPortProperty,
+                Constants.DEFAULT_INTERNAL_HTTP_API_PORT);
+    }
 
-        File synapseProperties = Paths.get(CarbonUtils.getCarbonConfigDirPath(), "synapse.properties").toFile();
-        Properties properties = new Properties();
-        InputStream inputStream = null;
-        try {
-            inputStream = new FileInputStream(synapseProperties);
-            properties.load(inputStream);
-        } catch (FileNotFoundException e) {
-            handleException("synapse.properties file not found", e);
-        } catch (IOException e) {
-            handleException("Error while reading synapse.properties file", e);
-        } finally {
-            if (inputStream != null) {
-                try {
-                    inputStream.close();
-                } catch (IOException ignored) {
-                }
-            }
-        }
-        int internalInboundPort = Constants.DEFAULT_INTERNAL_HTTP_API_PORT;
+    public static int getInternalInboundHttpsPort() {
 
-        String internalInboundEnabledProperty = properties.getProperty(Constants.INTERNAL_HTTP_API_ENABLED);
-        if (internalInboundEnabledProperty == null) {
-            return -1;
-        }
-        boolean internalInboundEnabled = Boolean.parseBoolean(internalInboundEnabledProperty);
-        if (!internalInboundEnabled) {
-            return -1;
-        }
+        return getPort(Constants.INTERNAL_HTTPS_API_PORT, internalInboundHttpsPortProperty,
+                Constants.DEFAULT_INTERNAL_HTTPS_API_PORT);
+    }
 
-        String internalInboundPortProperty =
-                properties.getProperty(Constants.INTERNAL_HTTP_API_PORT);
-        if (internalInboundPortProperty != null) {
+    private static int getPort(String propertyName, String portProperty, int defaultPort) {
+
+        int port = defaultPort;
+        if (portProperty != null) {
             try {
-                internalInboundPort = Integer.parseInt(internalInboundPortProperty);
-            } catch (Exception ex) {
-                handleException(Constants.INTERNAL_HTTP_API_PORT + " is not in proper format", ex);
+                port = Integer.parseInt(portProperty);
+            } catch (NumberFormatException ex) {
+                handleException(propertyName + " is not in proper format", ex);
             }
         }
-        return internalInboundPort;
+        return port + PORT_OFFSET;
     }
 
     private static void handleException(String msg) {
@@ -166,4 +212,122 @@ public class ConfigurationLoader {
         log.error(msg, ex);
         throw new SynapseException(msg, ex);
     }
+
+    public static SSLConfiguration getSslConfiguration() {
+        return sslConfiguration;
+    }
+
+    public static List<InternalAPI> getHttpInternalApis() {
+        return internalHttpApiList;
+    }
+
+    public static List<InternalAPI> getHttpsInternalApis() {
+        return internalHttpsApiList;
+    }
+
+    public static boolean isSslConfiguredSuccessfully() {
+        return sslConfiguredSuccessfully;
+    }
+
+    /**
+     * Reads and check from the synapse properties file whether the Internal api is enabled.
+     *
+     * @return - whether internal api is enabled in synapse properties file.
+     */
+    public static boolean isInternalApiEnabled() {
+
+        File synapseProperties = Paths.get(CarbonUtils.getCarbonConfigDirPath(), "synapse.properties").toFile();
+        Properties properties = new Properties();
+        try (InputStream inputStream = new FileInputStream(synapseProperties)) {
+            properties.load(inputStream);
+        } catch (FileNotFoundException e) {
+            handleException("synapse.properties file not found", e);
+        } catch (IOException e) {
+            handleException("Error while reading synapse.properties file", e);
+        }
+        String internalInboundEnabledProperty = properties.getProperty(Constants.INTERNAL_HTTP_API_ENABLED);
+        if (internalInboundEnabledProperty == null) {
+            return false;
+        }
+        boolean isEnabled = Boolean.parseBoolean(internalInboundEnabledProperty);
+        if (isEnabled) {
+            internalInboundHttpPortProperty = properties.getProperty(Constants.INTERNAL_HTTP_API_PORT);
+            internalInboundHttpsPortProperty = properties.getProperty(Constants.INTERNAL_HTTPS_API_PORT);
+        }
+        return isEnabled;
+    }
+
+    private static SSLConfiguration setSslConfig(OMElement sslConfig) {
+
+        Iterator iterator = sslConfig.getChildElements();
+
+        String trustStore = null;
+        String keyStore = null;
+        String clientAuth = null;
+        String httpsProtocols = null;
+        String revocationVerifier = null;
+        String sslProtocol = null;
+        String prefferedCiphers = null;
+
+        while (iterator.hasNext()) {
+
+            OMElement parameter = (OMElement) iterator.next();
+            String attributeName = parameter.getAttributeValue(NAME_ATT);
+
+            if (parameter.getFirstElement() != null) {
+
+                String value = parameter.getFirstElement().toString();
+
+                switch (attributeName) {
+                case KEYSTORE_ATT:
+                    keyStore = value;
+                    break;
+                case TRUSTSTORE_ATT:
+                    trustStore = value;
+                    break;
+                case CERTIFICATE_REVOCATION_VERIFIER_ATT:
+                    revocationVerifier = value;
+                    break;
+                default:
+                    handleException("Invalid parameter found for internal API ssl configuration");
+                }
+
+            } else {
+
+                String value = parameter.getText();
+
+                switch (attributeName) {
+                case SSL_PROTOCOL_ATT:
+                    sslProtocol = value;
+                    break;
+                case PREFERRED_CIPHERS_ATT:
+                    prefferedCiphers = value;
+                    break;
+                case HTTPS_PROTOCOLS_ATT:
+                    httpsProtocols = value;
+                    break;
+                case SSL_VERIFY_CLIENT_ATT:
+                    clientAuth = value;
+                    break;
+                default:
+                    handleException("Invalid parameter found for internal API ssl configuration");
+                }
+            }
+        }
+
+        if (keyStore == null) {
+            log.error("Keystore must be specified to configure internal Https Api.");
+        } else {
+            sslConfiguredSuccessfully = true;
+        }
+
+        return new SSLConfiguration(keyStore, trustStore, clientAuth, httpsProtocols, revocationVerifier, sslProtocol,
+                prefferedCiphers);
+    }
+
+    public static void destroy() {
+        internalHttpApiList = new ArrayList<>();
+        internalHttpsApiList = new ArrayList<>();
+    }
+
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
@@ -23,7 +23,9 @@ package org.wso2.carbon.inbound.endpoint.internal.http.api;
 public class Constants {
 
     static final String INTERNAL_HTTP_API_PORT = "internal.http.api.port";
+    static final String INTERNAL_HTTPS_API_PORT = "internal.https.api.port";
     static final int DEFAULT_INTERNAL_HTTP_API_PORT = 9191;
+    static final int DEFAULT_INTERNAL_HTTPS_API_PORT = 9154;
     static final String INTERNAL_HTTP_API_ENABLED = "internal.http.api.enabled";
     public static final String INTERNAL_APIS_FILE = "internal-apis.xml";
     public static final String PREFIX_TO_ENABLE_INTERNAL_APIS = "enable";

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
@@ -67,6 +67,7 @@ public class InboundHttpConstants {
     /** Parameter name for preferred ciphers in inbound endpoint configs **/
     public static final String PREFERRED_CIPHERS = "PreferredCiphers";
 
-    public static final String INTERNAL_INBOUND_ENDPOINT_NAME = "EI_INTERNAL_INBOUND_ENDPOINT";
+    public static final String INTERNAL_HTTP_INBOUND_ENDPOINT_NAME = "EI_INTERNAL_HTTP_INBOUND_ENDPOINT";
+    public static final String INTERNAL_HTTPS_INBOUND_ENDPOINT_NAME = "EI_INTERNAL_HTTPS_INBOUND_ENDPOINT";
 
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
@@ -71,7 +71,8 @@ public class InboundHttpServerWorker extends ServerWorker {
     private RESTRequestHandler restHandler;
     private Pattern dispatchPattern;
     private Matcher patternMatcher;
-    private boolean isInternalInboundEndpoint;
+    private boolean isInternalHttpInboundEndpoint;
+    private boolean isInternalHttpsInboundEndpoint;
 
     public InboundHttpServerWorker(int port, String tenantDomain,
                                    SourceRequest sourceRequest,
@@ -82,7 +83,8 @@ public class InboundHttpServerWorker extends ServerWorker {
         this.port = port;
         this.tenantDomain = tenantDomain;
         restHandler = new RESTRequestHandler();
-        isInternalInboundEndpoint = (HTTPEndpointManager.getInstance().getInternalInboundPort() == port);
+        isInternalHttpInboundEndpoint = (HTTPEndpointManager.getInstance().getInternalInboundHttpPort() == port);
+        isInternalHttpsInboundEndpoint = (HTTPEndpointManager.getInstance().getInternalInboundHttpsPort() == port);
     }
 
     public void run() {
@@ -103,9 +105,16 @@ public class InboundHttpServerWorker extends ServerWorker {
                         getRequestLine().getMethod().toUpperCase() : "";
                 processHttpRequestUri(axis2MsgContext, method);
 
-                if (isInternalInboundEndpoint) {
+                if (isInternalHttpInboundEndpoint) {
                     doPreInjectTasks(axis2MsgContext, (Axis2MessageContext) synCtx, method);
-                    boolean result = HTTPEndpointManager.getInstance().getInternalAPIDispatcher().dispatch(synCtx);
+                    boolean result = HTTPEndpointManager.getInstance().getInternalHttpApiDispatcher().dispatch(synCtx);
+                    respond(synCtx, result);
+                    return;
+                }
+
+                if (isInternalHttpsInboundEndpoint) {
+                    doPreInjectTasks(axis2MsgContext, (Axis2MessageContext) synCtx, method);
+                    boolean result = HTTPEndpointManager.getInstance().getInternalHttpsApiDispatcher().dispatch(synCtx);
                     respond(synCtx, result);
                     return;
                 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/management/HTTPEndpointManager.java
@@ -26,16 +26,15 @@ import org.apache.synapse.transport.passthru.config.SourceConfiguration;
 import org.apache.synapse.transport.passthru.core.ssl.SSLConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.inbound.endpoint.common.AbstractInboundEndpointManager;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.Constants;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPI;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPIDispatcher;
 import org.wso2.carbon.inbound.endpoint.persistence.InboundEndpointInfoDTO;
-import org.wso2.carbon.inbound.endpoint.persistence.PersistenceUtils;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpConfiguration;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpConstants;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpSourceHandler;
 import org.wso2.carbon.inbound.endpoint.protocol.http.config.WorkerPoolConfiguration;
-import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
-import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPIDispatcher;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -62,20 +61,25 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
     private ConcurrentHashMap<String, ConcurrentHashMap<Integer, Pattern>> dispatchPatternMap =
             new ConcurrentHashMap<String, ConcurrentHashMap<Integer, Pattern>>();
 
-    private int internalInboundPort;
-
-    private InternalAPIDispatcher internalAPIDispatcher;
-
-    private boolean internalApiEnabled;
+    private int internalInboundHttpPort;
+    private int internalInboundHttpsPort;
+    private InternalAPIDispatcher internalHttpApiDispatcher;
+    private InternalAPIDispatcher internalHttpsApiDispatcher;
+    private boolean internalHttpApiEnabled;
+    private boolean internalHttpsApiEnabled;
 
     private HTTPEndpointManager() {
         super();
-        internalInboundPort = ConfigurationLoader.getInternalInboundPort();
-        if (internalInboundPort != -1) {
-            internalInboundPort += PersistenceUtils.getPortOffset();
-            List<InternalAPI> internalAPIList = ConfigurationLoader.loadInternalAPIs(Constants.INTERNAL_APIS_FILE);
-            internalAPIDispatcher = new InternalAPIDispatcher(internalAPIList);
-            internalApiEnabled = !internalAPIList.isEmpty();
+        if (ConfigurationLoader.isInternalApiEnabled()) {
+            internalInboundHttpPort = ConfigurationLoader.getInternalInboundHttpPort();
+            internalInboundHttpsPort = ConfigurationLoader.getInternalInboundHttpsPort();
+            ConfigurationLoader.loadInternalApis(Constants.INTERNAL_APIS_FILE);
+            List<InternalAPI> httpInternalAPIList = ConfigurationLoader.getHttpInternalApis();
+            internalHttpApiDispatcher = new InternalAPIDispatcher(httpInternalAPIList);
+            internalHttpApiEnabled = !httpInternalAPIList.isEmpty();
+            List<InternalAPI> httpsInternalAPIList = ConfigurationLoader.getHttpsInternalApis();
+            internalHttpsApiDispatcher = new InternalAPIDispatcher(httpsInternalAPIList);
+            internalHttpsApiEnabled = !httpsInternalAPIList.isEmpty();
         }
     }
 
@@ -426,20 +430,37 @@ public class HTTPEndpointManager extends AbstractInboundEndpointManager {
         }
     }
 
-    public InternalAPIDispatcher getInternalAPIDispatcher() {
-        return internalAPIDispatcher;
+    public InternalAPIDispatcher getInternalHttpApiDispatcher() {
+        return internalHttpApiDispatcher;
     }
 
-    public int getInternalInboundPort() {
-        return internalInboundPort;
+    public InternalAPIDispatcher getInternalHttpsApiDispatcher() {
+        return internalHttpsApiDispatcher;
+    }
+
+    public int getInternalInboundHttpPort() {
+        return internalInboundHttpPort;
+    }
+
+    public int getInternalInboundHttpsPort() {
+        return internalInboundHttpsPort;
     }
 
     /**
-     * Checks whether at least one internal API is enabled.
+     * Checks whether at least one internal http api is enabled.
      *
-     * @return - whether any internal API is enabled.
+     * @return - whether any internal http api enabled.
      */
-    public boolean isAnyInternalApiEnabled() {
-        return internalApiEnabled;
+    public boolean isAnyInternalHttpApiEnabled() {
+        return internalHttpApiEnabled;
+    }
+
+    /**
+     * Checks whether at least one internal https api is enabled.
+     *
+     * @return - whether any internal https api is enabled.
+     */
+    public boolean isAnyInternalHttpsApiEnabled() {
+        return internalHttpsApiEnabled;
     }
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/ConfigurationLoaderTestCase.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/ConfigurationLoaderTestCase.java
@@ -18,6 +18,7 @@
 package internal.http.api;
 
 import junit.framework.Assert;
+import org.junit.After;
 import org.junit.Test;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.Constants;
@@ -37,10 +38,16 @@ public class ConfigurationLoaderTestCase {
         URL url = getClass().getResource("internal-apis.xml");
         Assert.assertNotNull("Configuration file not found", url);
 
-        List<InternalAPI> apis = ConfigurationLoader.loadInternalAPIs("internal/http/api/internal-apis.xml");
+        ConfigurationLoader.loadInternalApis("internal/http/api/internal-apis.xml");
+        List<InternalAPI> apis = ConfigurationLoader.getHttpInternalApis();
         Assert.assertEquals("Expected number of APIs not found", 1, apis.size());
         Assert.assertEquals("Loaded API name is not correct", "SampleAPI" , apis.get(0).getName());
         Assert.assertEquals("Loaded API context is not correct", "/foo" , apis.get(0).getContext());
+    }
+
+    @After
+    public void cleanup(){
+        ConfigurationLoader.destroy();
     }
 
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/DispatcherTestCase.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/java/internal/http/api/DispatcherTestCase.java
@@ -27,6 +27,7 @@ import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
 import org.apache.synapse.core.axis2.MessageContextCreatorForAxis2;
+import org.junit.After;
 import org.junit.Test;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPI;
@@ -43,8 +44,10 @@ public class DispatcherTestCase {
     public void testDispatching() throws Exception {
         System.setProperty(org.wso2.carbon.inbound.endpoint.internal.http.api.Constants.PREFIX_TO_ENABLE_INTERNAL_APIS
                 + "SampleAPI", "true");
-        List<InternalAPI> apis = ConfigurationLoader.loadInternalAPIs("internal/http/api/internal-apis.xml");
-        Assert.assertEquals("Expected API not loaded", 1, apis.size());
+
+        ConfigurationLoader.loadInternalApis("internal/http/api/internal-apis.xml");
+        List<InternalAPI> apis = ConfigurationLoader.getHttpInternalApis();
+                Assert.assertEquals("Expected API not loaded", 1, apis.size());
 
         InternalAPIDispatcher internalAPIDispatcher = new InternalAPIDispatcher(apis);
         MessageContext synCtx = createMessageContext();
@@ -73,5 +76,10 @@ public class DispatcherTestCase {
         org.apache.axis2.context.MessageContext axis2Ctx = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
         axis2Ctx.setProperty(Constants.Configuration.TRANSPORT_IN_URL, path);
         axis2Ctx.setProperty(Constants.Configuration.HTTP_METHOD, method);
+    }
+
+    @After
+    public void cleanup(){
+        ConfigurationLoader.destroy();
     }
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/resources/internal/http/api/internal-apis.xml
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/test/resources/internal/http/api/internal-apis.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -16,6 +16,34 @@
   ~ under the License.
   -->
 
-<apis>
-  <api name="SampleAPI" class="internal.http.api.SampleInternalAPI"/>
-</apis>
+<internalApis>
+    <apis>
+        <api name="SampleAPI" protocol="http https" class="internal.http.api.SampleInternalAPI"/>
+    </apis>
+    <sslConfig>
+        <parameter name="keystore">
+            <KeyStore>
+                <Location>repository/resources/security/wso2carbon.jks</Location>
+                <Type>JKS</Type>
+                <Password>wso2carbon</Password>
+                <KeyPassword>wso2carbon</KeyPassword>
+            </KeyStore>
+        </parameter>
+        <parameter name="truststore">
+            <TrustStore>
+                <Location>repository/resources/security/client-truststore.jks</Location>
+                <Type>JKS</Type>
+                <Password>wso2carbon</Password>
+            </TrustStore>
+        </parameter>
+        <parameter name="sslVerifyClient">false</parameter>
+        <parameter name="httpsProtocols">TLSv1,TLSv1.1,TLSv1.2</parameter>
+        <parameter name="sslProtocol">SSLV3</parameter>
+        <parameter name="certificateRevocationVerifier">
+            <CertificateRevocationVerifier enable="false">
+                <CacheSize>10</CacheSize>
+                <CacheDelay>2</CacheDelay>
+            </CertificateRevocationVerifier>
+        </parameter>
+    </sslConfig>
+</internalApis>


### PR DESCRIPTION
## Purpose
>  Facilitate HTTPS Listener for Internal APIs.

## Goals
> Facilitate HTTPS Listener for Internal APIs.

## Approach
>  Strart the HTTPS Listner also if the API has protocol https.

**Updated Internal API Config**
```
<internalApis>
    <apis>
        <api name="PrometheusApi" protocol="http" class="org.wso2.carbon.prometheus.publisher.service.MetricAPI"/>
        <api name="ManagementApi" protocol="https"
             class="org.wso2.carbon.micro.integrator.management.apis.ManagementInternalAPI"/>
    </apis>
    <sslConfig>
        <parameter name="keystore">
            <KeyStore>
                <Location>repository/resources/security/wso2carbon.jks</Location>
                <Type>JKS</Type>
                <Password>wso2carbon</Password>
                <KeyPassword>wso2carbon</KeyPassword>
            </KeyStore>
        </parameter>
        <parameter name="truststore">
            <TrustStore>
                <Location>repository/resources/security/client-truststore.jks</Location>
                <Type>JKS</Type>
                <Password>wso2carbon</Password>
            </TrustStore>
        </parameter>
        <parameter name="sslVerifyClient">false</parameter>
        <parameter name="httpsProtocols">TLSv1,TLSv1.1,TLSv1.2</parameter>
        <parameter name="sslProtocol">SSLV3</parameter>
        <parameter name="certificateRevocationVerifier">
            <CertificateRevocationVerifier enable="false">
                <CacheSize>10</CacheSize>
                <CacheDelay>2</CacheDelay>
            </CertificateRevocationVerifier>
        </parameter>
    </sslConfig>
</internalApis>
```