### PR TITLE
Fix endpoint radio button getting deselected when adding endpoint as the clone target 

### DIFF
--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.target.ui/src/main/resources/web/target-mediator/js/mediator-util.js
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.target.ui/src/main/resources/web/target-mediator/js/mediator-util.js
@@ -180,9 +180,6 @@ function hideEpOps() {
 
 function disableEnableEndPointOnSequencRef(selectOp){
     var theObj = document.getElementById(selectOp);
-    document.getElementById('epOpNone').checked=false;
-    document.getElementById('epOpAnon').checked=false;
-    document.getElementById('epOpReg').checked=false;
          
     if(theObj != null && theObj.checked){
       document.getElementById('epOpNone').disabled="true";


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/wso2/product-ei/issues/3812

>When trying to add an endpoint as a clone target, it rejects the input data and shows empty tags. 
It happens because the radio button gets deselected after refreshing the page. 

## Goals
> Add an endpoint as a clone target and able to successfully switch between design view and source view.

## Approach
> Not letting the radio button to get deselected when refreshing the page