### PR TITLE
Check the environment property when enabling Management Apis

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
@@ -106,8 +106,9 @@ public class ConfigurationLoader {
                             if (name == null || name.isEmpty()) {
                                 handleException("Name not specified in one or more handlers");
                             }
-                            if (!Boolean.parseBoolean(
-                                    System.getProperty(Constants.PREFIX_TO_ENABLE_INTERNAL_APIS + name))) {
+                            String property = Constants.PREFIX_TO_ENABLE_INTERNAL_APIS + name;
+                            if (!Boolean.parseBoolean(System.getProperty(property)) && !Boolean
+                                    .parseBoolean(System.getenv(property))) {
                                 continue;
                             }
                         } else {


### PR DESCRIPTION
## Purpose
>  Honour the environment property in addition to system property when starting Management Apis.

System property has more priority than environment property.