### PR TITLE
Store media type of registry resources in file and retrieve

### DIFF
--- a/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/FileRegistryResourceDeployer.java
+++ b/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/FileRegistryResourceDeployer.java
@@ -89,15 +89,15 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
      * @param parentAppName - name of the parent cApp
      */
     private void deployRegistryArtifacts(List<Artifact> artifacts, String parentAppName) {
-        for (Artifact artifact : artifacts) {
-            if (REGISTRY_RESOURCE_TYPE.equals(artifact.getType())) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Deploying registry artifact: " + artifact.getName());
-                }
-                RegistryConfig regConfig = buildRegistryConfig(artifact, parentAppName);
-                writeArtifactToRegistry(regConfig);
-            }
-        }
+        artifacts.stream()
+                 .filter(artifact -> REGISTRY_RESOURCE_TYPE.equals(artifact.getType()))
+                 .forEach(artifact -> {
+                     if (log.isDebugEnabled()) {
+                         log.debug("Deploying registry artifact: " + artifact.getName());
+                     }
+                     RegistryConfig regConfig = buildRegistryConfig(artifact, parentAppName);
+                     writeArtifactToRegistry(regConfig);
+                 });
     }
 
 
@@ -166,8 +166,8 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
         List<RegistryConfig.Resourse> resources = registryConfig.getResources();
 
         for (RegistryConfig.Resourse resource : resources) {
-            String filePath = registryConfig.getExtractedPath() + File.separator +
-                    AppDeployerConstants.RESOURCES_DIR + File.separator + resource.getFileName();
+            String filePath = registryConfig.getExtractedPath() + File.separator + AppDeployerConstants.RESOURCES_DIR
+                    + File.separator + resource.getFileName();
 
             // check whether the file exists
             File file = new File(filePath);

--- a/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/FileRegistryResourceDeployer.java
+++ b/components/application-deployers/org.wso2.carbon.application.deployer.synapse/src/main/java/org/wso2/carbon/application/deployer/synapse/FileRegistryResourceDeployer.java
@@ -176,8 +176,8 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
                 continue;
             }
             String resourcePath = AppDeployerUtils.computeResourcePath(createRegistryKey(resource),resource.getFileName());
-            lightweightRegistry.newNonEmptyResource(resourcePath, false, null, readResourceContent(file), null);
-
+            String mediaType = resource.getMediaType();
+            lightweightRegistry.newNonEmptyResource(resourcePath, false, mediaType, readResourceContent(file), null);
         }
     }
 

--- a/components/mediation-registry/org.wso2.carbon.mediation.registry/src/main/java/org/wso2/carbon/mediation/registry/MicroIntegratorRegistry.java
+++ b/components/mediation-registry/org.wso2.carbon.mediation.registry/src/main/java/org/wso2/carbon/mediation/registry/MicroIntegratorRegistry.java
@@ -75,11 +75,11 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
      * File system path corresponding to the FILE url path. This is a system depending path
      * used for accessing resources as files.
      */
-    private String localRegistry = null;
+    private String localRegistry;
 
-    private String configRegistry = null;
+    private String configRegistry;
 
-    private String govRegistry = null;
+    private String govRegistry;
 
     /**
      * Specifies whether the registry is in the local host or a remote registry.
@@ -732,7 +732,7 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
      * @param metadata
      * @throws SynapseException
      */
-    private void writeToFile(URI parentName, String newFileName, String content, Properties metadata) throws SynapseException {
+    private void writeToFile(URI parentName, String newFileName, String content, Properties metadata) {
         /*
             search for parent. if found, create the new FILE in it
         */
@@ -761,9 +761,8 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
      * @param parent parent dir of the resource
      * @param resourceFileName filename of the resource
      * @param metadata metadata properties object
-     * @throws SynapseException
      */
-    private void writeMetadata(File parent, String resourceFileName, Properties metadata) throws SynapseException {
+    private void writeMetadata(File parent, String resourceFileName, Properties metadata) {
 
         File metadataDir = new File(parent, METADATA_DIR_NAME);
         if (!metadataDir.exists() && !metadataDir.mkdirs()) {

--- a/components/mediation-registry/org.wso2.carbon.mediation.registry/src/main/java/org/wso2/carbon/mediation/registry/MicroIntegratorRegistry.java
+++ b/components/mediation-registry/org.wso2.carbon.mediation.registry/src/main/java/org/wso2/carbon/mediation/registry/MicroIntegratorRegistry.java
@@ -34,6 +34,8 @@ import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,9 +47,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import javax.activation.DataHandler;
 import javax.xml.stream.XMLInputFactory;
@@ -63,6 +63,9 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
     private static final int DELETE_RETRY_SLEEP_TIME = 10;
     private static final long DEFAULT_CACHABLE_DURATION = 0;
     private static final int MAX_KEYS = 200;
+    private static final String METADATA_DIR_NAME = ".metadata";
+    private static final String METADATA_FILE_SUFFIX = ".meta";
+    private static final String METADATA_KEY_MEDIA_TYPE = "mediaType";
 
     public static final int FILE = 1;
     public static final int HTTP = 2;
@@ -77,8 +80,6 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
     private String configRegistry = null;
 
     private String govRegistry = null;
-
-    private Map<String, String> fileExtensionMediaTypeMap = null;
 
     /**
      * Specifies whether the registry is in the local host or a remote registry.
@@ -126,7 +127,6 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
                 addConfigProperty(name, value);
             }
         }
-        this.fileExtensionMediaTypeMap =  createFileExtensionsMap();
         log.debug("EI lightweight registry is initialized.");
 
     }
@@ -480,7 +480,7 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
     }
 
     @Override
-    public void newNonEmptyResource(String path, boolean isDirectory, String contentType, String content, String propertyName) {
+    public void newNonEmptyResource(String path, boolean isDirectory, String mediaType, String content, String propertyName) {
 
         if (registryType == ESBRegistryConstants.LOCAL_HOST_REGISTRY) {
             String targetPath = resolveRegistryURI(path);
@@ -492,8 +492,13 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
             String parent = getParentPath(targetPath, isDirectory);
             String fileName = getResourceName(targetPath);
 
+            Properties metadata = new Properties();
+            if (mediaType != null) {
+                metadata.setProperty(METADATA_KEY_MEDIA_TYPE, mediaType);
+            }
+
             try {
-                writeToFile(new URI(parent), fileName, content);
+                writeToFile(new URI(parent), fileName, content, metadata);
             } catch (Exception e) {
                 handleException("Error when adding a new resource", e);
             }
@@ -724,9 +729,10 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
      *
      * @param parentName
      * @param newFileName
-     * @throws Exception
+     * @param metadata
+     * @throws SynapseException
      */
-    private void writeToFile(URI parentName, String newFileName, String content) throws Exception {
+    private void writeToFile(URI parentName, String newFileName, String content, Properties metadata) throws SynapseException {
         /*
             search for parent. if found, create the new FILE in it
         */
@@ -734,16 +740,43 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
         if (!parent.exists() && !parent.mkdirs()) {
             handleException("Unable to create parent directory: " + parentName);
         }
+
         File newFile = new File(parent, newFileName);
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(newFile))) {
             writer.write(content);
             writer.flush();
+            writeMetadata(parent, newFileName, metadata);
 
             if (log.isDebugEnabled()) {
                 log.debug("Successfully content written to file : " + parentName + URL_SEPARATOR + newFileName);
             }
         } catch (IOException e) {
             handleException("Couldn't write to registry resource: " + parentName + URL_SEPARATOR + newFileName, e);
+        }
+    }
+
+    /**
+     * Writes metadata related to the given resource.
+     *
+     * @param parent parent dir of the resource
+     * @param resourceFileName filename of the resource
+     * @param metadata metadata properties object
+     * @throws SynapseException
+     */
+    private void writeMetadata(File parent, String resourceFileName, Properties metadata) throws SynapseException {
+
+        File metadataDir = new File(parent, METADATA_DIR_NAME);
+        if (!metadataDir.exists() && !metadataDir.mkdirs()) {
+            handleException("Unable to create metadata directory: " + metadataDir.getPath());
+        }
+        File newMetadataFile = new File(metadataDir, resourceFileName + METADATA_FILE_SUFFIX);
+        try (BufferedWriter metadataWriter = new BufferedWriter(new FileWriter(newMetadataFile))) {
+            metadata.store(metadataWriter, null);
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully written metadata to file: " + newMetadataFile.getPath());
+            }
+        } catch (IOException e) {
+            handleException("Couldn't write to metadata file: " + newMetadataFile.getPath(), e);
         }
     }
 
@@ -812,7 +845,7 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
      * @throws IOException
      */
     private OMNode readNonXML (URL url) throws IOException {
-        String mediaType = lookUpFileMediaType(url.getPath());
+
         URLConnection urlConnection = url.openConnection();
         urlConnection.connect();
 
@@ -821,6 +854,9 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
             if (inputStream == null) {
                 return null;
             }
+
+            Properties metadata = getMetadata(url.getPath());
+            String mediaType = metadata.getProperty(METADATA_KEY_MEDIA_TYPE, ESBRegistryConstants.DEFAULT_MEDIA_TYPE);
 
             if (ESBRegistryConstants.DEFAULT_MEDIA_TYPE.equals(mediaType)) {
                 StringBuilder strBuilder = new StringBuilder();
@@ -961,45 +997,28 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
     }
 
     /**
-     * Populate file extension to media type mapping
-     *
-     * @return Map which contains file extension to media type mapping
-     */
-    private Map<String, String> createFileExtensionsMap() {
-
-        Map<String, String> extensionContentTypeMap = new HashMap<>();
-
-        extensionContentTypeMap.put(".xml", "application/xml");
-        extensionContentTypeMap.put(".js", "application/javascript");
-        extensionContentTypeMap.put(".css", "text/css");
-        extensionContentTypeMap.put(".html", "text/html");
-        extensionContentTypeMap.put(".sql", "text/plain");
-        extensionContentTypeMap.put(".xsd", "Schema");
-        extensionContentTypeMap.put(".xsl", "application/xsl+xml");
-        extensionContentTypeMap.put(".xslt", "application/xslt+xml");
-        extensionContentTypeMap.put(".zip", "application/zip");
-        extensionContentTypeMap.put(".wsdl", "WSDL");
-
-        return extensionContentTypeMap;
-    }
-
-    /**
-     * Loopkup media-type for the relevant file from the mappings
+     * Get metadata of the registry resource.
      *
      * @param fileUrl File URL of the registry resource
-     * @return Media-type of the file
+     * @return Properties object containing metadata of the registry resource
      */
-    private String lookUpFileMediaType(String fileUrl) {
-        String extension = "";
-        int indexOfExtensionDot = fileUrl.lastIndexOf('.');
-        if (indexOfExtensionDot > 0) {
-            extension = fileUrl.substring(indexOfExtensionDot);
+    private Properties getMetadata(String fileUrl) {
+
+        Properties metadata = new Properties();
+        File file = new File(fileUrl);
+        String metadataFilePath = file.getParent()
+                                  + File.separator + METADATA_DIR_NAME
+                                  + File.separator + file.getName() + METADATA_FILE_SUFFIX;
+        File metadataFile = new File(metadataFilePath);
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(metadataFile))) {
+            metadata.load(reader);
+        } catch (FileNotFoundException e) {
+            log.error("Metadata file cannot be found at " + metadataFile.getPath(), e);
+        } catch (IOException e) {
+            log.error("Error while reading file " + metadataFile.getPath(), e);
         }
 
-        String mediaType = ESBRegistryConstants.DEFAULT_MEDIA_TYPE;
-        if (fileExtensionMediaTypeMap.containsKey(extension)) {
-            mediaType = fileExtensionMediaTypeMap.get(extension);
-        }
-        return mediaType;
+        return metadata;
     }
 }

--- a/components/mediation-registry/org.wso2.carbon.mediation.registry/src/test/java/org/wso2/carbon/mediation/registry/TestMicroIntegratorRegistry.java
+++ b/components/mediation-registry/org.wso2.carbon.mediation.registry/src/test/java/org/wso2/carbon/mediation/registry/TestMicroIntegratorRegistry.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ */
+
+package org.wso2.carbon.mediation.registry;
+
+import org.apache.axiom.om.OMNode;
+import org.apache.axiom.om.impl.llom.OMTextImpl;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.Properties;
+import javax.activation.DataHandler;
+
+public class TestMicroIntegratorRegistry {
+
+    private static MicroIntegratorRegistry microIntegratorRegistry;
+    private static Path governanceRegistry;
+
+    @BeforeClass
+    public static void init() throws IOException {
+
+        microIntegratorRegistry = new MicroIntegratorRegistry();
+
+        governanceRegistry = Paths.get("src", "test", "resources", "registry", "governance").toAbsolutePath();
+        Files.createDirectories(governanceRegistry);
+
+        Properties properties = new Properties();
+        properties.setProperty(ESBRegistryConstants.GOV_REG_ROOT, governanceRegistry.toUri().toURL().toString());
+        microIntegratorRegistry.init(properties);
+    }
+
+    @Before
+    public void deployRegistryResource() {
+
+        String filePath = "gov:/custom/checkJsScript.js";
+        String content = "function checkLog(mc) {\n"
+                         + "\tvar log = mc.getServiceLog();\n"
+                         + "\tlog.info(\"Logging inside Script Mediator\");\n"
+                         + "}\n";
+
+        microIntegratorRegistry.newNonEmptyResource(filePath, false, "application/javascript", content, "");
+    }
+
+    @Test
+    public void TestRegistryResourceDeployment() throws IOException {
+
+        File resourceFile = Paths.get(governanceRegistry.toString(), "custom", "checkJsScript.js").toFile();
+        Assert.assertTrue("checkJsScript.js file should be created", resourceFile.exists());
+
+        File metadataFile =
+                Paths.get(governanceRegistry.toString(), "custom", ".metadata", "checkJsScript.js.meta").toFile();
+        Assert.assertTrue(".metadata/checkJsScript.js.meta file should be created", metadataFile.exists());
+
+        Properties metadata = new Properties();
+        try (BufferedReader reader = new BufferedReader(new FileReader(metadataFile))) {
+            metadata.load(reader);
+        }
+        String mediaType = metadata.getProperty("mediaType");
+        Assert.assertEquals("Media type should be as expected", "application/javascript", mediaType);
+    }
+
+    @Test
+    public void TestRegistryResourceRead() throws IOException {
+
+        OMNode omNode = microIntegratorRegistry.lookup("gov:/custom/checkJsScript.js");
+        String mediaType = ((DataHandler) ((OMTextImpl) omNode).getDataHandler()).getContentType();
+        Assert.assertEquals("Media type should be as expected", "application/javascript", mediaType);
+    }
+
+    @AfterClass
+    public static void cleanup() throws IOException {
+        Files.walk(Paths.get(governanceRegistry.getParent().toString()))
+                .map(Path::toFile)
+                .sorted(Comparator.reverseOrder())
+                .forEach(File::delete);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                 <version>3.8.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <source>1.8</source>

--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@
                 <version>2.3.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.5</version>
+                    <version>3.5.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <obrRepository>NONE</obrRepository>


### PR DESCRIPTION
The metadata related to registry resource is stored in a separate file named <resource_file_name>.meta inside the ".metadata" dir which is located where the registry resource is.
At the moment media type is the only metadata stored.

Example:
```
|registry/
| ---- | governance/
| -------- | custom1/
| ------------ | checkJsScript.js
| ------------ | .metadata/
| ---------------- | checkJsScript.js.meta
```

Fixes wso2/micro-integrator#180