### PR TITLE
Added 'RABBITMQ_REPLY_TO' transport property for rabbitmq inbound endpoints

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQInjectHandler.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQInjectHandler.java
@@ -36,6 +36,8 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * RabbitMQInjectHandler uses to mediate the received RabbitMQ message
@@ -76,6 +78,14 @@ public class RabbitMQInjectHandler {
             msgCtx.setProperty(RabbitMQConstants.CORRELATION_ID, message.getMessageId());
         }
 
+        // Set the reply to queue name (in transport properties)
+        String replyTo = message.getReplyTo();
+        if (replyTo != null) {
+        	Map<String, String> trpHeaders = new HashMap<String, String>();
+        	trpHeaders.put(RabbitMQConstants.RABBITMQ_REPLY_TO, replyTo);
+        	axis2MsgCtx.setProperty(MessageContext.TRANSPORT_HEADERS, trpHeaders);
+        }
+        
         String contentType = message.getContentType();
         Builder builder = null;
         if (contentType == null) {


### PR DESCRIPTION
## Purpose
> When retrieving messages from a RabbitMq message broker using a WSO2 proxy, a transport property is added to make the name of the provided reply queue available to the processing sequence. However, when an inbound endpoint is used, this property is not available in the processing sequence. This is also related to ticket EWALSSUB-27.
When using an inbound endpoint (with 'rabbitmq' protocol), the reply queue name can now be accessed using the expression '$trp:RABBITMQ_REPLY_TO'.
This pull request was created based on tag 'v4.6.19', since we are using WSO2 EI 6.1.1.