### PR TITLE
Correction credentials starting with "Basic "

### DIFF
--- a/components/org.wso2.carbon.integrator.core/src/main/java/org/wso2/carbon/integrator/core/handler/RESTBasicAuthHandler.java
+++ b/components/org.wso2.carbon.integrator.core/src/main/java/org/wso2/carbon/integrator/core/handler/RESTBasicAuthHandler.java
@@ -100,6 +100,9 @@ public class RESTBasicAuthHandler implements Handler {
     private boolean processSecurity(String credentials) {
 
         try {
+            if(credentials.startsWith("Basic ")) {
+        		credentials = credentials.replaceAll("Basic ", "");
+        	}
             String decodedCredentials = new String(new Base64().decode(credentials.getBytes()));
             String[] details = decodedCredentials.split(":");
             String username = details[0];


### PR DESCRIPTION
Sometimes we can have an authorization header starting with "Basic ". Without this "if" condition, WSO2 returns an ArrrayIndexOutOfBoundsException because "decodedCredentials" returns a String without ":" inside. It can't split with ":" so username and password are null.

Purpose : 
Do a correction to the REST Basic Auth Handler