### PR TITLE
Changed how endpoint test displays Error Messages

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/java/org/wso2/carbon/endpoint/ui/util/EndpointConfigurationHelper.java
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/java/org/wso2/carbon/endpoint/ui/util/EndpointConfigurationHelper.java
@@ -145,7 +145,7 @@ public class EndpointConfigurationHelper {
             } catch (SSLHandshakeException e) {
                 returnValue = "ssl_error";
             } catch (Exception e) {
-                returnValue = "Cannot establish connection to the provided address";
+                returnValue = "Error thrown when connecting to endpoint : " + e.getMessage();
             }
         }
         return returnValue;

--- a/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/js/endpoint-util.js
+++ b/components/mediation-ui/org.wso2.carbon.endpoint.ui/src/main/resources/web/endpoints/js/endpoint-util.js
@@ -193,7 +193,7 @@ function testURL(url) {
                        } else if (data.replace(/^\s+|\s+$/g, '') == 'unsupported') {
                            CARBON.showErrorDialog(jsi18n['unsupported.protocol']);
                        } else {
-                           CARBON.showErrorDialog(jsi18n['invalid.address']);
+                           CARBON.showErrorDialog(data);
                        }
                    });
     }


### PR DESCRIPTION
Testing endpoints now displays a general Error message in cases where a general exception is caught.

Resolves Issue : wso2/product-ei#4585