### PR TITLE
Fix properties file last modified is not updated when resource is updated

### DIFF
--- a/components/mediation-registry/org.wso2.carbon.mediation.registry/src/main/java/org/wso2/carbon/mediation/registry/MicroIntegratorRegistry.java
+++ b/components/mediation-registry/org.wso2.carbon.mediation.registry/src/main/java/org/wso2/carbon/mediation/registry/MicroIntegratorRegistry.java
@@ -326,7 +326,21 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
         MediationRegistryEntryImpl entryEmbedded = new MediationRegistryEntryImpl();
 
         try {
-            URL url = new URL(resolveRegistryURI(key));
+            URL url;
+            String surl = resolveRegistryURI(key);
+            url = new URL(surl);
+
+            boolean isDirectory = new File(new URL(surl.trim()).getFile()).isDirectory();
+            if (isDirectory) {
+                String[] files = new File(new URL(surl).getFile()).list();
+                for (String file : files) {
+                    if (file.contains(ESBRegistryConstants.PROPERTY_EXTENTION)) {
+                        String resolvedRegKeyPath = getPropertyFileURI(surl);
+                        url = new URL(resolvedRegKeyPath);
+                    }
+                }
+            }
+
             if ("file".equals(url.getProtocol())) {
                 try {
                     url.openStream();


### PR DESCRIPTION
Issue ID: https://github.com/wso2/micro-integrator/issues/536

## Purpose
> If we update the .properties file (which resides inside registry folder) when MI server is running the changes will not get updated. But we can resolve this by touching the directory. Because the implementation looks for the last modified property of the directory, not of the .properties file. This PR fixes this by checking the last modified property of the .properties file.