### PR TITLE
Synchronize JMSPollingConsumer destroy to avoid deadlocks

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
@@ -431,15 +431,17 @@ public class JMSPollingConsumer {
         }
     }
 
-    public void destroy(){
-        if (messageConsumer != null) {
-            jmsConnectionFactory.closeConsumer(messageConsumer, true);
-        }
-        if (session != null) {
-            jmsConnectionFactory.closeSession(session, true);
-        }
-        if (connection != null) {
-            jmsConnectionFactory.closeConnection(connection, true);
+    public void destroy() {
+        synchronized (jmsConnectionFactory) {
+            if (messageConsumer != null) {
+                jmsConnectionFactory.closeConsumer(messageConsumer, true);
+            }
+            if (session != null) {
+                jmsConnectionFactory.closeSession(session, true);
+            }
+            if (connection != null) {
+                jmsConnectionFactory.closeConnection(connection, true);
+            }
         }
     }
     


### PR DESCRIPTION
Related to wso2/product-ei#4735

A deadlock possibility is there in the JMSPollingConsumer destroy method when two thread concurrently call that particular method on the same JMSPollingConsumer object. This PR will synchronise the method to avoid deadlocks.