### PR TITLE
Fix last entry added to the Secure Vault is not shown in the Management Console

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.mediation.security.ui/src/main/java/org/wso2/carbon/mediation/security/vault/ui/PropertiesServiceClient.java
+++ b/components/mediation-ui/org.wso2.carbon.mediation.security.ui/src/main/java/org/wso2/carbon/mediation/security/vault/ui/PropertiesServiceClient.java
@@ -134,7 +134,7 @@ public class PropertiesServiceClient {
 
 		if (start >= 0 && bean.getSysProperties() != null && bean.getSysProperties().length > 0) {
 			int length =
-			             start > 0 ? ((bean.getSysProperties().length - start) - 1)
+			             start > 0 ? ((bean.getSysProperties().length - start))
 			                      : bean.getSysProperties().length;
 			if (length > itemPerPage) {
 				length = itemPerPage;


### PR DESCRIPTION
## Purpose
> Fix: https://github.com/wso2/product-ei/issues/4774

Secure vault keys are listed according to the alphabetical order. When trying to add an entry to the end of the list on page 2 and onwards, the entry is getting successfully added, but not getting displayed in the Management Console. This PR resolves this issue since there is no need to subtract 1 (- 1) when calculating the length of the property list to be shown on the page.