### PR TITLE
Add jsonpath support for Header and Foreach mediators in Management console

### DIFF
--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.foreach.ui/pom.xml
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.foreach.ui/pom.xml
@@ -87,6 +87,10 @@
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.mediation</groupId>
+            <artifactId>org.wso2.carbon.sequences.ui</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.foreach.ui/src/main/java/org/wso2/carbon/mediator/foreach/ForEachMediator.java
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.foreach.ui/src/main/java/org/wso2/carbon/mediator/foreach/ForEachMediator.java
@@ -20,10 +20,10 @@ package org.wso2.carbon.mediator.foreach;
 
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
-import org.apache.synapse.config.xml.SynapseXPathFactory;
-import org.apache.synapse.config.xml.SynapseXPathSerializer;
+import org.apache.synapse.config.xml.SynapsePath;
+import org.apache.synapse.config.xml.SynapsePathFactory;
+import org.apache.synapse.config.xml.SynapsePathSerializer;
 import org.apache.synapse.config.xml.XMLConfigConstants;
-import org.apache.synapse.util.xpath.SynapseXPath;
 import org.jaxen.JaxenException;
 import org.wso2.carbon.mediator.service.MediatorException;
 import org.wso2.carbon.mediator.service.ui.AbstractListMediator;
@@ -34,7 +34,7 @@ import java.util.List;
 
 public class ForEachMediator extends AbstractListMediator {
 
-    private SynapseXPath expression = null;
+    private SynapsePath expression = null;
 
     private String sequenceRef = null;
 
@@ -50,11 +50,11 @@ public class ForEachMediator extends AbstractListMediator {
         return TAG_NAME;
     }
 
-    public SynapseXPath getExpression() {
+    public SynapsePath getExpression() {
         return expression;
     }
 
-    public void setExpression(SynapseXPath expression) {
+    public void setExpression(SynapsePath expression) {
         this.expression = expression;
     }
 
@@ -71,7 +71,7 @@ public class ForEachMediator extends AbstractListMediator {
         saveTracingState(forEachElem, this);
 
         if (expression != null) {
-            SynapseXPathSerializer.serializeXPath(expression, forEachElem, "expression");
+            SynapsePathSerializer.serializePath(expression, forEachElem, "expression");
         } else {
             throw new MediatorException("Missing expression of the ForEach which is required.");
         }
@@ -109,7 +109,7 @@ public class ForEachMediator extends AbstractListMediator {
         OMAttribute expression = elem.getAttribute(ATT_EXPRN);
         if (expression != null) {
             try {
-                this.expression = SynapseXPathFactory.getSynapseXPath(elem, ATT_EXPRN);
+                this.expression = SynapsePathFactory.getSynapsePath(elem, ATT_EXPRN);
             } catch (JaxenException e) {
                 throw new MediatorException("Unable to build the ForEach Mediator. " +
                         "Invalid XPath " +

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.foreach.ui/src/main/resources/web/foreach-mediator/update-mediator.jsp
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.foreach.ui/src/main/resources/web/foreach-mediator/update-mediator.jsp
@@ -16,13 +16,17 @@
  ~ specific language governing permissions and limitations
  ~ under the License.
 --%>
- 
+
 <%@ page import="org.wso2.carbon.mediator.foreach.ForEachMediator" %>
 <%@ page import="org.wso2.carbon.mediator.service.ui.Mediator" %>
 <%@ page import="org.wso2.carbon.sequences.ui.util.SequenceEditorHelper" %>
+<%@ page import="org.wso2.carbon.sequences.ui.util.ns.SynapseJsonPathFactory" %>
 <%@ page import="org.wso2.carbon.sequences.ui.util.ns.XPathFactory" %>
 
 <%
+    final String JSON_EVAL_START_STRING = "json-eval(";
+    final String ITR_EXPRESSION_KEY = "itr_expression";
+    
     Mediator mediator = SequenceEditorHelper.getEditingMediator(request, session);
 
     if (!(mediator instanceof ForEachMediator)) {
@@ -31,7 +35,17 @@
     ForEachMediator foreachMediator = (ForEachMediator) mediator;
 
     XPathFactory xPathFactory = XPathFactory.getInstance();
-    foreachMediator.setExpression(xPathFactory.createSynapseXPath("itr_expression", request, session));
+    SynapseJsonPathFactory jsonPathFactory = SynapseJsonPathFactory.getInstance();
+    
+    String iterateExpression = request.getParameter(ITR_EXPRESSION_KEY);
+    if (iterateExpression.startsWith(JSON_EVAL_START_STRING)) {
+        foreachMediator.setExpression(
+                jsonPathFactory.createSynapseJsonPath(ITR_EXPRESSION_KEY,
+                        iterateExpression.trim().substring(
+                                JSON_EVAL_START_STRING.length(), iterateExpression.length() - 1)));
+    } else {
+        foreachMediator.setExpression(xPathFactory.createSynapseXPath(ITR_EXPRESSION_KEY, iterateExpression, session));
+    }
 
     foreachMediator.setSequenceRef(null);
 

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.foreach.ui/src/main/resources/web/foreach-mediator/update-mediator.jsp
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.foreach.ui/src/main/resources/web/foreach-mediator/update-mediator.jsp
@@ -40,8 +40,7 @@
     String iterateExpression = request.getParameter(ITR_EXPRESSION_KEY);
     if (iterateExpression.startsWith(JSON_EVAL_START_STRING)) {
         foreachMediator.setExpression(
-                jsonPathFactory.createSynapseJsonPath(ITR_EXPRESSION_KEY,
-                        iterateExpression.trim().substring(
+                jsonPathFactory.createSynapseJsonPath(ITR_EXPRESSION_KEY, iterateExpression.trim().substring(
                                 JSON_EVAL_START_STRING.length(), iterateExpression.length() - 1)));
     } else {
         foreachMediator.setExpression(xPathFactory.createSynapseXPath(ITR_EXPRESSION_KEY, iterateExpression, session));

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.header.ui/pom.xml
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.header.ui/pom.xml
@@ -85,6 +85,10 @@
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.mediation</groupId>
+            <artifactId>org.wso2.carbon.sequences.ui</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.header.ui/src/main/java/org/wso2/carbon/mediator/header/HeaderMediator.java
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.header.ui/src/main/java/org/wso2/carbon/mediator/header/HeaderMediator.java
@@ -20,10 +20,10 @@ package org.wso2.carbon.mediator.header;
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.config.xml.OMElementUtils;
-import org.apache.synapse.config.xml.SynapseXPathFactory;
-import org.apache.synapse.config.xml.SynapseXPathSerializer;
+import org.apache.synapse.config.xml.SynapsePath;
+import org.apache.synapse.config.xml.SynapsePathFactory;
+import org.apache.synapse.config.xml.SynapsePathSerializer;
 import org.apache.synapse.config.xml.XMLConfigConstants;
-import org.apache.synapse.util.xpath.SynapseXPath;
 import org.jaxen.JaxenException;
 import org.wso2.carbon.mediator.service.MediatorException;
 import org.wso2.carbon.mediator.service.ui.AbstractMediator;
@@ -47,7 +47,7 @@ public class HeaderMediator extends AbstractMediator {
     private String scope = null; 
     
     /** An expression which should be evaluated, and the result set as the header value */
-    private SynapseXPath expression = null;
+    private SynapsePath expression = null;
     // An XML content as a complex header.
     private OMElement xml;
 
@@ -83,11 +83,11 @@ public class HeaderMediator extends AbstractMediator {
         this.value = value;
     }
 
-    public SynapseXPath getExpression() {
+    public SynapsePath getExpression() {
         return expression;
     }
 
-    public void setExpression(SynapseXPath expression) {
+    public void setExpression(SynapsePath expression) {
         this.expression = expression;
     }
 
@@ -140,7 +140,7 @@ public class HeaderMediator extends AbstractMediator {
 
             } else if (getExpression() != null) {
 
-                SynapseXPathSerializer.serializeXPath(
+                SynapsePathSerializer.serializePath(
                     getExpression(), header, "expression");
 
             } else if (getXml() == null) {
@@ -228,7 +228,7 @@ public class HeaderMediator extends AbstractMediator {
 
         } else if (exprn != null && exprn.getAttributeValue() != null) {
             try {
-                setExpression(SynapseXPathFactory.getSynapseXPath(elem, ATT_EXPRN));
+                setExpression(SynapsePathFactory.getSynapsePath(elem, ATT_EXPRN));
             } catch (JaxenException je) {
                 // TODO error
             }

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.header.ui/src/main/resources/web/header-mediator/update-mediator.jsp
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.header.ui/src/main/resources/web/header-mediator/update-mediator.jsp
@@ -18,6 +18,7 @@
 <%@ page import="org.wso2.carbon.mediator.header.HeaderMediator" %>
 <%@ page import="org.apache.synapse.util.xpath.SynapseXPath" %>
 <%@ page import="org.wso2.carbon.sequences.ui.util.SequenceEditorHelper" %>
+<%@ page import="org.wso2.carbon.sequences.ui.util.ns.SynapseJsonPathFactory" %>
 <%@ page import="org.wso2.carbon.sequences.ui.util.ns.QNameFactory" %>
 <%@ page import="org.wso2.carbon.sequences.ui.util.ns.XPathFactory" %>
 <%@ page import="javax.xml.namespace.QName" %>
@@ -31,6 +32,9 @@
 <%@ page import="org.wso2.carbon.mediator.header.HeaderMediatorHelper" %>
 
 <%
+    final String JSON_EVAL_START_STRING = "json-eval(";
+    final String EXPRESSION_KEY = "mediator.header.val_ex";
+    
     Mediator mediator = SequenceEditorHelper.getEditingMediator(request, session);
     SynapseXPath xpath = null;
     String name = null;
@@ -63,8 +67,16 @@
         headerMediator.setAction(HeaderMediator.ACTION_SET);
         String actionType = request.getParameter("mediator.header.actionType");
         if ("expression".equals(actionType)) {
+            String expression = request.getParameter(EXPRESSION_KEY);
             XPathFactory xPathFactory = XPathFactory.getInstance();
-            headerMediator.setExpression(xPathFactory.createSynapseXPath("mediator.header.val_ex", request, session));
+            SynapseJsonPathFactory jsonPathFactory = SynapseJsonPathFactory.getInstance();
+            if (expression.startsWith(JSON_EVAL_START_STRING)) {
+                headerMediator.setExpression(
+                        jsonPathFactory.createSynapseJsonPath(EXPRESSION_KEY, expression.trim().substring(
+                                        JSON_EVAL_START_STRING.length(), expression.length() - 1)));
+            } else {
+                headerMediator.setExpression(xPathFactory.createSynapseXPath(EXPRESSION_KEY, expression, session));
+            }
             headerMediator.setXml(null);//value and expression does not include inline xml definition
         } else if ("value".equals(actionType)) {
             headerMediator.setValue(request.getParameter("mediator.header.val_ex"));


### PR DESCRIPTION
## Purpose

Native JSONpath support was introduced for Header mediator (https://github.com/wso2/wso2-synapse/pull/1364) and Foreach mediator(https://github.com/wso2/wso2-synapse/pull/1377). 

This PR adds the jsonpath support in the management console for the above mediators.

Resolves https://github.com/wso2/product-ei/issues/4797
Related to https://github.com/wso2/product-ei/issues/4121
