### PR TITLE
Fix [EI-4796] JMS session.recover() upon mediation failure

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
@@ -64,6 +64,10 @@ public class JMSConstants {
     /** Root element name of JMS Map message payload representation */
     public static final String JMS_MAP_ELEMENT_NAME = "JMSMap";
     public static final String SET_ROLLBACK_ONLY = "SET_ROLLBACK_ONLY";
+
+    //Constant to represent jmsSession.recover()
+    static final String SET_RECOVER = "SET_RECOVER";
+
     public static final QName JMS_MAP_QNAME = new QName(JMS_MAP_NS, JMS_MAP_ELEMENT_NAME, "");
     /**
      * Constant that holds the name of the environment property

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
@@ -210,20 +210,20 @@ public class JMSInjectHandler {
                     documentElement = convertJMSMapToXML((MapMessage) msg);
                 }
             } catch (Exception ex) {
-                    // Handle message building error
-                    log.error("Error while building the message", ex);
-                    msgCtx.setProperty(SynapseConstants.ERROR_CODE, GenericConstants.INBOUND_BUILD_ERROR);
-                    msgCtx.setProperty(SynapseConstants.ERROR_MESSAGE, ex.getMessage());
-                    SequenceMediator faultSequence = getFaultSequence(msgCtx, inboundEndpoint);
-                    faultSequence.mediate(msgCtx);
+                // Handle message building error
+                log.error("Error while building the message", ex);
+                msgCtx.setProperty(SynapseConstants.ERROR_CODE, GenericConstants.INBOUND_BUILD_ERROR);
+                msgCtx.setProperty(SynapseConstants.ERROR_MESSAGE, ex.getMessage());
+                SequenceMediator faultSequence = getFaultSequence(msgCtx, inboundEndpoint);
+                faultSequence.mediate(msgCtx);
 
-                    if (isRollback(msgCtx)) {
-                        return false;
-                    }
-                    return true;
+                if (isRollback(msgCtx) || isToRecover(msgCtx)) {
+                    return false;
                 }
+                return true;
+            }
 
-                // Setting JMSXDeliveryCount header on the message context
+            // Setting JMSXDeliveryCount header on the message context
             try {
                 int deliveryCount = msg.getIntProperty("JMSXDeliveryCount");
                 msgCtx.setProperty(JMSConstants.DELIVERY_COUNT, deliveryCount);
@@ -259,7 +259,7 @@ public class JMSInjectHandler {
                 log.error("Sequence: " + injectingSeq + " not found");
             }
 
-            if (isRollback(msgCtx)) {
+            if (isRollback(msgCtx) || isToRecover(msgCtx)) {
                 return false;
             }
         } catch (SynapseException se) {
@@ -271,24 +271,26 @@ public class JMSInjectHandler {
         return true;
     }
 
+    /**
+     * Evaluate if JMS session need to be rollback judging
+     * from properties set to message context
+     *
+     * @param msgCtx MessageContext to evaluate
+     * @return true if JMS session need to be recovered
+     */
     private boolean isRollback(org.apache.synapse.MessageContext msgCtx) {
-        // First check for rollback property from synapse context
-        Object rollbackProp = msgCtx.getProperty(JMSConstants.SET_ROLLBACK_ONLY);
-        if (rollbackProp != null) {
-            if ((rollbackProp instanceof Boolean && ((Boolean) rollbackProp))
-                || (rollbackProp instanceof String && Boolean.valueOf((String) rollbackProp))) {
-                return true;
-            }
-            return false;
-        }
-        // Then from axis2 context - This is for make it consistent with JMS Transport config parameters
-        rollbackProp =
-                (((Axis2MessageContext) msgCtx).getAxis2MessageContext()).getProperty(JMSConstants.SET_ROLLBACK_ONLY);
-        if ((rollbackProp instanceof Boolean && ((Boolean) rollbackProp))
-            || (rollbackProp instanceof String && Boolean.valueOf((String) rollbackProp))) {
-            return true;
-        }
-        return false;
+        return JMSUtils.checkIfBooleanPropertyIsSet(JMSConstants.SET_ROLLBACK_ONLY, msgCtx);
+    }
+
+    /**
+     * Evaluate if JMS session need to be recovered judging
+     * from properties set to message context
+     *
+     * @param msgCtx MessageContext to evaluate
+     * @return true if JMS session need to be recovered
+     */
+    private boolean isToRecover(org.apache.synapse.MessageContext msgCtx) {
+        return JMSUtils.checkIfBooleanPropertyIsSet(JMSConstants.SET_RECOVER, msgCtx);
     }
 
     /**

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
@@ -311,6 +311,9 @@ public class JMSPollingConsumer {
                                         "Error acknowledging message : " + msg.getJMSMessageID(), e);
                             }
                         } else {
+                            // Need to recover the session to tell broker to send back messages on same session
+                            jmsConnectionFactory.recoverSession(session, false);
+
                             // Need to create a new consumer and session since
                             // we need to rollback the message
                             if (messageConsumer != null) {

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSUtils.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSUtils.java
@@ -21,6 +21,7 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axis2.context.MessageContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
 
 import javax.jms.BytesMessage;
 import javax.jms.Destination;
@@ -79,6 +80,33 @@ public class JMSUtils {
             OMElement elem = (OMElement)itr.next();
             message.setString(elem.getLocalName(),elem.getText());
         }
+    }
+
+    /**
+     * Check if a boolean property is set to the Synapse message context or Axis2 message context
+     *
+     * @param propertyName Name of the property
+     * @param msgContext   Synapse messageContext instance
+     * @return True if property is set to true
+     */
+    static boolean checkIfBooleanPropertyIsSet(String propertyName, org.apache.synapse.MessageContext msgContext) {
+        boolean isPropertySet = false;
+        Object booleanProperty = msgContext.getProperty(propertyName);
+        if (booleanProperty != null) {
+            if ((booleanProperty instanceof Boolean && ((Boolean) booleanProperty)) ||
+                    (booleanProperty instanceof String && Boolean.valueOf((String) booleanProperty))) {
+                isPropertySet = true;
+            }
+        } else {
+            // Then from axis2 context - This is for make it consistent with JMS Transport config parameters
+            booleanProperty =
+                    (((Axis2MessageContext) msgContext).getAxis2MessageContext()).getProperty(JMSConstants.SET_ROLLBACK_ONLY);
+            if ((booleanProperty instanceof Boolean && ((Boolean) booleanProperty))
+                    || (booleanProperty instanceof String && Boolean.valueOf((String) booleanProperty))) {
+                isPropertySet = true;
+            }
+        }
+        return isPropertySet;
     }
 
     /**

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/factory/CachedJMSConnectionFactory.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/factory/CachedJMSConnectionFactory.java
@@ -180,7 +180,24 @@ public class CachedJMSConnectionFactory extends JMSConnectionFactory {
             logger.error("JMS Exception while closing the connection.", e);
         }
         return false;
-    }    
+    }
+
+    /**
+     * Recover JMS session
+     *
+     * @param session    JMS session to issue recover() on
+     * @param forcefully True if recover needs to be done without conditions. Otherwise, recover
+     *                   will be done based on cache level
+     * @throws JMSException Upon error recovering the session
+     */
+    public void recoverSession(Session session, boolean forcefully) throws JMSException {
+        if (this.cacheLevel >= JMSConstants.CACHE_SESSION || forcefully) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Recovered JMS session");
+            }
+            session.recover();
+        }
+    }
 
     public boolean closeConsumer(MessageConsumer messageConsumer, boolean forcefully) {
         try {


### PR DESCRIPTION
## Purpose
Fixes : https://github.com/wso2/product-ei/issues/4796

## Goals
Issue JMS session.recover() upon mediation failures 

## Documentation
Need to add description on the issue to the documentation 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


