### PR TITLE
Fix secure vault support for rabbitMQ message store

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/SecurityServiceHolder.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/SecurityServiceHolder.java
@@ -18,12 +18,12 @@
 
 package org.wso2.carbon.mediation.security.vault;
 
-import org.apache.synapse.registry.Registry;
 import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.registry.core.service.RegistryService;
 
 public class SecurityServiceHolder {
 
-	private Registry registry;
+	private RegistryService registryService;
 
 	private ServerConfigurationService serverConfigurationService;
 
@@ -37,12 +37,12 @@ public class SecurityServiceHolder {
 		return INSTANCE;
 	}
 
-	public Registry getRegistry() {
-		return registry;
+	public RegistryService getRegistryService() {
+		return registryService;
 	}
 
-	public void setRegistry(Registry registry) {
-		this.registry = registry;
+	public void setRegistryService(RegistryService registryService) {
+		this.registryService = registryService;
 	}
 
 	public ServerConfigurationService getServerConfigurationService() {

--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/SynapseSecurityerviceComponent.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/SynapseSecurityerviceComponent.java
@@ -29,7 +29,8 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.base.api.ServerConfigurationService;
-import org.wso2.carbon.mediation.initializer.services.SynapseConfigurationService;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.registry.core.service.RegistryService;
 
 @Component(
         name = "mediation.security",
@@ -51,7 +52,11 @@ public class SynapseSecurityerviceComponent {
         BundleContext bundleCtx = ctxt.getBundleContext();
         bundleCtx.registerService(MediationSecurityAdminService.class.getName(), new MediationSecurityAdminService(),
                 null);
-        SecureVaultLookupHandlerImpl.getDefaultSecurityService();
+        try {
+            SecureVaultLookupHandlerImpl.getDefaultSecurityService();
+        } catch (RegistryException e) {
+            log.error("Error while activating secure vault registry component", e);
+        }
     }
 
     @Deactivate
@@ -61,24 +66,24 @@ public class SynapseSecurityerviceComponent {
 
     @Reference(
             name = "registry.service",
-            service = org.wso2.carbon.mediation.initializer.services.SynapseConfigurationService.class,
+            service = org.wso2.carbon.registry.core.service.RegistryService.class,
             cardinality = ReferenceCardinality.MANDATORY,
             policy = ReferencePolicy.DYNAMIC,
             unbind = "unsetRegistryService")
-    protected void setRegistryService(SynapseConfigurationService regService) {
+    protected void setRegistryService(RegistryService regService) {
 
         if (log.isDebugEnabled()) {
-            log.debug("Registry bound to the ESB initialization process");
+            log.debug("RegistryService bound to the ESB initialization process");
         }
-        SecurityServiceHolder.getInstance().setRegistry(regService.getSynapseConfiguration().getRegistry());
+        SecurityServiceHolder.getInstance().setRegistryService(regService);
     }
 
-    protected void unsetRegistryService(SynapseConfigurationService regService) {
+    protected void unsetRegistryService(RegistryService regService) {
 
         if (log.isDebugEnabled()) {
             log.debug("RegistryService unbound from the ESB environment");
         }
-        SecurityServiceHolder.getInstance().setRegistry(null);
+        SecurityServiceHolder.getInstance().setRegistryService(null);
     }
 
     @Reference(


### PR DESCRIPTION
## Purpose
> Fixes: https://github.com/wso2/product-ei/issues/4798

When we define the message store password as shown below,
`<parameter name="store.rabbitmq.password">{wso2:vault-lookup('user.password')}</parameter>` the password should be resolved from secure vault. 

According to our implementation, we resolve the password value while initializing the message store [[1]](https://github.com/wso2/wso2-synapse/blob/1f67e293d4947fd87a70e2b13c70a7d73f9992d8/modules/core/src/main/java/org/apache/synapse/message/store/impl/rabbitmq/RabbitMQStore.java#L175) during server startup. The resolve method [[2]]( https://github.com/wso2/wso2-synapse/blob/1f67e293d4947fd87a70e2b13c70a7d73f9992d8/modules/core/src/main/java/org/apache/synapse/util/resolver/SecureVaultResolver.java#L65) takes the configuration value and resolves the password for the given alias by referring to the registry. Meaning our registry implementation should be initialized before initializing the message store.
In PR https://github.com/wso2/carbon-mediation/pull/1077/, we have added secure vault support for MI profile. As per the above PR the registry instance is initialized from SynapseConfigurationService (org.wso2.carbon.mediation.initializer.services.SynapseConfigurationService).
But the SynapseConfigurationService is registered in ServiceBusInitializer class [[3]](https://github.com/wso2/carbon-mediation/blob/e13636658b897cd7de84a0ad74cbf7edb0174851/components/mediation-initializer/org.wso2.carbon.mediation.initializer/src/main/java/org/wso2/carbon/mediation/initializer/ServiceBusInitializer.java#L179) after the deployment of artifacts [[4]](https://github.com/wso2/carbon-mediation/blob/e13636658b897cd7de84a0ad74cbf7edb0174851/components/mediation-initializer/org.wso2.carbon.mediation.initializer/src/main/java/org/wso2/carbon/mediation/initializer/ServiceBusInitializer.java#L170). 
Because of that, we get a null pointer (https://github.com/wso2/product-ei/issues/4798) upon starting the server when we try to resolve secure vault passwords during deployment.

This PR fixes the issue by using the registryService available in org.wso2.carbon.registry.core.service, for secure vault implementation which is also initialized before the deployment of artifacts.

This will not have any impact on MI registryService as we have moved the necessary components from mediation to MI [[5]](https://github.com/wso2/micro-integrator/blob/master/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecureVaultLookupHandlerImpl.java). Also before providing secure vault support for MI profile, our old implementation was using the same registryService for secure vault support.

[1] https://github.com/wso2/wso2-synapse/blob/1f67e293d4947fd87a70e2b13c70a7d73f9992d8/modules/core/src/main/java/org/apache/synapse/message/store/impl/rabbitmq/RabbitMQStore.java#L175
[2] https://github.com/wso2/wso2-synapse/blob/1f67e293d4947fd87a70e2b13c70a7d73f9992d8/modules/core/src/main/java/org/apache/synapse/util/resolver/SecureVaultResolver.java#L65
[3] https://github.com/wso2/carbon-mediation/blob/e13636658b897cd7de84a0ad74cbf7edb0174851/components/mediation-initializer/org.wso2.carbon.mediation.initializer/src/main/java/org/wso2/carbon/mediation/initializer/ServiceBusInitializer.java#L179
[4] https://github.com/wso2/carbon-mediation/blob/e13636658b897cd7de84a0ad74cbf7edb0174851/components/mediation-initializer/org.wso2.carbon.mediation.initializer/src/main/java/org/wso2/carbon/mediation/initializer/ServiceBusInitializer.java#L170
[5] https://github.com/wso2/micro-integrator/blob/master/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecureVaultLookupHandlerImpl.java
