### PR TITLE
Add check for transacted session before invoking recoverSession method

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
@@ -312,7 +312,10 @@ public class JMSPollingConsumer {
                             }
                         } else {
                             // Need to recover the session to tell broker to send back messages on same session
-                            jmsConnectionFactory.recoverSession(session, false);
+                            // recoverSession method is used only in non transacted session
+                            if (!jmsConnectionFactory.isTransactedSession()) {
+                                jmsConnectionFactory.recoverSession(session, false);
+                            }
 
                             // Need to create a new consumer and session since
                             // we need to rollback the message

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSUtils.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSUtils.java
@@ -100,7 +100,7 @@ public class JMSUtils {
         } else {
             // Then from axis2 context - This is for make it consistent with JMS Transport config parameters
             booleanProperty =
-                    (((Axis2MessageContext) msgContext).getAxis2MessageContext()).getProperty(JMSConstants.SET_ROLLBACK_ONLY);
+                    (((Axis2MessageContext) msgContext).getAxis2MessageContext()).getProperty(propertyName);
             if ((booleanProperty instanceof Boolean && ((Boolean) booleanProperty))
                     || (booleanProperty instanceof String && Boolean.valueOf((String) booleanProperty))) {
                 isPropertySet = true;


### PR DESCRIPTION
Fixes: https://github.com/wso2/product-ei/issues/4852

According to JMS specification 1.0.2, If a session is transacted, message acknowledgement is handled automatically by commit and recovery is handled automatically by the rollback. Session recover can not be used in a transacted session.

When CLIENT_ACKNOWLEDGE mode is used, A session’s recover method is used to stop a session and restart it with its first unacknowledged message.
More details on this can be found in [1].

The test case is failing because it is configured with SessionTransacted parameter true.`<parameter name="transport.jms.SessionTransacted">true</parameter>`
After the above fix, the flow goes and executes recoverSession() method. As we cannot execute session.recover() in a transacted session, the test case is failing. 

This PR fixes the issue by adding a check before recoverSession() to confirm it is a transacted session or not.

[1] https://docs.oracle.com/cd/E19957-01/816-5904-10/816-5904-10.pdf
