### PR TITLE
Prevent publishing mediation flow statistics when only OpenTracing is enabled

### DIFF
--- a/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/services/MessageFlowReporterThread.java
+++ b/components/mediation-monitor/mediation-data-publisher/org.wso2.carbon.das.messageflow.data.publisher/src/main/java/org/wso2/carbon/das/messageflow/data/publisher/services/MessageFlowReporterThread.java
@@ -89,7 +89,8 @@ public class MessageFlowReporterThread extends Thread {
         while (!shutdownRequested) {
             try {
                 statisticsReportingEventHolder = synapseEnvironmentService.getSynapseEnvironment().getMessageDataStore().dequeue();
-                if (statisticsReportingEventHolder != null) {
+                if (statisticsReportingEventHolder != null &&
+                    statisticsReportingEventHolder.isPublishMediationFlowStatistics()) {
 
 //                    log.info("******* event list size - " + statisticsReportingEventHolder.getQueueSize() + " holder " +
 //                            "count - " + statisticsReportingEventHolder.countHolder.getStatCount() + " callback - " + statisticsReportingEventHolder.countHolder.getCallBackCount());


### PR DESCRIPTION
## Purpose
> Statistics is published to Analytics nodes through carbon-mediation. [With the introduction of Jaeger Tracing](https://github.com/wso2/wso2-synapse/pull/1466), collection of statistics remain the same, but publishing them to analytics should be done only when a user enables mediation flow statistics.

## Goals
> Prevent publishing mediation flow statistics when only OpenTracing is enabled

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2/wso2-synapse/pull/1466