### PR TITLE
Enforce travis maven version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,9 @@ jdk:
 cache:
   directories:
   - $HOME/.m2
+
+before_install:
+  - wget https://archive.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz
+  - tar xzvf apache-maven-3.6.0-bin.tar.gz
+  - export PATH=`pwd`/apache-maven-3.6.0/bin:$PATH
+  - mvn -v


### PR DESCRIPTION
Enforce travis maven version to 3.6 since not building in 3.6.2

