### PR TITLE
Fix max.store.connection.attempts config is missing for sampling processor

### DIFF
--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageMessageSamplingProcessor.jsp
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageMessageSamplingProcessor.jsp
@@ -126,6 +126,21 @@
         return false;
     }
 
+    function isNumber(aTextField) {
+        if (aTextField.value.trim() >= 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    function isMinusOne(aTextField) {
+        if (aTextField.value.trim() == -1) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
 
     function submitTextContent(value) {
     	if(validateSubmit()){

--- a/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageMessageSamplingProcessor.jsp
+++ b/components/mediation-ui/org.wso2.carbon.message.processor.ui/src/main/resources/web/message_processor/manageMessageSamplingProcessor.jsp
@@ -89,6 +89,18 @@
             return false;
         }
 
+        if (!isNumber(form.store_connection_retry_interval)) {
+            CARBON.showWarningDialog('<fmt:message key="number.field.cannot.be.minus"/>')
+            form.client_retry_interval.focus();
+            return false;
+        }
+
+        if (!isMinusOne(form.store_connection_attempts) && !isNumber(form.store_connection_attempts)) {
+            CARBON.showWarningDialog('<fmt:message key="number.field.cannot.be.minus"/>')
+            form.client_retry_interval.focus();
+            return false;
+        }
+
         return true;
     }
 
@@ -145,6 +157,10 @@
         addServiceParameter("quartz.conf", document.getElementById('quartz_conf').value);
         addServiceParameter("cronExpression", document.getElementById('cron_expression').value);
         addServiceParameter("is.active", document.getElementById('mp_state').value);
+        addServiceParameter("max.store.connection.attempts", 
+                                    document.getElementById('store_connection_attempts').value);
+        addServiceParameter("store.connection.retry.interval", 
+                                    document.getElementById('store_connection_retry_interval').value);
     }
 
     function addServiceParameter(parameter, value) {
@@ -409,6 +425,26 @@
                                    value="<%=((null!=processorData)&& processorData.getParams() != null
                                         && !processorData.getParams().isEmpty()&&(processorData.getParams().get("concurrency")!=null))?processorData.getParams().get("concurrency"):"1"%>"
                                 />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><fmt:message key="store.connection.attempts"/></td>
+                        <td><input type="text" id="store_connection_attempts" name="store_connection_attempts"
+                                   value="<%=((null!=processorData)&& processorData.getParams() != null
+                                        && !processorData.getParams().isEmpty()&&(processorData.getParams()
+                                        .get("max.store.connection.attempts")!=null))?processorData.getParams()
+                                        .get("max.store.connection.attempts"):"-1"%>"
+                                />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><fmt:message key="store.connection.retry.interval"/></td>
+                        <td><input type="text" id="store_connection_retry_interval"
+                        name="store_connection_retry_interval"
+                                   value="<%=((null!=processorData)&& processorData.getParams() != null
+                                        && !processorData.getParams().isEmpty()&&(processorData.getParams()
+                                        .get("store.connection.retry.interval")!=null))?processorData.getParams()
+                                        .get("store.connection.retry.interval"):"1000"%>"/>
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
## Purpose
> Reverts: https://github.com/wso2/carbon-mediation/pull/1331
> Fixes: wso2/product-ei#4884, https://github.com/wso2/product-ei/issues/4690