### PR TITLE
Remove SAP feature from the default profile

### DIFF
--- a/features/business-adaptors/org.wso2.carbon.sap.feature/pom.xml
+++ b/features/business-adaptors/org.wso2.carbon.sap.feature/pom.xml
@@ -31,59 +31,76 @@
     <url>http://wso2.org</url>
     <description>This feature contains the bundles required for sap</description>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.wso2.carbon.mediation</groupId>
-            <artifactId>org.wso2.carbon.transports.sap</artifactId>
-        </dependency>
-    </dependencies>
-
     <profiles>
         <profile>
             <id>jenkins</id>
-            <properties>
-                <org.wso2.carbon.transports.sap.import.version>${carbon.mediation.version}
-                </org.wso2.carbon.transports.sap.import.version>
-            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wso2.carbon.mediation</groupId>
+                    <artifactId>org.wso2.carbon.transports.sap</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wso2.maven</groupId>
+                        <artifactId>carbon-p2-plugin</artifactId>
+                        <version>${carbon.p2.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>4-p2-feature-generation</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>p2-feature-gen</goal>
+                                </goals>
+
+                                <configuration>
+                                    <bundles>
+                                        <bundleDef>
+                                            org.wso2.carbon.mediation:org.wso2.carbon.transports.sap:${carbon.mediation.version}
+                                        </bundleDef>
+                                    </bundles>
+                                    <id>org.wso2.carbon.transports.sap</id>
+                                    <propertiesFile>../../etc/feature.properties</propertiesFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>default</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <org.wso2.carbon.transports.sap.import.version>RELEASE</org.wso2.carbon.transports.sap.import.version>
-            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wso2.maven</groupId>
+                        <artifactId>carbon-p2-plugin</artifactId>
+                        <version>${carbon.p2.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>4-p2-feature-generation</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>p2-feature-gen</goal>
+                                </goals>
+
+                                <configuration>
+                                    <bundles>
+                                        <!-- We are not adding the feature here, since its not getting build
+                                        in the default profile -->
+                                    </bundles>
+                                    <id>org.wso2.carbon.transports.sap</id>
+                                    <propertiesFile>../../etc/feature.properties</propertiesFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
-
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.wso2.maven</groupId>
-                <artifactId>carbon-p2-plugin</artifactId>
-                <version>${carbon.p2.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>4-p2-feature-generation</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>p2-feature-gen</goal>
-                        </goals>
-
-                        <configuration>
-                            <bundles>
-                                <bundleDef>
-                                    org.wso2.carbon.mediation:org.wso2.carbon.transports.sap:${org.wso2.carbon.transports.sap.import.version}
-                                </bundleDef>
-                            </bundles>
-                            <id>org.wso2.carbon.transports.sap</id>
-                            <propertiesFile>../../etc/feature.properties</propertiesFile>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
## Purpose

There are two profiles (default and Jenkins) to build the SAP component and feature. 
Jenkins profile use in release builds and default profile used in normal builds. 
  
In normal builds (default profile) we are not building the SAP component. (due to use of proprietary jars). Until now we used the latest released version of the SAP component to building the SAP feature. ( ex: we are using component version 4.7.32 in feature version 4.7.33-SNAPSHOT) 

The plugin we used to take the previously released version (build-helper), is no longer working with maven newer versions (3.6.2)

As an alternative, we can use a hard-coded version of the component. 
But this may introduce confusion when testing the SAP feature since the latest version is not used.

Due to this reason, we are limiting the SAP feature to be build when doing a release only.
In this method SAP feature will not be packed and, when we need to test the SAP feature, we must explicitly run the Jenkins profile. 