### PR TITLE
fix Null values were being published to the analytics when using Salesforce StreamData inbond connector

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/generic/GenericConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/generic/GenericConstants.java
@@ -20,4 +20,5 @@ package org.wso2.carbon.inbound.endpoint.protocol.generic;
 public class GenericConstants {
 
     public static final int INBOUND_BUILD_ERROR = 600001;
+    public static final String INBOUND_ENDPOINT_NAME = "inbound.endpoint.name";
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/generic/GenericPollingConsumer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/generic/GenericPollingConsumer.java
@@ -86,6 +86,7 @@ public abstract class GenericPollingConsumer {
                 log.debug("Processed Custom inbound EP Message of Content-type : " + contentType);
             }             
             MessageContext axis2MsgCtx = ((org.apache.synapse.core.axis2.Axis2MessageContext)msgCtx).getAxis2MessageContext();
+            msgCtx.setProperty(GenericConstants.INBOUND_ENDPOINT_NAME, name);
             // Determine the message builder to use
             Builder builder;
             if (contentType == null) {


### PR DESCRIPTION
…

## Purpose
> When we are using SF Salesforce StreamData inbound connector with the analytics, It will publish null information to the analytics server. Since the connector haven't populated the inbound name and other information while initializing the connector inbound endpoint. 
 
## Goals
> This fix will set the inbound name to the message context while initializing the inbound. 

## Approach
> We can log the analytics event in the analytics worker node by adding the below log to the <EI_HOME>/wso2/analytics/wso2/worker/deployment/siddhi-files$ EI_Analytics_StatApp.siddhi file.

> @sink(type='log')

Ex:

> @sink(type='log')
> define stream PreProcessedESBStatStream (componentId string, componentName string, componentType string, duration long, faultCount int, startTime long, entryPoint string, metaTenantId int);

without fix:
> INFO {org.wso2.siddhi.core.stream.output.sink.LogSink} - EI_Analytics_StatApp : PreProcessedESBStatStream : Event{timestamp=1582018864292, data=[HashCodeNullComponent, null, inbound endpoint, 1, 0, 1582018861970, null, -1234], isExpired=false}

with fix: 
> INFO {org.wso2.siddhi.core.stream.output.sink.LogSink} - EI_Analytics_StatApp : PreProcessedESBStatStream : Event{timestamp=1582106574906, data=[SalesforceStreamDatainbond@0:SalesforceStreamDatainbond, SalesforceStreamDatainbond, inbound endpoint, 7, 0, 1582106572070, SalesforceStreamDatainbond, -1234], isExpired=false}