### PR TITLE
Add support for dynamic names of property mediator in management console

### DIFF
--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.property.ui/src/main/resources/web/property-mediator/edit-mediator.jsp
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.property.ui/src/main/resources/web/property-mediator/edit-mediator.jsp
@@ -27,6 +27,7 @@
     Mediator mediator = SequenceEditorHelper.getEditingMediator(request, session);
     boolean isExpression = false;
     String val = "";
+    String propertyName = "";
 
     if (!(mediator instanceof org.wso2.carbon.mediator.property.PropertyMediator)) {
         // todo : proper error handling
@@ -43,6 +44,10 @@
                 == propertyMediator.getAction()) {
             displayPatternAndGroup = false;
         }
+    }
+    if (propertyMediator.getName() != null) {
+        propertyName = propertyMediator.getName();
+        propertyName = propertyName.replace("\"","&quot;");//replace quote sign with &quot;
     }
     if (propertyMediator.getValue() != null) {
         isExpression = false;
@@ -88,7 +93,7 @@
                 <td>
                     <input type="text" id="mediator.property.name" name="mediator.property.name"
                            style="width:300px;"
-                           value='<%=propertyMediator.getName() != null ? propertyMediator.getName() : ""%>'/>
+                           value="<%=propertyMediator.getName() != null ? propertyName : ""%>"/>
                 </td>
                 <td></td>
             </tr>


### PR DESCRIPTION
Property mediator does not allow dynamic names at the moment. It is supported for other mediators - e.g. sequence mediator. This is a useful feature to have.

```
<property name="{get-property('propertyName')}" expression="$ctx:propertyValue" />
<property name="{$ctx:propertyName}" expression="$ctx:propertyValue" />
<property name="{json-eval({$ctx:propertyName})}" expression="$ctx:propertyValue" />
```

Related issue- https://github.com/wso2/product-ei/issues/3300