### PR TITLE
Add xacml advice to msg context

### DIFF
--- a/components/mediators/entitlement/org.wso2.carbon.identity.entitlement.mediator/src/main/java/org/wso2/carbon/identity/entitlement/mediator/EntitlementMediator.java
+++ b/components/mediators/entitlement/org.wso2.carbon.identity.entitlement.mediator/src/main/java/org/wso2/carbon/identity/entitlement/mediator/EntitlementMediator.java
@@ -108,6 +108,7 @@ public class EntitlementMediator extends AbstractMediator implements ManagedLife
 
     private final String ORIGINAL_ENTITLEMENT_PAYLOAD = "ORIGINAL_ENTITLEMENT_PAYLOAD";
     private final String ENTITLEMENT_DECISION = "ENTITLEMENT_DECISION";
+    private final String ENTITLEMENT_ADVICE = "ENTITLEMENT_ADVICE";
 
     /**
      * {@inheritDoc}
@@ -236,6 +237,7 @@ public class EntitlementMediator extends AbstractMediator implements ManagedLife
 
             synCtx.setProperty(ORIGINAL_ENTITLEMENT_PAYLOAD, synCtx.getEnvelope());
             synCtx.setProperty(ENTITLEMENT_DECISION, simpleDecision);
+            synCtx.setProperty(ENTITLEMENT_ADVICE, advice);
 
             // assume entitlement mediator always acts as base PEP
             // then behavior for not-applicable and indeterminate results are undefined


### PR DESCRIPTION
## Purpose
XACML advice information is not available for the mediation sequences. Therefore this PR will add advice information into the message context as a property
issue: wso2/product-apim#8093
