### PR TITLE
Fix HTTP inbound endpoint creating new worker thread pool for each request

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpSourceHandler.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpSourceHandler.java
@@ -72,15 +72,17 @@ public class InboundHttpSourceHandler extends SourceHandler {
             String tenantDomain = getTenantDomain(request);
 
             if (tenantDomain != null) {
-                WorkerPoolConfiguration workerPoolConfiguration =
-                           HTTPEndpointManager.getInstance().getWorkerPoolConfiguration(tenantDomain, port);
-                if (workerPoolConfiguration != null) {
-                    workerPool = sourceConfiguration.getWorkerPool(workerPoolConfiguration.getWorkerPoolCoreSize(),
-                                                                   workerPoolConfiguration.getWorkerPoolSizeMax(),
-                                                                   workerPoolConfiguration.getWorkerPoolThreadKeepAliveSec(),
-                                                                   workerPoolConfiguration.getWorkerPoolQueuLength(),
-                                                                   workerPoolConfiguration.getThreadGroupID(),
-                                                                   workerPoolConfiguration.getThreadID());
+                if (workerPool == null) {
+                    WorkerPoolConfiguration workerPoolConfiguration =
+                            HTTPEndpointManager.getInstance().getWorkerPoolConfiguration(tenantDomain, port);
+                    if (workerPoolConfiguration != null) {
+                        workerPool = sourceConfiguration.getWorkerPool(workerPoolConfiguration.getWorkerPoolCoreSize(),
+                                workerPoolConfiguration.getWorkerPoolSizeMax(),
+                                workerPoolConfiguration.getWorkerPoolThreadKeepAliveSec(),
+                                workerPoolConfiguration.getWorkerPoolQueuLength(),
+                                workerPoolConfiguration.getThreadGroupID(),
+                                workerPoolConfiguration.getThreadID());
+                    }
                 }
             }
             if (workerPool == null) {


### PR DESCRIPTION
This PR fixes the issue where HTTP inbound endpoint creates a new worker thread pool for each request. A new workerPool will only be created if the workerPool object is null for the incoming request.

Fixes https://github.com/wso2/product-ei/issues/5101