### PR TITLE
Introduced a new Synapse property to skip saving runtime artifacts to local

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
@@ -72,8 +72,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
     private static final Log log = LogFactory.getLog(EndpointAdmin.class);
     public static final String WSO2_ENDPOINT_MEDIA_TYPE = "application/vnd.wso2.esb.endpoint";
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty(
-                    SynapseConstants.ARTIFACT_STORAGE_ENABLING_SYNAPSE_PROPERTY, true);
+            SynapsePropertiesLoader.getBooleanProperty(SynapseConstants.STORE_ARTIFACTS_LOCALLY, true);
 
     /**
      * Set Endpoint status to Active

--- a/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
@@ -12,6 +12,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.config.Entry;
 import org.apache.synapse.config.SynapseConfiguration;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.config.xml.SynapseXMLConfigurationFactory;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.config.xml.endpoints.EndpointFactory;
@@ -69,6 +70,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
 
     private static final Log log = LogFactory.getLog(EndpointAdmin.class);
     public static final String WSO2_ENDPOINT_MEDIA_TYPE = "application/vnd.wso2.esb.endpoint";
+    private boolean skipLocalCopy = SynapsePropertiesLoader.getBooleanProperty("skipLocalCopy",false);
 
     /**
      * Set Endpoint status to Active
@@ -290,7 +292,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
             if (endpoint instanceof AbstractEndpoint) {
                 fileName = endpoint.getFileName();
             }
-            if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+            if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                 MediationPersistenceManager pm = getMediationPersistenceManager();
                 pm.deleteItem(endpointName, fileName, ServiceBusConstants.ITEM_TYPE_ENDPOINT);
             }
@@ -333,7 +335,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
                     if (endpoint instanceof AbstractEndpoint) {
                         fileName = endpoint.getFileName();
                     }
-                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
 
                         pm.deleteItem(endpointName, fileName, ServiceBusConstants.ITEM_TYPE_ENDPOINT);
                     }
@@ -378,7 +380,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
                         if (endpoint instanceof AbstractEndpoint) {
                             fileName = endpoint.getFileName();
                         }
-                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                             MediationPersistenceManager pm = getMediationPersistenceManager();
                             pm.deleteItem(endpointName, fileName, ServiceBusConstants.ITEM_TYPE_ENDPOINT);
                         }
@@ -573,7 +575,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
     }
 
     private void persistEndpoint(Endpoint ep) throws EndpointAdminException {
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
 
             MediationPersistenceManager pm = getMediationPersistenceManager();
             pm.saveItem(ep.getName(), ServiceBusConstants.ITEM_TYPE_ENDPOINT);

--- a/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
@@ -9,6 +9,7 @@ import org.apache.axis2.clustering.ClusteringFault;
 import org.apache.axis2.util.XMLPrettyPrinter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.config.Entry;
 import org.apache.synapse.config.SynapseConfiguration;
@@ -71,7 +72,8 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
     private static final Log log = LogFactory.getLog(EndpointAdmin.class);
     public static final String WSO2_ENDPOINT_MEDIA_TYPE = "application/vnd.wso2.esb.endpoint";
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file", true);
+            SynapsePropertiesLoader.getBooleanProperty(
+                    SynapseConstants.ARTIFACT_STORAGE_ENABLING_SYNAPSE_PROPERTY, true);
 
     /**
      * Set Endpoint status to Active

--- a/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
@@ -71,7 +71,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
     private static final Log log = LogFactory.getLog(EndpointAdmin.class);
     public static final String WSO2_ENDPOINT_MEDIA_TYPE = "application/vnd.wso2.esb.endpoint";
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file",true);
+            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file", true);
 
     /**
      * Set Endpoint status to Active

--- a/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
@@ -70,7 +70,8 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
 
     private static final Log log = LogFactory.getLog(EndpointAdmin.class);
     public static final String WSO2_ENDPOINT_MEDIA_TYPE = "application/vnd.wso2.esb.endpoint";
-    private boolean skipLocalCopy = SynapsePropertiesLoader.getBooleanProperty("skipLocalCopy",false);
+    private boolean saveRuntimeArtifacts =
+            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file",true);
 
     /**
      * Set Endpoint status to Active
@@ -292,7 +293,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
             if (endpoint instanceof AbstractEndpoint) {
                 fileName = endpoint.getFileName();
             }
-            if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+            if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                 MediationPersistenceManager pm = getMediationPersistenceManager();
                 pm.deleteItem(endpointName, fileName, ServiceBusConstants.ITEM_TYPE_ENDPOINT);
             }
@@ -335,8 +336,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
                     if (endpoint instanceof AbstractEndpoint) {
                         fileName = endpoint.getFileName();
                     }
-                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
-
+                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                         pm.deleteItem(endpointName, fileName, ServiceBusConstants.ITEM_TYPE_ENDPOINT);
                     }
                     if (log.isDebugEnabled()) {
@@ -380,7 +380,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
                         if (endpoint instanceof AbstractEndpoint) {
                             fileName = endpoint.getFileName();
                         }
-                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                             MediationPersistenceManager pm = getMediationPersistenceManager();
                             pm.deleteItem(endpointName, fileName, ServiceBusConstants.ITEM_TYPE_ENDPOINT);
                         }
@@ -575,7 +575,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
     }
 
     private void persistEndpoint(Endpoint ep) throws EndpointAdminException {
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
 
             MediationPersistenceManager pm = getMediationPersistenceManager();
             pm.saveItem(ep.getName(), ServiceBusConstants.ITEM_TYPE_ENDPOINT);

--- a/components/mediation-admin/org.wso2.carbon.localentry/src/main/java/org/wso2/carbon/localentry/service/LocalEntryAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.localentry/src/main/java/org/wso2/carbon/localentry/service/LocalEntryAdmin.java
@@ -58,7 +58,7 @@ public class LocalEntryAdmin extends AbstractServiceBusAdmin {
     private static final Log log = LogFactory.getLog(LocalEntryAdmin.class);
     public static final int LOCAL_ENTRIES_PER_PAGE = 10;
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file", true);
+            SynapsePropertiesLoader.getBooleanProperty(SynapseConstants.ARTIFACT_STORAGE_ENABLING_SYNAPSE_PROPERTY, true);
 
     public EntryData[] entryData() throws LocalEntryAdminException {
         final Lock lock = getLock();

--- a/components/mediation-admin/org.wso2.carbon.localentry/src/main/java/org/wso2/carbon/localentry/service/LocalEntryAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.localentry/src/main/java/org/wso2/carbon/localentry/service/LocalEntryAdmin.java
@@ -24,6 +24,7 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.config.Entry;
 import org.apache.synapse.config.SynapseConfiguration;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.config.xml.EntryFactory;
 import org.apache.synapse.config.xml.EntrySerializer;
 import org.apache.synapse.config.xml.XMLConfigConstants;
@@ -56,6 +57,7 @@ public class LocalEntryAdmin extends AbstractServiceBusAdmin {
 
     private static final Log log = LogFactory.getLog(LocalEntryAdmin.class);
     public static final int LOCAL_ENTRIES_PER_PAGE = 10;
+    private boolean skipLocalCopy = SynapsePropertiesLoader.getBooleanProperty("skipLocalCopy",false);
 
     public EntryData[] entryData() throws LocalEntryAdminException {
         final Lock lock = getLock();
@@ -216,7 +218,7 @@ public class LocalEntryAdmin extends AbstractServiceBusAdmin {
                             getSynapseConfiguration().getProperties());
                     entry.setFileName(ServiceBusUtils.generateFileName(entry.getKey()));
                     getSynapseConfiguration().addEntry(entryKey, entry);
-                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                         MediationPersistenceManager pm
                                 = ServiceBusUtils.getMediationPersistenceManager(getAxisConfig());
                         pm.saveItem(entry.getKey(), ServiceBusConstants.ITEM_TYPE_ENTRY);
@@ -303,7 +305,7 @@ public class LocalEntryAdmin extends AbstractServiceBusAdmin {
                         entry.setIsEdited(true);
                     }
                     else {
-                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                             MediationPersistenceManager pm
                                     = ServiceBusUtils.getMediationPersistenceManager(getAxisConfig());
                             pm.saveItem(key, ServiceBusConstants.ITEM_TYPE_ENTRY);
@@ -430,7 +432,7 @@ public class LocalEntryAdmin extends AbstractServiceBusAdmin {
             Entry entry = synapseConfiguration.getDefinedEntries().get(entryKey);
             if (entry != null) {
                 synapseConfiguration.removeEntry(entryKey);
-                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                     MediationPersistenceManager pm
                             = ServiceBusUtils.getMediationPersistenceManager(getAxisConfig());
                     pm.deleteItem(entryKey, entry.getFileName(), ServiceBusConstants.ITEM_TYPE_ENTRY);

--- a/components/mediation-admin/org.wso2.carbon.localentry/src/main/java/org/wso2/carbon/localentry/service/LocalEntryAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.localentry/src/main/java/org/wso2/carbon/localentry/service/LocalEntryAdmin.java
@@ -57,7 +57,8 @@ public class LocalEntryAdmin extends AbstractServiceBusAdmin {
 
     private static final Log log = LogFactory.getLog(LocalEntryAdmin.class);
     public static final int LOCAL_ENTRIES_PER_PAGE = 10;
-    private boolean skipLocalCopy = SynapsePropertiesLoader.getBooleanProperty("skipLocalCopy",false);
+    private boolean saveRuntimeArtifacts =
+            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file",true);
 
     public EntryData[] entryData() throws LocalEntryAdminException {
         final Lock lock = getLock();
@@ -218,7 +219,7 @@ public class LocalEntryAdmin extends AbstractServiceBusAdmin {
                             getSynapseConfiguration().getProperties());
                     entry.setFileName(ServiceBusUtils.generateFileName(entry.getKey()));
                     getSynapseConfiguration().addEntry(entryKey, entry);
-                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                         MediationPersistenceManager pm
                                 = ServiceBusUtils.getMediationPersistenceManager(getAxisConfig());
                         pm.saveItem(entry.getKey(), ServiceBusConstants.ITEM_TYPE_ENTRY);
@@ -305,7 +306,7 @@ public class LocalEntryAdmin extends AbstractServiceBusAdmin {
                         entry.setIsEdited(true);
                     }
                     else {
-                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                             MediationPersistenceManager pm
                                     = ServiceBusUtils.getMediationPersistenceManager(getAxisConfig());
                             pm.saveItem(key, ServiceBusConstants.ITEM_TYPE_ENTRY);
@@ -432,7 +433,7 @@ public class LocalEntryAdmin extends AbstractServiceBusAdmin {
             Entry entry = synapseConfiguration.getDefinedEntries().get(entryKey);
             if (entry != null) {
                 synapseConfiguration.removeEntry(entryKey);
-                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                     MediationPersistenceManager pm
                             = ServiceBusUtils.getMediationPersistenceManager(getAxisConfig());
                     pm.deleteItem(entryKey, entry.getFileName(), ServiceBusConstants.ITEM_TYPE_ENTRY);

--- a/components/mediation-admin/org.wso2.carbon.localentry/src/main/java/org/wso2/carbon/localentry/service/LocalEntryAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.localentry/src/main/java/org/wso2/carbon/localentry/service/LocalEntryAdmin.java
@@ -58,7 +58,7 @@ public class LocalEntryAdmin extends AbstractServiceBusAdmin {
     private static final Log log = LogFactory.getLog(LocalEntryAdmin.class);
     public static final int LOCAL_ENTRIES_PER_PAGE = 10;
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file",true);
+            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file", true);
 
     public EntryData[] entryData() throws LocalEntryAdminException {
         final Lock lock = getLock();

--- a/components/mediation-admin/org.wso2.carbon.localentry/src/main/java/org/wso2/carbon/localentry/service/LocalEntryAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.localentry/src/main/java/org/wso2/carbon/localentry/service/LocalEntryAdmin.java
@@ -58,7 +58,7 @@ public class LocalEntryAdmin extends AbstractServiceBusAdmin {
     private static final Log log = LogFactory.getLog(LocalEntryAdmin.class);
     public static final int LOCAL_ENTRIES_PER_PAGE = 10;
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty(SynapseConstants.ARTIFACT_STORAGE_ENABLING_SYNAPSE_PROPERTY, true);
+            SynapsePropertiesLoader.getBooleanProperty(SynapseConstants.STORE_ARTIFACTS_LOCALLY, true);
 
     public EntryData[] entryData() throws LocalEntryAdminException {
         final Lock lock = getLock();

--- a/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
@@ -35,7 +35,6 @@ import org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils;
 import org.wso2.carbon.mediation.commons.rest.api.swagger.APIGenException;
 import org.wso2.carbon.mediation.commons.rest.api.swagger.APIGenerator;
 import org.wso2.carbon.mediation.commons.rest.api.swagger.GenericApiObjectDefinition;
-import org.wso2.carbon.mediation.commons.rest.api.swagger.ServerConfig;
 import org.wso2.carbon.mediation.commons.rest.api.swagger.SwaggerConstants;
 import org.wso2.carbon.mediation.initializer.AbstractServiceBusAdmin;
 import org.wso2.carbon.mediation.initializer.ServiceBusConstants;
@@ -48,7 +47,6 @@ import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.rest.api.APIData;
 import org.wso2.carbon.rest.api.APIDataSorter;
 import org.wso2.carbon.rest.api.APIException;
-import org.wso2.carbon.rest.api.CarbonServerConfig;
 import org.wso2.carbon.rest.api.ConfigHolder;
 import org.wso2.carbon.rest.api.ResourceData;
 import org.wso2.carbon.rest.api.RestApiAdminUtils;
@@ -85,7 +83,8 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
     private static final String CONFIG_REG_PREFIX = "conf:";
     private static final String GOV_REG_PREFIX = "gov:";
     private static final String FILE_PREFIX = "file:";
-    private boolean skipLocalCopy = SynapsePropertiesLoader.getBooleanProperty("skipLocalCopy",false);
+    private boolean saveRuntimeArtifacts =
+            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file",true);
 
 	public boolean addApi(APIData apiData) throws APIException {
 		final Lock lock = getLock();
@@ -167,7 +166,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
                 api.setArtifactContainerName(oldAPI.getArtifactContainerName());
                 apiData.setIsEdited(true);
             } else {
-                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                     MediationPersistenceManager pm = getMediationPersistenceManager();
                     String fileName = api.getFileName();
                     pm.deleteItem(apiName, fileName, ServiceBusConstants.ITEM_TYPE_REST_API);
@@ -215,7 +214,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
                 api.setIsEdited(true);
                 getApiByName(api.getName()).setIsEdited(true);
             } else {
-                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                     MediationPersistenceManager pm = getMediationPersistenceManager();
                     String fileName = api.getFileName();
                     pm.deleteItem(apiName, fileName, ServiceBusConstants.ITEM_TYPE_REST_API);
@@ -272,7 +271,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
                 api.destroy();
                 synapseConfiguration.removeAPI(apiName);
 
-                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                     MediationPersistenceManager pm = getMediationPersistenceManager();
                     String fileName = api.getFileName();
                     pm.deleteItem(apiName, fileName, ServiceBusConstants.ITEM_TYPE_REST_API);
@@ -312,7 +311,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
                     api.destroy();
                     synapseConfiguration.removeAPI(apiName);
 
-                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                         MediationPersistenceManager pm = getMediationPersistenceManager();
                         String fileName = api.getFileName();
                         pm.deleteItem(apiName, fileName, ServiceBusConstants.ITEM_TYPE_REST_API);
@@ -906,7 +905,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
     }
 	
 	private void persistApi(API api) throws APIException {
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
             MediationPersistenceManager pm = getMediationPersistenceManager();
             if (pm != null) {
                 pm.saveItem(api.getName(), ServiceBusConstants.ITEM_TYPE_REST_API);

--- a/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
@@ -86,7 +86,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
     private static final String GOV_REG_PREFIX = "gov:";
     private static final String FILE_PREFIX = "file:";
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file", true);
+            SynapsePropertiesLoader.getBooleanProperty(SynapseConstants.ARTIFACT_STORAGE_ENABLING_SYNAPSE_PROPERTY, true);
 
 	public boolean addApi(APIData apiData) throws APIException {
 		final Lock lock = getLock();

--- a/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils;
 import org.wso2.carbon.mediation.commons.rest.api.swagger.APIGenException;
 import org.wso2.carbon.mediation.commons.rest.api.swagger.APIGenerator;
 import org.wso2.carbon.mediation.commons.rest.api.swagger.GenericApiObjectDefinition;
+import org.wso2.carbon.mediation.commons.rest.api.swagger.ServerConfig;
 import org.wso2.carbon.mediation.commons.rest.api.swagger.SwaggerConstants;
 import org.wso2.carbon.mediation.initializer.AbstractServiceBusAdmin;
 import org.wso2.carbon.mediation.initializer.ServiceBusConstants;
@@ -47,6 +48,7 @@ import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.rest.api.APIData;
 import org.wso2.carbon.rest.api.APIDataSorter;
 import org.wso2.carbon.rest.api.APIException;
+import org.wso2.carbon.rest.api.CarbonServerConfig;
 import org.wso2.carbon.rest.api.ConfigHolder;
 import org.wso2.carbon.rest.api.ResourceData;
 import org.wso2.carbon.rest.api.RestApiAdminUtils;
@@ -84,7 +86,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
     private static final String GOV_REG_PREFIX = "gov:";
     private static final String FILE_PREFIX = "file:";
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file",true);
+            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file", true);
 
 	public boolean addApi(APIData apiData) throws APIException {
 		final Lock lock = getLock();

--- a/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
@@ -18,6 +18,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.aspects.AspectConfiguration;
 import org.apache.synapse.config.SynapseConfiguration;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.config.xml.rest.APIFactory;
 import org.apache.synapse.config.xml.rest.APISerializer;
@@ -84,6 +85,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
     private static final String CONFIG_REG_PREFIX = "conf:";
     private static final String GOV_REG_PREFIX = "gov:";
     private static final String FILE_PREFIX = "file:";
+    private boolean skipLocalCopy = SynapsePropertiesLoader.getBooleanProperty("skipLocalCopy",false);
 
 	public boolean addApi(APIData apiData) throws APIException {
 		final Lock lock = getLock();
@@ -165,7 +167,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
                 api.setArtifactContainerName(oldAPI.getArtifactContainerName());
                 apiData.setIsEdited(true);
             } else {
-                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                     MediationPersistenceManager pm = getMediationPersistenceManager();
                     String fileName = api.getFileName();
                     pm.deleteItem(apiName, fileName, ServiceBusConstants.ITEM_TYPE_REST_API);
@@ -213,7 +215,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
                 api.setIsEdited(true);
                 getApiByName(api.getName()).setIsEdited(true);
             } else {
-                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                     MediationPersistenceManager pm = getMediationPersistenceManager();
                     String fileName = api.getFileName();
                     pm.deleteItem(apiName, fileName, ServiceBusConstants.ITEM_TYPE_REST_API);
@@ -270,7 +272,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
                 api.destroy();
                 synapseConfiguration.removeAPI(apiName);
 
-                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                     MediationPersistenceManager pm = getMediationPersistenceManager();
                     String fileName = api.getFileName();
                     pm.deleteItem(apiName, fileName, ServiceBusConstants.ITEM_TYPE_REST_API);
@@ -310,7 +312,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
                     api.destroy();
                     synapseConfiguration.removeAPI(apiName);
 
-                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                         MediationPersistenceManager pm = getMediationPersistenceManager();
                         String fileName = api.getFileName();
                         pm.deleteItem(apiName, fileName, ServiceBusConstants.ITEM_TYPE_REST_API);
@@ -904,7 +906,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
     }
 	
 	private void persistApi(API api) throws APIException {
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
             MediationPersistenceManager pm = getMediationPersistenceManager();
             if (pm != null) {
                 pm.saveItem(api.getName(), ServiceBusConstants.ITEM_TYPE_REST_API);

--- a/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
@@ -86,7 +86,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
     private static final String GOV_REG_PREFIX = "gov:";
     private static final String FILE_PREFIX = "file:";
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty(SynapseConstants.ARTIFACT_STORAGE_ENABLING_SYNAPSE_PROPERTY, true);
+            SynapsePropertiesLoader.getBooleanProperty(SynapseConstants.STORE_ARTIFACTS_LOCALLY, true);
 
 	public boolean addApi(APIData apiData) throws APIException {
 		final Lock lock = getLock();

--- a/components/mediation-admin/org.wso2.carbon.sequences/src/main/java/org/wso2/carbon/sequences/services/SequenceAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.sequences/src/main/java/org/wso2/carbon/sequences/services/SequenceAdmin.java
@@ -80,7 +80,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
 
     private static final Log log = LogFactory.getLog(SequenceAdmin.class);
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file", true);
+            SynapsePropertiesLoader.getBooleanProperty(SynapseConstants.ARTIFACT_STORAGE_ENABLING_SYNAPSE_PROPERTY, true);
 
     //TODO: Move WSO2_SEQUENCE_MEDIA_TYPE to registry
     public static final String WSO2_SEQUENCE_MEDIA_TYPE ="application/vnd.wso2.sequence";

--- a/components/mediation-admin/org.wso2.carbon.sequences/src/main/java/org/wso2/carbon/sequences/services/SequenceAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.sequences/src/main/java/org/wso2/carbon/sequences/services/SequenceAdmin.java
@@ -79,7 +79,8 @@ import java.util.regex.Pattern;
 public class SequenceAdmin extends AbstractServiceBusAdmin {
 
     private static final Log log = LogFactory.getLog(SequenceAdmin.class);
-    private boolean skipLocalCopy = SynapsePropertiesLoader.getBooleanProperty("skipLocalCopy",false);
+    private boolean saveRuntimeArtifacts =
+            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file",true);
 
     //TODO: Move WSO2_SEQUENCE_MEDIA_TYPE to registry
     public static final String WSO2_SEQUENCE_MEDIA_TYPE ="application/vnd.wso2.sequence";
@@ -219,7 +220,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
             SequenceMediator sequence = synCfg.getDefinedSequences().get(sequenceName);
             if (sequence != null && sequence.getArtifactContainerName() == null) {
                 synCfg.removeSequence(sequenceName);
-                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                     MediationPersistenceManager pm = getMediationPersistenceManager();
                     pm.deleteItem(sequenceName, sequence.getFileName(),
                             ServiceBusConstants.ITEM_TYPE_SEQUENCE);
@@ -278,7 +279,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
                 SequenceMediator sequence = synCfg.getDefinedSequences().get(sequenceName);
                 if (sequence != null && sequence.getArtifactContainerName() == null) {
                     synCfg.removeSequence(sequenceName);
-                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                         MediationPersistenceManager pm = getMediationPersistenceManager();
                         pm.deleteItem(sequenceName, sequence.getFileName(),
                                 ServiceBusConstants.ITEM_TYPE_SEQUENCE);
@@ -310,7 +311,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
                     if ((!sequence.getName().equals("main")) && (!sequence.getName().equals("fault"))
                             && sequence.getArtifactContainerName() == null) {
                         synCfg.removeSequence(sequence.getName());
-                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
                             MediationPersistenceManager pm = getMediationPersistenceManager();
                             pm.deleteItem(sequence.getName(), sequence.getFileName(),
                                     ServiceBusConstants.ITEM_TYPE_SEQUENCE);
@@ -873,7 +874,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
     }
 
     private void persistSequence(SequenceMediator sequence) throws SequenceEditorException {
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
+        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !saveRuntimeArtifacts) {
             MediationPersistenceManager pm = getMediationPersistenceManager();
             if (pm == null) {
                 handleException("Cannot Persist sequence because persistence manager is null, " +

--- a/components/mediation-admin/org.wso2.carbon.sequences/src/main/java/org/wso2/carbon/sequences/services/SequenceAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.sequences/src/main/java/org/wso2/carbon/sequences/services/SequenceAdmin.java
@@ -80,7 +80,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
 
     private static final Log log = LogFactory.getLog(SequenceAdmin.class);
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file",true);
+            SynapsePropertiesLoader.getBooleanProperty("synapse.runtime_artifacts.save.local.file", true);
 
     //TODO: Move WSO2_SEQUENCE_MEDIA_TYPE to registry
     public static final String WSO2_SEQUENCE_MEDIA_TYPE ="application/vnd.wso2.sequence";
@@ -874,7 +874,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
     }
 
     private void persistSequence(SequenceMediator sequence) throws SequenceEditorException {
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !saveRuntimeArtifacts) {
+        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && saveRuntimeArtifacts) {
             MediationPersistenceManager pm = getMediationPersistenceManager();
             if (pm == null) {
                 handleException("Cannot Persist sequence because persistence manager is null, " +

--- a/components/mediation-admin/org.wso2.carbon.sequences/src/main/java/org/wso2/carbon/sequences/services/SequenceAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.sequences/src/main/java/org/wso2/carbon/sequences/services/SequenceAdmin.java
@@ -80,7 +80,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
 
     private static final Log log = LogFactory.getLog(SequenceAdmin.class);
     private boolean saveRuntimeArtifacts =
-            SynapsePropertiesLoader.getBooleanProperty(SynapseConstants.ARTIFACT_STORAGE_ENABLING_SYNAPSE_PROPERTY, true);
+            SynapsePropertiesLoader.getBooleanProperty(SynapseConstants.STORE_ARTIFACTS_LOCALLY, true);
 
     //TODO: Move WSO2_SEQUENCE_MEDIA_TYPE to registry
     public static final String WSO2_SEQUENCE_MEDIA_TYPE ="application/vnd.wso2.sequence";

--- a/components/mediation-admin/org.wso2.carbon.sequences/src/main/java/org/wso2/carbon/sequences/services/SequenceAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.sequences/src/main/java/org/wso2/carbon/sequences/services/SequenceAdmin.java
@@ -24,6 +24,7 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.config.Entry;
 import org.apache.synapse.config.SynapseConfiguration;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.config.xml.MediatorFactoryFinder;
 import org.apache.synapse.config.xml.MediatorSerializerFinder;
 import org.apache.synapse.config.xml.SynapseXMLConfigurationFactory;
@@ -78,6 +79,7 @@ import java.util.regex.Pattern;
 public class SequenceAdmin extends AbstractServiceBusAdmin {
 
     private static final Log log = LogFactory.getLog(SequenceAdmin.class);
+    private boolean skipLocalCopy = SynapsePropertiesLoader.getBooleanProperty("skipLocalCopy",false);
 
     //TODO: Move WSO2_SEQUENCE_MEDIA_TYPE to registry
     public static final String WSO2_SEQUENCE_MEDIA_TYPE ="application/vnd.wso2.sequence";
@@ -217,7 +219,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
             SequenceMediator sequence = synCfg.getDefinedSequences().get(sequenceName);
             if (sequence != null && sequence.getArtifactContainerName() == null) {
                 synCfg.removeSequence(sequenceName);
-                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                     MediationPersistenceManager pm = getMediationPersistenceManager();
                     pm.deleteItem(sequenceName, sequence.getFileName(),
                             ServiceBusConstants.ITEM_TYPE_SEQUENCE);
@@ -276,7 +278,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
                 SequenceMediator sequence = synCfg.getDefinedSequences().get(sequenceName);
                 if (sequence != null && sequence.getArtifactContainerName() == null) {
                     synCfg.removeSequence(sequenceName);
-                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                    if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                         MediationPersistenceManager pm = getMediationPersistenceManager();
                         pm.deleteItem(sequenceName, sequence.getFileName(),
                                 ServiceBusConstants.ITEM_TYPE_SEQUENCE);
@@ -308,7 +310,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
                     if ((!sequence.getName().equals("main")) && (!sequence.getName().equals("fault"))
                             && sequence.getArtifactContainerName() == null) {
                         synCfg.removeSequence(sequence.getName());
-                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+                        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
                             MediationPersistenceManager pm = getMediationPersistenceManager();
                             pm.deleteItem(sequence.getName(), sequence.getFileName(),
                                     ServiceBusConstants.ITEM_TYPE_SEQUENCE);
@@ -871,7 +873,7 @@ public class SequenceAdmin extends AbstractServiceBusAdmin {
     }
 
     private void persistSequence(SequenceMediator sequence) throws SequenceEditorException {
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) && !skipLocalCopy) {
             MediationPersistenceManager pm = getMediationPersistenceManager();
             if (pm == null) {
                 handleException("Cannot Persist sequence because persistence manager is null, " +

--- a/pom.xml
+++ b/pom.xml
@@ -2446,7 +2446,7 @@
         <carbon.rule.version>4.5.6</carbon.rule.version>
         <carbon.rule.imp.pkg.version>[4.5.0, 4.6.0)</carbon.rule.imp.pkg.version>
         <!-- Synapse Version -->
-        <synapse.version>2.1.7-wso2v167</synapse.version>
+        <synapse.version>2.1.7-wso2v168</synapse.version>
         <carbon.identity.entitlement.proxy.version>5.3.4</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.2.0, 6.0.0)
         </carbon.identity.entitlement.proxy.imp.pkg.version>


### PR DESCRIPTION
Introduced a new synapse property ```synapse.runtime_artifacts.save.local.file``` to skip saving runtime artifacts of API manager gateway to the local directory.

Used with the new feature: https://github.com/wso2/product-apim/issues/8246