### PR TITLE
Add RefreshAccessToken Class Mediator

### DIFF
--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
@@ -31,6 +31,13 @@ import java.io.IOException;
 import java.util.Scanner;
 import java.util.Set;
 
+/**
+ * This class can be used by connectors to refresh OAuth 2.0 access tokens by setting the following mandatory
+ * properties in message context: uri.var.hostName, uri.var.refreshToken
+ *
+ * After refresh call this will set the uri.var.accessToken, and uri.var.apiUrl in the message context to be used by
+ * subsequent calls
+ */
 public class RefreshAccessToken extends AbstractConnector {
     private CloseableHttpClient httpClient = HttpClients.createDefault();
 
@@ -76,6 +83,9 @@ public class RefreshAccessToken extends AbstractConnector {
 
         try {
             httpResponse = httpClient.execute(httpget);
+            if (httpResponse.getEntity() == null) {
+                throw new ConnectException("Empty response received for refresh access token call");
+            }
             Scanner scanner = new Scanner(httpResponse.getEntity().getContent());
             String jsonResponse = scanner.nextLine();
             JSONObject jsonObject = new JSONObject(jsonResponse);

--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
@@ -135,8 +135,8 @@ public class RefreshAccessToken extends AbstractConnector {
             return customRefreshUrl;
         } else {
             StringBuilder urlStringBuilder = new StringBuilder();
-            urlStringBuilder.append(messageContext.getProperty(PROPERTY_PREFIX + "hostName"));
-            urlStringBuilder.append("/services/oauth2/token?grant_type=refresh_token");
+            urlStringBuilder.append(messageContext.getProperty(PROPERTY_PREFIX + "tokenEndpointUrl"));
+            urlStringBuilder.append("?grant_type=refresh_token");
             String clientId = (String) messageContext.getProperty(PROPERTY_PREFIX + "clientId");
             if (StringUtils.isNotEmpty(clientId)) {
                 urlStringBuilder.append("&client_id=").append(clientId);

--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.connector.core;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseLog;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.Scanner;
+
+public class RefreshAccessToken extends AbstractConnector {
+    CloseableHttpClient httpclient = HttpClients.createDefault();
+
+    @Override
+    public void connect(MessageContext messageContext) throws ConnectException {
+        SynapseLog synLog = getLog(messageContext);
+
+        if (synLog.isTraceOrDebugEnabled()) {
+            synLog.traceOrDebug("Start : Salesforce Refresh Access Token mediator");
+
+            if (synLog.isTraceTraceEnabled()) {
+                synLog.traceTrace("Message : " + messageContext.getEnvelope());
+            }
+        }
+
+        String tokenRefreshUrl = "";
+        tokenRefreshUrl += messageContext.getProperty("uri.var.hostName");
+        tokenRefreshUrl += "/services/oauth2/token?grant_type=refresh_token";
+        tokenRefreshUrl += "&client_id=" + messageContext.getProperty("uri.var.clientId");
+        tokenRefreshUrl += "&client_secret=" + messageContext.getProperty("uri.var.clientSecret");
+        tokenRefreshUrl += "&refresh_token=" + messageContext.getProperty("uri.var.refreshToken");
+        tokenRefreshUrl += "&format=json";
+
+        HttpGet httpget = new HttpGet(tokenRefreshUrl);
+        CloseableHttpResponse httpResponse = null;
+        try {
+            httpResponse = httpclient.execute(httpget);
+            Scanner scanner = new Scanner(httpResponse.getEntity().getContent());
+            String jsonResponse = scanner.nextLine();
+            JSONObject jsonObject = new JSONObject(jsonResponse);
+
+            String accessToken = jsonObject.getString("access_token");
+            messageContext.setProperty("uri.var.accessToken", accessToken);
+
+            String instanceUrl = jsonObject.getString("instance_url");
+            messageContext.setProperty("uri.var.apiUrl", instanceUrl);
+
+            String systemTime = Long.toString(System.currentTimeMillis());
+            String newAccessRegistryPath = (String) messageContext.getProperty("uri.var.accessTokenRegistryPath");
+            String newTimeRegistryPath = (String) messageContext.getProperty("uri.var.timeRegistryPath");
+
+            if((accessToken != null) && (!accessToken.equals(""))){
+                if (!messageContext.getConfiguration().getRegistry().isResourceExists(newAccessRegistryPath)) {
+                    messageContext.getConfiguration().getRegistry().newResource(newAccessRegistryPath, false);
+                    messageContext.getConfiguration().getRegistry().updateResource(newAccessRegistryPath, accessToken);
+                    messageContext.getConfiguration().getRegistry().newResource(newTimeRegistryPath, false);
+                    messageContext.getConfiguration().getRegistry().updateResource(newTimeRegistryPath, systemTime);
+                } else {
+                    messageContext.getConfiguration().getRegistry().updateResource(newAccessRegistryPath, accessToken);
+                    messageContext.getConfiguration().getRegistry().updateResource(newTimeRegistryPath, systemTime);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+
+        } finally {
+            httpget.releaseConnection();
+            if (httpResponse != null) {
+                try {
+                    httpResponse.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+}

--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
@@ -41,6 +41,7 @@ import java.util.Set;
  */
 public class RefreshAccessToken extends AbstractConnector {
     private CloseableHttpClient httpClient = HttpClients.createDefault();
+    private final String PROPERTY_PREFIX = "uri.var.";
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
@@ -57,23 +58,23 @@ public class RefreshAccessToken extends AbstractConnector {
         }
 
         String refreshUrl;
-        String customRefreshUrl = (String) messageContext.getProperty("uri.var.customRefreshUrl");
+        String customRefreshUrl = (String) messageContext.getProperty(PROPERTY_PREFIX + "customRefreshUrl");
 
         if (StringUtils.isNotEmpty(customRefreshUrl)) {
             refreshUrl = customRefreshUrl;
         } else {
             StringBuilder urlStringBuilder = new StringBuilder();
-            urlStringBuilder.append(messageContext.getProperty("uri.var.hostName"));
+            urlStringBuilder.append(messageContext.getProperty(PROPERTY_PREFIX + "hostName"));
             urlStringBuilder.append("/services/oauth2/token?grant_type=refresh_token");
-            String clientId = (String) messageContext.getProperty("uri.var.clientId");
+            String clientId = (String) messageContext.getProperty(PROPERTY_PREFIX + "clientId");
             if (StringUtils.isNotEmpty(clientId)) {
                 urlStringBuilder.append("&client_id=").append(clientId);
             }
-            String clientSecret = (String) messageContext.getProperty("uri.var.clientSecret");
+            String clientSecret = (String) messageContext.getProperty(PROPERTY_PREFIX + "clientSecret");
             if (StringUtils.isNotEmpty(clientSecret)) {
                 urlStringBuilder.append("&client_secret=").append(clientSecret);
             }
-            urlStringBuilder.append("&refresh_token=").append(messageContext.getProperty("uri.var.refreshToken"));
+            urlStringBuilder.append("&refresh_token=").append(messageContext.getProperty(PROPERTY_PREFIX + "refreshToken"));
             urlStringBuilder.append("&format=json");
             refreshUrl = urlStringBuilder.toString();
         }
@@ -91,14 +92,15 @@ public class RefreshAccessToken extends AbstractConnector {
             JSONObject jsonObject = new JSONObject(jsonResponse);
 
             String accessToken = jsonObject.getString("access_token");
-            messageContext.setProperty("uri.var.accessToken", accessToken);
+            messageContext.setProperty(PROPERTY_PREFIX + "accessToken", accessToken);
 
             String instanceUrl = jsonObject.getString("instance_url");
-            messageContext.setProperty("uri.var.apiUrl", instanceUrl);
+            messageContext.setProperty(PROPERTY_PREFIX + "apiUrl", instanceUrl);
 
             String systemTime = Long.toString(System.currentTimeMillis());
-            String newAccessRegistryPath = (String) messageContext.getProperty("uri.var.accessTokenRegistryPath");
-            String newTimeRegistryPath = (String) messageContext.getProperty("uri.var.timeRegistryPath");
+            String newAccessRegistryPath = (String) messageContext.getProperty(PROPERTY_PREFIX +
+                    "accessTokenRegistryPath");
+            String newTimeRegistryPath = (String) messageContext.getProperty(PROPERTY_PREFIX + "timeRegistryPath");
             Registry registry = messageContext.getConfiguration().getRegistry();
 
             if(StringUtils.isNotEmpty(accessToken)) {

--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
@@ -40,7 +40,6 @@ public class RefreshAccessToken extends AbstractConnector {
         Set propertyKeySet = messageContext.getPropertyKeySet();
         propertyKeySet.remove("Accept-Encoding");
 
-
         if (synLog.isTraceOrDebugEnabled()) {
             synLog.traceOrDebug("Start : Salesforce Refresh Access Token mediator. If you want to observe refresh " +
                     "access token header and wire logs please enable Apache HTTP Client logs in Log4j.properties");
@@ -53,18 +52,18 @@ public class RefreshAccessToken extends AbstractConnector {
         String refreshUrl;
         String customRefreshUrl = (String) messageContext.getProperty("uri.var.customRefreshUrl");
 
-        if (customRefreshUrl != null && !StringUtils.isEmpty(customRefreshUrl)) {
+        if (StringUtils.isNotEmpty(customRefreshUrl)) {
             refreshUrl = customRefreshUrl;
         } else {
             StringBuilder urlStringBuilder = new StringBuilder();
             urlStringBuilder.append(messageContext.getProperty("uri.var.hostName"));
             urlStringBuilder.append("/services/oauth2/token?grant_type=refresh_token");
             String clientId = (String) messageContext.getProperty("uri.var.clientId");
-            if (clientId != null && !clientId.equals("")) {
+            if (StringUtils.isNotEmpty(clientId)) {
                 urlStringBuilder.append("&client_id=").append(clientId);
             }
             String clientSecret = (String) messageContext.getProperty("uri.var.clientSecret");
-            if (clientSecret != null && !StringUtils.isEmpty(clientSecret)) {
+            if (StringUtils.isNotEmpty(clientSecret)) {
                 urlStringBuilder.append("&client_id=").append(clientSecret);
             }
             urlStringBuilder.append("&refresh_token=").append(messageContext.getProperty("uri.var.refreshToken"));
@@ -91,7 +90,7 @@ public class RefreshAccessToken extends AbstractConnector {
             String newAccessRegistryPath = (String) messageContext.getProperty("uri.var.accessTokenRegistryPath");
             String newTimeRegistryPath = (String) messageContext.getProperty("uri.var.timeRegistryPath");
 
-            if((accessToken != null) && (!StringUtils.isEmpty(accessToken))) {
+            if(StringUtils.isNotEmpty(accessToken)) {
                 if (!messageContext.getConfiguration().getRegistry().isResourceExists(newAccessRegistryPath)) {
                     messageContext.getConfiguration().getRegistry().newResource(newAccessRegistryPath, false);
                     messageContext.getConfiguration().getRegistry().updateResource(newAccessRegistryPath, accessToken);
@@ -103,7 +102,8 @@ public class RefreshAccessToken extends AbstractConnector {
                 }
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            synLog.error(e);
+            throw new ConnectException(e, "Error while executing GET request to refresh the access token");
         } finally {
             propertyKeySet.remove("Cache-Control");
             propertyKeySet.remove("Pragma");
@@ -112,7 +112,7 @@ public class RefreshAccessToken extends AbstractConnector {
                 try {
                     httpResponse.close();
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    synLog.error(e);
                 }
             }
         }

--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.connector.core;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -52,7 +53,7 @@ public class RefreshAccessToken extends AbstractConnector {
         String refreshUrl;
         String customRefreshUrl = (String) messageContext.getProperty("uri.var.customRefreshUrl");
 
-        if (customRefreshUrl != null && !customRefreshUrl.equals("")) {
+        if (customRefreshUrl != null && !StringUtils.isEmpty(customRefreshUrl)) {
             refreshUrl = customRefreshUrl;
         } else {
             StringBuilder urlStringBuilder = new StringBuilder();
@@ -63,7 +64,7 @@ public class RefreshAccessToken extends AbstractConnector {
                 urlStringBuilder.append("&client_id=").append(clientId);
             }
             String clientSecret = (String) messageContext.getProperty("uri.var.clientSecret");
-            if (clientSecret != null && !clientSecret.equals("")) {
+            if (clientSecret != null && !StringUtils.isEmpty(clientSecret)) {
                 urlStringBuilder.append("&client_id=").append(clientSecret);
             }
             urlStringBuilder.append("&refresh_token=").append(messageContext.getProperty("uri.var.refreshToken"));
@@ -90,7 +91,7 @@ public class RefreshAccessToken extends AbstractConnector {
             String newAccessRegistryPath = (String) messageContext.getProperty("uri.var.accessTokenRegistryPath");
             String newTimeRegistryPath = (String) messageContext.getProperty("uri.var.timeRegistryPath");
 
-            if((accessToken != null) && (!accessToken.equals(""))){
+            if((accessToken != null) && (!StringUtils.isEmpty(accessToken))) {
                 if (!messageContext.getConfiguration().getRegistry().isResourceExists(newAccessRegistryPath)) {
                     messageContext.getConfiguration().getRegistry().newResource(newAccessRegistryPath, false);
                     messageContext.getConfiguration().getRegistry().updateResource(newAccessRegistryPath, accessToken);

--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessToken.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.connector.core;
 
+import org.apache.axiom.om.OMText;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -25,19 +26,25 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseLog;
+import org.apache.synapse.config.Entry;
 import org.apache.synapse.registry.Registry;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.Properties;
 import java.util.Scanner;
 import java.util.Set;
 
 /**
  * This class can be used by connectors to refresh OAuth 2.0 access tokens by setting the following mandatory
- * properties in message context: uri.var.hostName, uri.var.refreshToken
+ * properties in message context: uri.var.hostName, uri.var.refreshToken. By default this class constructs the refresh
+ * url in the format "{uri.var.hostName}/services/oauth2/token?grant_type=refresh_token&client_id=
+ * {uri.var.clientId}&client_secret={uri.var.clientSecret}&refresh_token={uri.var.refreshToken}&format=json".
+ * Here client_id and client_secret are optional. If you want to use a different url please set the custom url to
+ * uri.var.customRefreshUrl in message context prior to using this class mediator.
  *
  * After refresh call this will set the uri.var.accessToken, and uri.var.apiUrl in the message context to be used by
- * subsequent calls
+ * subsequent calls.
  */
 public class RefreshAccessToken extends AbstractConnector {
     private CloseableHttpClient httpClient = HttpClients.createDefault();
@@ -45,23 +52,92 @@ public class RefreshAccessToken extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        SynapseLog synLog = getLog(messageContext);
-        Set propertyKeySet = messageContext.getPropertyKeySet();
-        propertyKeySet.remove("Accept-Encoding");
-
-        if (synLog.isTraceOrDebugEnabled()) {
-            synLog.traceOrDebug("Start : Salesforce Refresh Access Token mediator.");
-
-            if (synLog.isTraceTraceEnabled()) {
-                synLog.traceTrace("Message : " + messageContext.getEnvelope());
+        Registry registry = messageContext.getConfiguration().getRegistry();
+        boolean isRefreshNeeded = false;
+        String accessTokenRegistryPath = (String) messageContext.getProperty(PROPERTY_PREFIX +
+                "accessTokenRegistryPath");
+        String lastRefreshedTimeString = registry.getResourceProperties(accessTokenRegistryPath).getProperty("timestamp");
+        if (StringUtils.isEmpty(lastRefreshedTimeString)) {
+            isRefreshNeeded = true;
+        } else {
+            String intervalTimeString = (String) messageContext.getProperty("uri.var.intervalTime");
+            if (StringUtils.isEmpty(intervalTimeString)) {
+                intervalTimeString = "300000"; // sets default interval time as 50 min
+            }
+            long expiryTimeInterval = Long.parseLong(intervalTimeString);
+            long lastRefreshedTime = Long.parseLong(lastRefreshedTimeString);
+            if (System.currentTimeMillis() - lastRefreshedTime > expiryTimeInterval) {
+                isRefreshNeeded = true;
             }
         }
 
-        String refreshUrl;
+        if (!isRefreshNeeded) {
+            String savedAccessToken = null;
+            Entry propEntry = messageContext.getConfiguration().getEntryDefinition(accessTokenRegistryPath);
+            if (propEntry == null) {
+                propEntry = new Entry();
+                propEntry.setType(Entry.REMOTE_ENTRY);
+                propEntry.setKey(accessTokenRegistryPath);
+            }
+            registry.getResource(propEntry, new Properties());
+            if (propEntry.getValue() != null) {
+                if (propEntry.getValue() instanceof OMText) {
+                    savedAccessToken = ((OMText) propEntry.getValue()).getText();
+                } else {
+                    savedAccessToken = propEntry.getValue().toString();
+                }
+                messageContext.setProperty(PROPERTY_PREFIX + "accessToken", savedAccessToken);
+            } else {
+                isRefreshNeeded = true;
+            }
+        }
+
+        if (isRefreshNeeded) {
+            SynapseLog synLog = getLog(messageContext);
+            Set propertyKeySet = messageContext.getPropertyKeySet();
+            propertyKeySet.remove("Accept-Encoding");
+
+            if (synLog.isTraceOrDebugEnabled()) {
+                synLog.traceOrDebug("Start : Salesforce Refresh Access Token mediator.");
+
+                if (synLog.isTraceTraceEnabled()) {
+                    synLog.traceTrace("Message : " + messageContext.getEnvelope());
+                }
+            }
+
+            String refreshUrl = getRefreshUrl(messageContext);
+            HttpGet httpget = new HttpGet(refreshUrl);
+            CloseableHttpResponse httpResponse = null;
+
+            try {
+                httpResponse = httpClient.execute(httpget);
+                if (httpResponse.getEntity() == null) {
+                    throw new ConnectException("Empty response received for refresh access token call");
+                }
+                extractAndSetPropertyAndRegistryResource(messageContext, httpResponse, registry);
+            } catch (IOException e) {
+                synLog.error(e);
+                throw new ConnectException(e, "Error while executing GET request to refresh the access token");
+            } finally {
+                propertyKeySet.remove("Cache-Control");
+                propertyKeySet.remove("Pragma");
+                httpget.releaseConnection();
+                if (httpResponse != null) {
+                    try {
+                        httpResponse.close();
+                    } catch (IOException e) {
+                        synLog.error(e);
+                    }
+                }
+            }
+        }
+    }
+
+    private String getRefreshUrl (MessageContext messageContext) {
         String customRefreshUrl = (String) messageContext.getProperty(PROPERTY_PREFIX + "customRefreshUrl");
 
         if (StringUtils.isNotEmpty(customRefreshUrl)) {
-            refreshUrl = customRefreshUrl;
+            return customRefreshUrl;
         } else {
             StringBuilder urlStringBuilder = new StringBuilder();
             urlStringBuilder.append(messageContext.getProperty(PROPERTY_PREFIX + "hostName"));
@@ -74,60 +150,33 @@ public class RefreshAccessToken extends AbstractConnector {
             if (StringUtils.isNotEmpty(clientSecret)) {
                 urlStringBuilder.append("&client_secret=").append(clientSecret);
             }
-            urlStringBuilder.append("&refresh_token=").append(messageContext.getProperty(PROPERTY_PREFIX + "refreshToken"));
+            urlStringBuilder.append("&refresh_token=").append(messageContext.getProperty(PROPERTY_PREFIX +
+                    "refreshToken"));
             urlStringBuilder.append("&format=json");
-            refreshUrl = urlStringBuilder.toString();
+            return urlStringBuilder.toString();
         }
+    }
 
-        HttpGet httpget = new HttpGet(refreshUrl);
-        CloseableHttpResponse httpResponse = null;
+    private void extractAndSetPropertyAndRegistryResource (MessageContext messageContext,
+                                                           CloseableHttpResponse httpResponse,
+                                                           Registry registry) throws IOException {
+        Scanner scanner = new Scanner(httpResponse.getEntity().getContent());
+        String jsonResponse = scanner.nextLine();
+        JSONObject jsonObject = new JSONObject(jsonResponse);
 
-        try {
-            httpResponse = httpClient.execute(httpget);
-            if (httpResponse.getEntity() == null) {
-                throw new ConnectException("Empty response received for refresh access token call");
-            }
-            Scanner scanner = new Scanner(httpResponse.getEntity().getContent());
-            String jsonResponse = scanner.nextLine();
-            JSONObject jsonObject = new JSONObject(jsonResponse);
+        String accessToken = jsonObject.getString("access_token");
+        messageContext.setProperty(PROPERTY_PREFIX + "accessToken", accessToken);
 
-            String accessToken = jsonObject.getString("access_token");
-            messageContext.setProperty(PROPERTY_PREFIX + "accessToken", accessToken);
+        String instanceUrl = jsonObject.getString("instance_url");
+        messageContext.setProperty(PROPERTY_PREFIX + "apiUrl", instanceUrl);
 
-            String instanceUrl = jsonObject.getString("instance_url");
-            messageContext.setProperty(PROPERTY_PREFIX + "apiUrl", instanceUrl);
+        String systemTime = Long.toString(System.currentTimeMillis());
+        String newAccessRegistryPath = (String) messageContext.getProperty(PROPERTY_PREFIX +
+                "accessTokenRegistryPath");
 
-            String systemTime = Long.toString(System.currentTimeMillis());
-            String newAccessRegistryPath = (String) messageContext.getProperty(PROPERTY_PREFIX +
-                    "accessTokenRegistryPath");
-            String newTimeRegistryPath = (String) messageContext.getProperty(PROPERTY_PREFIX + "timeRegistryPath");
-            Registry registry = messageContext.getConfiguration().getRegistry();
-
-            if(StringUtils.isNotEmpty(accessToken)) {
-                if (!registry.isResourceExists(newAccessRegistryPath)) {
-                    registry.newResource(newAccessRegistryPath, false);
-                    registry.updateResource(newAccessRegistryPath, accessToken);
-                    registry.newResource(newTimeRegistryPath, false);
-                    registry.updateResource(newTimeRegistryPath, systemTime);
-                } else {
-                    registry.updateResource(newAccessRegistryPath, accessToken);
-                    registry.updateResource(newTimeRegistryPath, systemTime);
-                }
-            }
-        } catch (IOException e) {
-            synLog.error(e);
-            throw new ConnectException(e, "Error while executing GET request to refresh the access token");
-        } finally {
-            propertyKeySet.remove("Cache-Control");
-            propertyKeySet.remove("Pragma");
-            httpget.releaseConnection();
-            if (httpResponse != null) {
-                try {
-                    httpResponse.close();
-                } catch (IOException e) {
-                    synLog.error(e);
-                }
-            }
+        if(StringUtils.isNotEmpty(accessToken)) {
+                registry.newNonEmptyResource(newAccessRegistryPath, false, "text/plain", systemTime, "timestamp");
+                registry.updateResource(newAccessRegistryPath, accessToken);
         }
     }
 }

--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessTokenWithExpiry.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessTokenWithExpiry.java
@@ -57,7 +57,7 @@ public class RefreshAccessTokenWithExpiry extends RefreshAccessToken {
         }
 
         if (!isRefreshNeeded) {
-            isRefreshNeeded = handleSavedCredentialReuse(messageContext, registry, accessTokenRegistryPath);
+            isRefreshNeeded = reuseSavedAccessToken(messageContext, registry, accessTokenRegistryPath);
         }
 
         if (isRefreshNeeded) {

--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessTokenWithExpiry.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/RefreshAccessTokenWithExpiry.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.connector.core;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.registry.Registry;
+
+/**
+ * This class can be used by connectors to refresh OAuth 2.0 access tokens by setting the following mandatory
+ * properties in message context: uri.var.hostName, uri.var.refreshToken. By default this class constructs the refresh
+ * url in the format "{uri.var.hostName}/services/oauth2/token?grant_type=refresh_token&client_id=
+ * {uri.var.clientId}&client_secret={uri.var.clientSecret}&refresh_token={uri.var.refreshToken}&format=json".
+ * Here client_id and client_secret are optional. If you want to use a different url please set the custom url to
+ * uri.var.customRefreshUrl in message context prior to using this class mediator.
+ *
+ * After refresh call this will set the uri.var.accessToken, and uri.var.apiUrl in the message context to be used by
+ * subsequent calls.
+ */
+public class RefreshAccessTokenWithExpiry extends RefreshAccessToken {
+
+    @Override
+    public void connect(MessageContext messageContext) throws ConnectException {
+        Registry registry = messageContext.getConfiguration().getRegistry();
+        boolean isRefreshNeeded = false;
+        String accessTokenRegistryPath = (String) messageContext.getProperty(PROPERTY_PREFIX +
+                "accessTokenRegistryPath");
+        String lastRefreshedTimeString = registry.getResourceProperties(accessTokenRegistryPath).getProperty("timestamp");
+        if (StringUtils.isEmpty(lastRefreshedTimeString)) {
+            isRefreshNeeded = true;
+        } else {
+            String intervalTimeString = (String) messageContext.getProperty("uri.var.intervalTime");
+            if (StringUtils.isEmpty(intervalTimeString)) {
+                intervalTimeString = "300000"; // sets default interval time as 50 min
+            }
+            long expiryTimeInterval = Long.parseLong(intervalTimeString);
+            long lastRefreshedTime = Long.parseLong(lastRefreshedTimeString);
+            if (System.currentTimeMillis() - lastRefreshedTime > expiryTimeInterval) {
+                isRefreshNeeded = true;
+            }
+        }
+
+        if (!isRefreshNeeded) {
+            isRefreshNeeded = handleSavedCredentialReuse(messageContext, registry, accessTokenRegistryPath);
+        }
+
+        if (isRefreshNeeded) {
+            handleRefresh(messageContext, registry, accessTokenRegistryPath);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
Add class mediator to be used by connectors to refresh access tokens

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes