### PR TITLE
Add extension for HashiCorp external vault resolver

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.mediation.security/pom.xml
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.bettercloud</groupId>
+            <artifactId>vault-java-driver</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -65,7 +69,7 @@
                             org.wso2.carbon.mediation.security.*,
                         </Export-Package>
                         <Import-Package>
-                            org.apache.synapse.*,
+                            org.apache.synapse.*;version="0.0.0",
                             org.apache.axiom.*;
                             version="${axiom.osgi.version.range}",
                             org.apache.commons.logging; version="${import.package.version.commons.logging}",

--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/ExternalVaultConfigLoader.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/ExternalVaultConfigLoader.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.mediation.security.vault.external;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.securevault.SecretCallbackHandlerService;
+import org.wso2.carbon.utils.CarbonUtils;
+import org.wso2.securevault.SecretResolver;
+import org.wso2.securevault.SecretResolverFactory;
+import org.wso2.securevault.commons.MiscellaneousUtil;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * {@code ExternalVaultLoader} contains utilities to load configuration file content required for External vault loader
+ * implementation.
+ */
+public class ExternalVaultConfigLoader {
+
+    private static Log log = LogFactory.getLog(ExternalVaultConfigLoader.class);
+
+    private static final QName ROOT_Q = new QName("secureVaults");
+    private static final QName VAULT_NAME_Q = new QName("name");
+
+    private static final String EXTERNAL_VAULTS = "external-vaults.xml";
+
+    private static SecretResolver secretResolver;
+
+    private static Map<String, Map<String, String>> externalVaultMap = new HashMap<>();
+
+    private ExternalVaultConfigLoader() {}
+
+    /**
+     * Reads the external-vaults.xml file located in conf/security dir and loads to the memory.
+     *
+     * @param secretCallbackHandlerService secret resolver to resolve the cipher-tool encrypted secrets
+     */
+    public static void loadExternalVaultConfigs(SecretCallbackHandlerService secretCallbackHandlerService)
+            throws ExternalVaultException {
+        String vaultConfigFilePath = CarbonUtils.getCarbonSecurityConfigDirPath() + File.separator + EXTERNAL_VAULTS;
+        OMElement vaultConfig = null;
+
+        try {
+            File externalVaultFile = new File(vaultConfigFilePath);
+            if (externalVaultFile.exists()) {
+                String configsFileAsString = FileUtils.readFileToString(externalVaultFile);
+                vaultConfig = AXIOMUtil.stringToOM(configsFileAsString);
+            } else {
+                log.warn("No such file: " + EXTERNAL_VAULTS + " in location " + vaultConfigFilePath);
+            }
+        } catch (IOException| XMLStreamException e) {
+            log.error("Error while reading the " + EXTERNAL_VAULTS + " file in location + "
+                    + vaultConfigFilePath, e);
+        }
+
+        if (vaultConfig != null) {
+            if (!ROOT_Q.equals(vaultConfig.getQName())) {
+                throw new ExternalVaultException("Invalid external secure vault configuration file");
+            }
+            setSecretResolver(vaultConfig);
+
+            Iterator vaultIterator =  vaultConfig.getChildElements();
+            while (vaultIterator.hasNext()) {
+                OMElement vaultNode = (OMElement) vaultIterator.next();
+                if (vaultNode != null) {
+                    Iterator vaultNodeIterator =  vaultNode.getChildElements();
+                    Map<String, String> childParameters = new HashMap<>();
+                    while (vaultNodeIterator.hasNext()) {
+                        OMElement vaultChildNode = (OMElement) vaultNodeIterator.next();
+                        if (vaultChildNode != null) {
+                            String resolvedValue = MiscellaneousUtil.resolve(vaultChildNode, secretResolver);
+                            childParameters.put(vaultChildNode.getAttributeValue(VAULT_NAME_Q), resolvedValue);
+                        }
+                    }
+                    externalVaultMap.put(vaultNode.getAttributeValue(VAULT_NAME_Q), childParameters);
+                }
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug(EXTERNAL_VAULTS + " file external secure vault configurations loaded to the map");
+            }
+        }
+    }
+
+    /**
+     * Get the external vault configuration map based on the given vault name.
+     *
+     * @param name vault name
+     */
+    public static Map<String, String> getVaultParameters(String name) {
+        return externalVaultMap.get(name);
+    }
+
+    /**
+     * Sets the SecretResolver the document OMElement.
+     *
+     * @param rootElement Document OMElement
+     */
+    private static void setSecretResolver(OMElement rootElement) {
+        secretResolver = SecretResolverFactory.create(rootElement, true);
+    }
+}

--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/ExternalVaultException.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/ExternalVaultException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.mediation.security.vault.external;
+
+public class ExternalVaultException extends Exception {
+    public ExternalVaultException(String message) {
+        super(message);
+    }
+
+    public ExternalVaultException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/ExternalVaultLookupHandler.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/ExternalVaultLookupHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.mediation.security.vault.external;
+
+import org.apache.synapse.MessageContext;
+
+import java.util.Map;
+
+public interface ExternalVaultLookupHandler {
+
+    /**
+     * Method to evaluate the parameters passed to extract values from secure-vault lookup.
+     *
+     * @param vaultParameters secure-key parameters
+     * @param synCtx synapse context
+     * @return decrypted value
+     * @throws ExternalVaultException customize external vault exception
+     */
+    public String evaluate(Map<String, String> vaultParameters, MessageContext synCtx)
+            throws ExternalVaultException;
+
+    public String name() throws ExternalVaultException;
+
+}

--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultConstant.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultConstant.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.mediation.security.vault.external.hashicorp;
+
+public class HashiCorpVaultConstant {
+
+    private HashiCorpVaultConstant() {}
+
+    static final String CARBON_HOME_VARIABLE = "${carbon.home}";
+    static final String NUMBER_REGEX = "[0-9]+";
+
+    static final String VAULT_NAMESPACE_PARAMETER = "vault-namespace";
+    static final String PATH_PARAMETER = "path-parameter";
+    static final String FIELD_PARAMETER = "field-parameter";
+
+    static final String ADDRESS_PARAMETER = "address";
+    static final String TOKEN_PARAMETER = "rootToken";
+    static final String ENGINE_TYPE_PARAMETER = "engineVersion";
+    static final String CACHEABLE_DURATION_PARAMETER = "cacheableDuration";
+    static final String NAMESPACE_PARAMETER = "namespace";
+    static final String TRUST_STORE_PARAMETER = "trustStoreFile";
+    static final String KEY_STORE_PARAMETER = "keyStoreFile";
+    static final String KEY_STORE_PASSWORD_PARAMETER = "keyStorePassword";
+    static final String HTTPS_PARAMETER = "https";
+}

--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultLookupFunction.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultLookupFunction.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.mediation.security.vault.external.hashicorp;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.SynapseConstants;
+import org.jaxen.Context;
+import org.jaxen.Function;
+import org.jaxen.FunctionCallException;
+import org.jaxen.function.StringFunction;
+import org.wso2.carbon.mediation.security.vault.external.ExternalVaultLookupHandler;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implements the XPath extension function hashicorp:vault-lookup(alias).
+ */
+public class HashiCorpVaultLookupFunction implements Function {
+
+	private static final Log log = LogFactory.getLog(HashiCorpVaultLookupFunction.class);
+	private static final Log trace = LogFactory.getLog(SynapseConstants.TRACE_LOGGER);
+
+	private static final String NULL_STRING = "";
+
+	/** Synapse Message context */
+	private final org.apache.synapse.MessageContext synCtx;
+
+	public HashiCorpVaultLookupFunction(org.apache.synapse.MessageContext synCtx) {
+		this.synCtx = synCtx;
+	}
+
+	/**
+	 * Returns the string value of the property which is get from the
+	 * corresponding context to the provided scope.
+	 * vault-lookup('xxx')
+	 * 
+	 * @param context the context at the point in the expression when the function is called
+	 * @param args arguments of the functions
+	 * @return The string value of a property
+	 * @throws FunctionCallException throws FunctionCallException when error occurs
+	 */
+	@Override
+	public Object call(Context context, List args) throws FunctionCallException {
+
+		boolean traceOn = synCtx.getTracingState() == SynapseConstants.TRACING_ON;
+		boolean traceOrDebugOn = traceOn || log.isDebugEnabled();
+
+		if (args == null || args.isEmpty()) {
+			if (traceOrDebugOn) {
+				traceOrDebug(traceOn, "vault alias for lookup is not specified");
+			}
+			return NULL_STRING;
+		}
+
+		if (args.size() != 2 && args.size() != 3) {
+			if (traceOrDebugOn) {
+				traceOrDebug(traceOn, "vault path and field values for lookup is not specified");
+			}
+			return NULL_STRING;
+		}
+
+		// check the args list length and add to the map with keys
+		Map<String, String> vaultParameterMap = new HashMap<>();
+		if (args.size() == 3) {
+			vaultParameterMap.put(HashiCorpVaultConstant.VAULT_NAMESPACE_PARAMETER,
+					StringFunction.evaluate(args.get(0), context.getNavigator()));
+			vaultParameterMap.put(HashiCorpVaultConstant.PATH_PARAMETER,
+					StringFunction.evaluate(args.get(1), context.getNavigator()));
+			vaultParameterMap.put(HashiCorpVaultConstant.FIELD_PARAMETER,
+					StringFunction.evaluate(args.get(2), context.getNavigator()));
+		} else {
+			vaultParameterMap.put(HashiCorpVaultConstant.PATH_PARAMETER,
+					StringFunction.evaluate(args.get(0), context.getNavigator()));
+			vaultParameterMap.put(HashiCorpVaultConstant.FIELD_PARAMETER,
+					StringFunction.evaluate(args.get(1), context.getNavigator()));
+		}
+
+		try {
+			ExternalVaultLookupHandler mediationSecurity = HashiCorpVaultLookupHandlerImpl.getDefaultSecurityService();
+			return mediationSecurity.evaluate(vaultParameterMap, synCtx);
+		} catch (Exception msg) {
+			throw new FunctionCallException(msg);
+		}
+	}
+
+	private void traceOrDebug(boolean traceOn, String msg) {
+		if (traceOn) {
+			trace.info(msg);
+		}
+		if (log.isDebugEnabled()) {
+			log.debug(msg);
+		}
+	}
+}

--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultLookupHandlerImpl.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultLookupHandlerImpl.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.mediation.security.vault.external.hashicorp;
+
+import com.bettercloud.vault.SslConfig;
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.api.Logical;
+import com.bettercloud.vault.rest.RestException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.config.SynapseConfiguration;
+import org.wso2.carbon.mediation.security.vault.SecureVaultCacheContext;
+import org.wso2.carbon.mediation.security.vault.external.ExternalVaultConfigLoader;
+import org.wso2.carbon.mediation.security.vault.external.ExternalVaultException;
+import org.wso2.carbon.mediation.security.vault.external.ExternalVaultLookupHandler;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import java.io.File;
+import java.util.Calendar;
+import java.util.Map;
+
+/**
+ * Class responsible for the HashiCorp vault integration model.
+ */
+public class HashiCorpVaultLookupHandlerImpl implements ExternalVaultLookupHandler {
+
+	private static Log log = LogFactory.getLog(HashiCorpVaultLookupHandlerImpl.class);
+
+	private static HashiCorpVaultLookupHandlerImpl instance = null;
+	
+	private Object decryptLockObj = new Object();
+
+	private Vault vaultConnection;
+
+	private String cachableDuration = "15000";
+
+	private String engineVersion = "2";
+
+	private String vaultNamespace;
+
+	private HashiCorpVaultLookupHandlerImpl() throws ExternalVaultException {
+		try {
+			initialize();
+		} catch (ExternalVaultException e) {
+			throw new ExternalVaultException("Error while initializing the secure vault configs", e);
+		}
+	}
+
+	static HashiCorpVaultLookupHandlerImpl getDefaultSecurityService() throws ExternalVaultException {
+		if (instance == null) {
+			instance = new HashiCorpVaultLookupHandlerImpl();
+		}
+		return instance;
+	}
+
+	@Override
+	public String name() {
+		return "hashicorp";
+	}
+
+	/**
+	 * Check parameters and initialize the the connection with external HashiCorp vault.
+	 */
+	private void initialize() throws ExternalVaultException {
+		Map<String, String> parameters = ExternalVaultConfigLoader.getVaultParameters(name());
+		if (parameters == null || parameters.size() < 2) {
+			throw new ExternalVaultException("Required configurations of the " + name()
+					+ " secure vault can not found");
+		} else if (!parameters.containsKey(HashiCorpVaultConstant.ADDRESS_PARAMETER)) {
+			throw new ExternalVaultException(HashiCorpVaultConstant.ADDRESS_PARAMETER
+					+ " parameter can not found in " + name() + " secure vault configurations");
+		} else if (!parameters.containsKey(HashiCorpVaultConstant.TOKEN_PARAMETER)) {
+			throw new ExternalVaultException(HashiCorpVaultConstant.TOKEN_PARAMETER
+					+ " parameter can not found in " + name() + " secure vault configurations");
+		}
+
+		processHashiCorpParameters(parameters);
+
+		try {
+			vaultConnection = new Vault(createHashiCorpVaultConfig(parameters));
+		} catch (VaultException e) {
+			if (e.getCause() instanceof RestException) {
+				throw new ExternalVaultException("Error in connecting to HashiCorp vault. Vault address: "
+						+ parameters.get(HashiCorpVaultConstant.ADDRESS_PARAMETER), e);
+			} else {
+				throw new ExternalVaultException("Error while connecting the HashiCorp vault", e);
+			}
+		}
+	}
+
+	/**
+	 * Process parameters loaded from external-vault.xml file.
+	 *
+	 * @param parameters values loaded map.
+	 */
+	private void processHashiCorpParameters(Map<String, String> parameters) {
+		// set cacheable duration value if it defines in external-vaults configurations
+		if (parameters.containsKey(HashiCorpVaultConstant.CACHEABLE_DURATION_PARAMETER)
+				&& !parameters.get(HashiCorpVaultConstant.CACHEABLE_DURATION_PARAMETER).isEmpty()
+				&& parameters.get(HashiCorpVaultConstant.CACHEABLE_DURATION_PARAMETER)
+				.matches(HashiCorpVaultConstant.NUMBER_REGEX)) {
+			cachableDuration = parameters.get(HashiCorpVaultConstant.CACHEABLE_DURATION_PARAMETER);
+		}
+
+		// set engineVersion value if it defines in external-vaults configurations
+		if (parameters.containsKey(HashiCorpVaultConstant.ENGINE_TYPE_PARAMETER)
+				&& !parameters.get(HashiCorpVaultConstant.ENGINE_TYPE_PARAMETER).isEmpty()
+				&& parameters.get(HashiCorpVaultConstant.ENGINE_TYPE_PARAMETER)
+				.matches(HashiCorpVaultConstant.NUMBER_REGEX)) {
+			engineVersion = parameters.get(HashiCorpVaultConstant.ENGINE_TYPE_PARAMETER);
+		}
+
+		// set namespace value if it defines in external-vaults configurations
+		if (parameters.containsKey(HashiCorpVaultConstant.NAMESPACE_PARAMETER)
+				&& !parameters.get(HashiCorpVaultConstant.NAMESPACE_PARAMETER).isEmpty()) {
+			vaultNamespace = parameters.get(HashiCorpVaultConstant.NAMESPACE_PARAMETER);
+		}
+
+		// resolve ${carbon.home} variable when file paths are relative
+		if (parameters.containsKey(HashiCorpVaultConstant.TRUST_STORE_PARAMETER)) {
+			String trustStoreFilePath = parameters.get(HashiCorpVaultConstant.TRUST_STORE_PARAMETER);
+			if (trustStoreFilePath.startsWith(HashiCorpVaultConstant.CARBON_HOME_VARIABLE)) {
+				trustStoreFilePath = trustStoreFilePath.replace(HashiCorpVaultConstant.CARBON_HOME_VARIABLE,
+						CarbonUtils.getCarbonHome());
+				parameters.put(HashiCorpVaultConstant.TRUST_STORE_PARAMETER, trustStoreFilePath);
+			}
+		}
+
+		if (parameters.containsKey(HashiCorpVaultConstant.KEY_STORE_PARAMETER)) {
+			String keyStoreFilePath = parameters.get(HashiCorpVaultConstant.KEY_STORE_PARAMETER);
+			if (keyStoreFilePath.startsWith(HashiCorpVaultConstant.CARBON_HOME_VARIABLE)) {
+				keyStoreFilePath = keyStoreFilePath.replace(HashiCorpVaultConstant.CARBON_HOME_VARIABLE,
+						CarbonUtils.getCarbonHome());
+				parameters.put(HashiCorpVaultConstant.KEY_STORE_PARAMETER, keyStoreFilePath);
+			}
+		}
+	}
+
+	/**
+	 * Create HashiCorp vault configuration using the loaded parameters from external-vaults.
+	 *
+	 * @param parameters values loaded map.
+	 * @return vault configuration
+	 */
+	private VaultConfig createHashiCorpVaultConfig(Map<String, String> parameters)
+			throws VaultException, ExternalVaultException {
+		VaultConfig config = new VaultConfig().address(parameters.get(HashiCorpVaultConstant.ADDRESS_PARAMETER));
+
+		if (parameters.get(HashiCorpVaultConstant.ADDRESS_PARAMETER)
+				.startsWith(HashiCorpVaultConstant.HTTPS_PARAMETER)) {
+			//configure SSL configurations to connect with HTTPS
+			SslConfig sslConfig = new SslConfig();
+
+			if (!parameters.containsKey(HashiCorpVaultConstant.TRUST_STORE_PARAMETER)
+					&& !parameters.containsKey(HashiCorpVaultConstant.KEY_STORE_PARAMETER)) {
+				throw new ExternalVaultException(HashiCorpVaultConstant.TRUST_STORE_PARAMETER
+						+ " parameter or " + HashiCorpVaultConstant.TRUST_STORE_PARAMETER
+						+ "parameter can not found in " + name() + " secure vault configurations");
+			}
+
+			// add trust store file path to the VaultConfig if exists
+			if (parameters.containsKey(HashiCorpVaultConstant.TRUST_STORE_PARAMETER)) {
+				sslConfig = sslConfig.trustStoreFile(
+						new File(parameters.get(HashiCorpVaultConstant.TRUST_STORE_PARAMETER)));
+			}
+
+			// add key store file path and keystore password to the VaultConfig if exists
+			if (parameters.containsKey(HashiCorpVaultConstant.KEY_STORE_PARAMETER) &&
+					parameters.containsKey(HashiCorpVaultConstant.KEY_STORE_PASSWORD_PARAMETER)) {
+				sslConfig = sslConfig.keyStoreFile(
+						new File(parameters.get(HashiCorpVaultConstant.KEY_STORE_PARAMETER)),
+						parameters.get(HashiCorpVaultConstant.KEY_STORE_PASSWORD_PARAMETER));
+			} else if (parameters.containsKey(HashiCorpVaultConstant.KEY_STORE_PARAMETER) &&
+					!parameters.containsKey(HashiCorpVaultConstant.KEY_STORE_PASSWORD_PARAMETER)) {
+				throw new ExternalVaultException(HashiCorpVaultConstant.KEY_STORE_PASSWORD_PARAMETER
+						+ " parameter can not found in " + name() + " secure vault configurations");
+			} else if (!parameters.containsKey(HashiCorpVaultConstant.KEY_STORE_PARAMETER) &&
+					parameters.containsKey(HashiCorpVaultConstant.KEY_STORE_PASSWORD_PARAMETER)) {
+				throw new ExternalVaultException(HashiCorpVaultConstant.KEY_STORE_PARAMETER
+						+ " parameter can not found in " + name() + " secure vault configurations");
+			}
+
+			// add the sslConfig configuration to the VaultConfig if the protocol is HTTPS
+			config = config.sslConfig(sslConfig);
+		}
+		config = config.token(parameters.get(HashiCorpVaultConstant.TOKEN_PARAMETER))
+				.engineVersion(Integer.parseInt(engineVersion)).build();
+
+		return config;
+	}
+
+	@Override
+	public String evaluate(Map<String, String> vaultParameters, MessageContext synCtx) throws ExternalVaultException {
+		SynapseConfiguration synapseConfiguration = synCtx.getConfiguration();
+		Map<String, Object> decryptedCacheMap = synapseConfiguration.getDecryptedCacheMap();
+		String pathParameter = vaultParameters.get(HashiCorpVaultConstant.PATH_PARAMETER);
+		String fieldParameter = vaultParameters.get(HashiCorpVaultConstant.FIELD_PARAMETER);
+
+		// set aliasPassword value based on the namespace. Here namespace can be inject either as the first parameter
+		// of the vault-lookup function or the namespace parameter in the external-vault configurations
+		String aliasPassword = pathParameter + "-" + fieldParameter;
+		String namespaceForEvaluation = null;
+		if (vaultParameters.containsKey(HashiCorpVaultConstant.VAULT_NAMESPACE_PARAMETER)) {
+			aliasPassword = vaultParameters.get(HashiCorpVaultConstant.VAULT_NAMESPACE_PARAMETER) + "-" + aliasPassword;
+			namespaceForEvaluation = vaultParameters.get(HashiCorpVaultConstant.VAULT_NAMESPACE_PARAMETER);
+		} else if (vaultNamespace != null) {
+			aliasPassword = vaultNamespace + "-" + aliasPassword;
+			namespaceForEvaluation = vaultNamespace;
+		}
+
+
+		if (decryptedCacheMap.containsKey(aliasPassword)) {
+			SecureVaultCacheContext cacheContext =
+					(SecureVaultCacheContext) decryptedCacheMap.get(aliasPassword);
+			if (cacheContext != null) {
+				long cacheTime = Long.parseLong(cachableDuration);
+				if ((cacheContext.getDateTime().getTime() + cacheTime) >= System.currentTimeMillis()) {
+					// which means the given value between the cacheable limit
+					return cacheContext.getDecryptedValue();
+				} else {
+					decryptedCacheMap.remove(aliasPassword);
+					return vaultLookup(namespaceForEvaluation, pathParameter, fieldParameter, decryptedCacheMap);
+				}
+			} else {
+				return vaultLookup(namespaceForEvaluation, pathParameter, fieldParameter, decryptedCacheMap);
+			}
+		} else {
+			return vaultLookup(namespaceForEvaluation, pathParameter, fieldParameter, decryptedCacheMap);
+		}
+	}
+
+	/**
+	 * Resolves the secret by fetching that secret from HashiCorp vault if it does not exist in the cache.
+	 *
+	 * @param namespace namespace of the secret
+	 * @param pathParameter pathParameter of the secret
+	 * @param fieldParameter fieldParameter of the secret
+	 * @param decryptedCacheMap map which contains fetched secrets
+	 * @return resolved string
+	 * @throws ExternalVaultException when failed to resolve the text from the vault
+	 */
+	private String vaultLookup(String namespace, String pathParameter, String fieldParameter,
+							   Map<String, Object> decryptedCacheMap) throws ExternalVaultException {
+		String aliasPassword = pathParameter + "-" + fieldParameter;
+		synchronized (decryptLockObj) {
+			if (vaultConnection == null) {
+				initialize();
+			}
+
+			String decryptedValue;
+			try {
+				Logical logical = vaultConnection.logical();
+
+				if (namespace != null) {
+					logical = logical.withNameSpace(namespace);
+					aliasPassword = namespace + "-" + aliasPassword;
+				}
+
+				decryptedValue = logical.read(pathParameter).getData().get(fieldParameter);
+
+			} catch (VaultException e) {
+				throw new ExternalVaultException("Cannot read the vault secret from the HashiCorp vault. "
+						+ (namespace != null ? "Namespace: " + namespace + ", " : "")
+						+ "Path: " + pathParameter + ", Field: " + fieldParameter, e);
+			}
+
+			if (decryptedCacheMap == null || decryptedValue == null) {
+				log.warn("Cannot find a vault secret from the HashiCorp vault for, "
+						+ (namespace != null ? "Namespace: " + namespace + ", " : "")
+						+ "Path: " + pathParameter + ", Field: " + fieldParameter);
+				return null;
+			}
+
+			if (decryptedValue.isEmpty()) {
+				SecureVaultCacheContext cacheContext =
+						(SecureVaultCacheContext) decryptedCacheMap.get(aliasPassword);
+				if (cacheContext != null) {
+					return cacheContext.getDecryptedValue();
+				}
+			}
+
+			decryptedCacheMap.put(aliasPassword,
+					new SecureVaultCacheContext(Calendar.getInstance().getTime(), decryptedValue));
+			return decryptedValue;
+		}
+	}
+}

--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultLookupXPathFunctionProvider.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultLookupXPathFunctionProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.mediation.security.vault.external.hashicorp;
+
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.util.xpath.ext.SynapseXpathFunctionContextProvider;
+import org.jaxen.Function;
+
+import javax.xml.namespace.QName;
+
+public class HashiCorpVaultLookupXPathFunctionProvider implements SynapseXpathFunctionContextProvider {
+
+	private static final String NAME_SPACE_PREFIX = "hashicorp";
+	private static final String VAULT_LOOKUP = "vault-lookup";
+
+	public Function getInitializedExtFunction(MessageContext messageContext) {
+		HashiCorpVaultLookupFunction resolver = new HashiCorpVaultLookupFunction(messageContext);
+		return resolver;
+	}
+
+	public QName getResolvingQName() {
+		return new QName(null, VAULT_LOOKUP, NAME_SPACE_PREFIX);
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2419,6 +2419,11 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.bettercloud</groupId>
+                <artifactId>vault-java-driver</artifactId>
+                <version>${hashicorp.vault.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <properties>
@@ -2494,6 +2499,7 @@
         <wsdl4j.wso2.version>1.6.2.wso2v4</wsdl4j.wso2.version>
         <ca.uhn.hapi.wso2.version>2.1.0.wso2v1</ca.uhn.hapi.wso2.version>
         <org.wso2.securevault.version>1.1.3</org.wso2.securevault.version>
+        <hashicorp.vault.version>5.1.0</hashicorp.vault.version>
         <jsch.wso2.version>0.1.54.wso2v1</jsch.wso2.version>
         <commons.net.wso2.version>3.4.wso2v1</commons.net.wso2.version>
         <jcifs.wso2.version>1.3.17.wso2v1</jcifs.wso2.version>


### PR DESCRIPTION
$subject.

This PR introduces feature integrating HashiCorp secure vault to the WSO2 EI. From this feature, we can fetch secrets from the HashiCorp vault by extending the existing vault-lookup function in the runtime as follows.
```
<property name="HashiCorpSecret" expression="hashicorp:vault-lookup('path-to-secret', 'secret-key')" />
```
Also, If HashiCorp secrets are saved under a specific namespace, we can extend the above expression as follows,
```
<property name="HashiCorpSecret" expression="hashicorp:vault-lookup('namespace', 'path-to-secret', 'secret-key')" />
```
Here, the namespace is an optional parameter.


Related issue: https://github.com/wso2/product-ei/issues/5214