### PR TITLE
Fix https://github.com/wso2/product-ei/issues/5256

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultLookupXPathFunctionProvider.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultLookupXPathFunctionProvider.java
@@ -33,7 +33,7 @@ public class HashiCorpVaultLookupXPathFunctionProvider implements SynapseXpathFu
 		return resolver;
 	}
 
-	public QName getResolvingQName() {
-		return new QName(null, VAULT_LOOKUP, NAME_SPACE_PREFIX);
+	public String getResolvingQName() {
+		return NAME_SPACE_PREFIX + VAULT_LOOKUP;
 	}
 }

--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/xpath/SecureVaultLookupXPathFunctionProvider.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/xpath/SecureVaultLookupXPathFunctionProvider.java
@@ -33,7 +33,7 @@ public class SecureVaultLookupXPathFunctionProvider implements SynapseXpathFunct
 		return resolver;
 	}
 
-	public QName getResolvingQName() {
-		return new QName(null, VAULT_LOOKUP, NAME_SPACE_PREFIX);
+	public String getResolvingQName() {
+		return NAME_SPACE_PREFIX + VAULT_LOOKUP;
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2456,7 +2456,7 @@
         <carbon.rule.version>4.5.6</carbon.rule.version>
         <carbon.rule.imp.pkg.version>[4.5.0, 4.6.0)</carbon.rule.imp.pkg.version>
         <!-- Synapse Version -->
-        <synapse.version>2.1.7-wso2v183</synapse.version>
+        <synapse.version>2.1.7-wso2v185</synapse.version>
         <carbon.identity.entitlement.proxy.version>5.3.4</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.2.0, 6.0.0)
         </carbon.identity.entitlement.proxy.imp.pkg.version>


### PR DESCRIPTION
## Purpose
This issue happens since function providers are registered with Qnames
and since Qnames do not consider prefix in equals or hashcode functions
the HashiCorp and SecVault function provides were registered under the
same Qname. So change function provider registration to avoid this.

Fixes: https://github.com/wso2/product-ei/issues/5256
