### PR TITLE
Set missing JMS properties into transport headers of Inbound Endpoints

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
@@ -202,7 +202,23 @@ public class JMSConstants {
      * A MessageContext property or client Option indicating the JMS timestamp (Long specified as String)
      */
     public static final String JMS_TIMESTAMP = "JMS_TIMESTAMP";
-    
+    /**
+     * A MessageContext property or client Option indicating the JMS delivery time (long specified as String)
+     */
+    public static final String JMS_DELIVERY_TIME = "JMS_DELIVERY_TIME";
+    /**
+     * A MessageContext property or client Option indicating the JMS message redelivered (boolean specified as String)
+     */
+    public static final String JMS_REDELIVERED = "JMS_REDELIVERED";
+    /**
+     * A MessageContext property or client Option indicating the JMS message destination
+     */
+    public static final String JMS_DESTINATION = "JMS_DESTINATION";
+    /**
+     * A MessageContext property or client Option indicating the JMS message reply to destination
+     */
+    public static final String JMS_REPLY_TO_DESTINATION = "JMS_REPLY_TO_DESTINATION";
+
     /**
      * Does the JMS broker support hyphen in JMS message property names.
      */

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
@@ -127,6 +127,17 @@ public class JMSInjectHandler {
             //setting transport headers
             Map<String, Object> transportHeaders = JMSUtils.getTransportHeaders(msg, axis2MsgCtx);
             transportHeaders.put(JMSConstants.JMS_TIMESTAMP, msg.getJMSTimestamp());
+            transportHeaders.put(JMSConstants.JMS_MESSAGE_ID, msg.getJMSMessageID());
+            transportHeaders.put(JMSConstants.JMS_PRIORITY, msg.getJMSPriority());
+            transportHeaders.put(JMSConstants.JMS_EXPIRATION, msg.getJMSExpiration());
+            transportHeaders.put(JMSConstants.JMS_DELIVERY_MODE, msg.getJMSDeliveryMode());
+            transportHeaders.put(JMSConstants.JMS_DELIVERY_TIME, msg.getJMSDeliveryTime());
+            transportHeaders.put(JMSConstants.JMS_REDELIVERED, msg.getJMSRedelivered());
+            transportHeaders.put(JMSConstants.JMS_DESTINATION, msg.getJMSDestination());
+            transportHeaders.put(JMSConstants.JMS_REPLY_TO_DESTINATION, msg.getJMSReplyTo());
+            transportHeaders.put(JMSConstants.JMS_MESSAGE_TYPE, msg.getJMSType());
+            transportHeaders.put(JMSConstants.JMS_COORELATION_ID, msg.getJMSCorrelationID());
+
             axis2MsgCtx.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS
                     , transportHeaders);
             // set the JMS Message ID as the Message ID of the MessageContext


### PR DESCRIPTION
This PR adds the following JMS properties into transport headers of Inbound Endpoints

- JMS_MESSAGE_ID
- JMS_PRIORITY
- JMS_EXPIRATION
- JMS_DELIVERY_MODE
- JMS_DELIVERY_TIME
- JMS_REDELIVERED
- JMS_DESTINATION
- JMS_REPLY_TO_DESTINATION
- JMS_MESSAGE_TYPE
- JMS_COORELATION_ID

Fixes https://github.com/wso2/product-ei/issues/5304