### PR TITLE
Update PR:https://github.com/wso2/carbon-mediation/pull/1471

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
@@ -210,14 +210,6 @@ public class JMSConstants {
      * A MessageContext property or client Option indicating the JMS message redelivered (boolean specified as String)
      */
     public static final String JMS_REDELIVERED = "JMS_REDELIVERED";
-    /**
-     * A MessageContext property or client Option indicating the JMS message destination
-     */
-    public static final String JMS_DESTINATION = "JMS_DESTINATION";
-    /**
-     * A MessageContext property or client Option indicating the JMS message reply to destination
-     */
-    public static final String JMS_REPLY_TO_DESTINATION = "JMS_REPLY_TO_DESTINATION";
 
     /**
      * Does the JMS broker support hyphen in JMS message property names.

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
@@ -133,8 +133,6 @@ public class JMSInjectHandler {
             transportHeaders.put(JMSConstants.JMS_DELIVERY_MODE, msg.getJMSDeliveryMode());
             transportHeaders.put(JMSConstants.JMS_DELIVERY_TIME, msg.getJMSDeliveryTime());
             transportHeaders.put(JMSConstants.JMS_REDELIVERED, msg.getJMSRedelivered());
-            transportHeaders.put(JMSConstants.JMS_DESTINATION, msg.getJMSDestination());
-            transportHeaders.put(JMSConstants.JMS_REPLY_TO_DESTINATION, msg.getJMSReplyTo());
             transportHeaders.put(JMSConstants.JMS_MESSAGE_TYPE, msg.getJMSType());
             transportHeaders.put(JMSConstants.JMS_COORELATION_ID, msg.getJMSCorrelationID());
 


### PR DESCRIPTION
## Purpose
Remove JMS_DESTINATION and JMS_REPLY_TO_DESTINATION properties as there's no requirement to have them in the transport headers of the Inbound endpoint.