### PR TITLE
Fix OOM issue due to multiple SynapseConfiguration instances created for a single tenant

### DIFF
--- a/components/mediation-initializer/org.wso2.carbon.mediation.initializer/src/main/java/org/wso2/carbon/mediation/initializer/utils/ConfigurationHolder.java
+++ b/components/mediation-initializer/org.wso2.carbon.mediation.initializer/src/main/java/org/wso2/carbon/mediation/initializer/utils/ConfigurationHolder.java
@@ -19,6 +19,7 @@
 
 package org.wso2.carbon.mediation.initializer.utils;
 
+import org.apache.synapse.config.SynapseConfiguration;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
@@ -31,7 +32,9 @@ public class ConfigurationHolder {
     private BundleContext bundleContext;
 
     private Map<Integer, ServiceRegistration> synapseRegistrations =
-            new HashMap<Integer, ServiceRegistration>(); 
+            new HashMap<Integer, ServiceRegistration>();
+
+    private Map<Integer, SynapseConfiguration> synapseConfigurationHashMap = new HashMap<>();
 
     public static ConfigurationHolder getInstance() {
         return ourInstance;
@@ -54,5 +57,13 @@ public class ConfigurationHolder {
 
     public ServiceRegistration getSynapseRegistration(int tenantId) {
         return synapseRegistrations.get(tenantId);
+    }
+
+    public SynapseConfiguration getSynapseConfiguration(int tenantId) {
+        return synapseConfigurationHashMap.get(tenantId);
+    }
+
+    public void addSynapseConfiguration(int tenanId, SynapseConfiguration synapseConfiguration) {
+        synapseConfigurationHashMap.put(tenanId, synapseConfiguration);
     }
 }


### PR DESCRIPTION
Whenever the lazy loading happens for a tenant, a new SynapseConfiguration object will be created. But, the older SynapseConfiguration reference that was created for a particular tenant is not getting cleaned. Hence, there can be an OOM issue after sometimes when there are multiple accumulated SynapseConfiguration instances in the memory.

To overcome the OOM issue, here, the localRegistry map in the older instance, which can bear the biggest object in the SynapseConfiguration instance is cleaned upon a new SynapseConfiguration is created. But, the original issue of cleaning out the older SynapseConfiguration instances is not addressed in this PR.

Fixes wso2/product-ei#5312