### PR TITLE
Fix passthrough threads being stuck in an infinite while loop

### DIFF
--- a/components/mediators/fastXSLT/org.wso2.carbon.mediator.fastXSLT/src/main/java/org/wso2/carbon/mediator/fastXSLT/FastXSLTMediator.java
+++ b/components/mediators/fastXSLT/org.wso2.carbon.mediator.fastXSLT/src/main/java/org/wso2/carbon/mediator/fastXSLT/FastXSLTMediator.java
@@ -214,11 +214,10 @@ public class FastXSLTMediator extends AbstractMediator implements ManagedLifecyc
                     fullLenthDone = true;
                 }
 
-                if (!fullLenthDone && Boolean.TRUE.equals(axis2MC.getProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED))) {
+                if (!fullLenthDone && (!Boolean.TRUE.equals(axis2MC.getProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED)))) {
                     RelayUtils.buildMessage(axis2MC, false, bufferedStream);
                 } else if (!fullLenthDone) {
                     IOUtils.write(_transformedOutMessage.toByteArray(), msgContextOutStream);
-                    pipe.setRawSerializationComplete(true);
 
                 }
             } else {


### PR DESCRIPTION
When the fastXSLT mediator is used, there can be a situation where the below thread is stuck in an infinite loop because the flush content method returns immediately when the rawSerializationComplete is true [1].

```
"PassThroughMessageProcessor-71" #538 prio=5 os_prio=0 tid=0x00007f9d0c166000 nid=0x49e1 runnable [0x00007f9cf5099000]
   java.lang.Thread.State: RUNNABLE
	at org.apache.synapse.transport.passthru.Pipe$ByteBufferOutputStream.write(Pipe.java:572)
	at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221)
	at sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:282)
	at sun.nio.cs.StreamEncoder.write(StreamEncoder.java:125)
	- locked <0x0000000089212918> (a java.io.OutputStreamWriter)
	at sun.nio.cs.StreamEncoder.write(StreamEncoder.java:135)
	at java.io.OutputStreamWriter.write(OutputStreamWriter.java:220)
	at java.io.Writer.write(Writer.java:157)
	at org.apache.synapse.commons.staxon.core.json.stream.impl.JsonStreamTargetImpl.value(JsonStreamTargetImpl.java:174)
	at org.apache.synapse.commons.staxon.core.json.stream.util.AutoArrayTarget$ValueEvent.write(AutoArrayTarget.java:155)
	at org.apache.synapse.commons.staxon.core.json.stream.util.AutoArrayTarget.endObject(AutoArrayTarget.java:230)
	at org.apache.synapse.commons.staxon.core.json.stream.util.StreamTargetDelegate.endObject(StreamTargetDelegate.java:62)
	at org.apache.synapse.commons.staxon.core.json.JsonXMLStreamWriter.writeEndDocument(JsonXMLStreamWriter.java:351)
	at org.apache.synapse.commons.staxon.core.event.SimpleXMLEventWriter.add(SimpleXMLEventWriter.java:57)
	at org.apache.synapse.commons.staxon.core.event.SimpleXMLEventWriter.add(SimpleXMLEventWriter.java:119)
	at org.apache.synapse.commons.json.JsonUtil.convertOMElementToJson(JsonUtil.java:566)
	at org.apache.synapse.commons.json.JsonUtil.writeAsJson(JsonUtil.java:526)
	at org.apache.synapse.commons.json.JsonUtil.writeAsJson(JsonUtil.java:397)
	at org.apache.synapse.commons.json.JsonStreamFormatter.writeTo(JsonStreamFormatter.java:77)
	at sun.reflect.GeneratedMethodAccessor138.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.wso2.carbon.integrator.core.json.JsonStreamFormatter.writeTo(JsonStreamFormatter.java:109)
	at org.apache.synapse.transport.passthru.PassThroughHttpSender.submitResponse(PassThroughHttpSender.java:626)
	at org.apache.synapse.transport.passthru.PassThroughHttpSender.invoke(PassThroughHttpSender.java:285)
	at org.apache.axis2.engine.AxisEngine.send(AxisEngine.java:442)
	at org.apache.synapse.core.axis2.Axis2Sender.sendBack(Axis2Sender.java:220)
	at org.apache.synapse.mediators.builtin.RespondMediator.mediate(RespondMediator.java:46)
	at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:109)
	at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:71)
	at org.apache.synapse.config.xml.AnonymousListMediator.mediate(AnonymousListMediator.java:37)
	at org.apache.synapse.config.xml.SwitchCase.mediate(SwitchCase.java:69)
	at org.apache.synapse.mediators.filters.SwitchMediator.mediate(SwitchMediator.java:134)
	at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:109)
	at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:71)
	at org.apache.synapse.config.xml.AnonymousListMediator.mediate(AnonymousListMediator.java:37)
	at org.apache.synapse.mediators.filters.FilterMediator.mediate(FilterMediator.java:205)
	at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:109)
	at org.apache.synapse.mediators.filters.FilterMediator.mediate(FilterMediator.java:252)
	at org.apache.synapse.mediators.base.SequenceMediator.mediate(SequenceMediator.java:267)
	at org.apache.synapse.core.axis2.Axis2SynapseEnvironment.mediateFromContinuationStateStack(Axis2SynapseEnvironment.java:807)
	at org.apache.synapse.core.axis2.Axis2SynapseEnvironment.injectMessage(Axis2SynapseEnvironment.java:305)
	at org.apache.synapse.core.axis2.SynapseCallbackReceiver.handleMessage(SynapseCallbackReceiver.java:579)
	at org.apache.synapse.core.axis2.SynapseCallbackReceiver.receive(SynapseCallbackReceiver.java:196)
	at org.apache.axis2.engine.AxisEngine.receive(AxisEngine.java:180)
	at org.apache.synapse.transport.passthru.ClientWorker.run(ClientWorker.java:285)
	at org.apache.axis2.transport.base.threads.NativeWorkerPool$1.run(NativeWorkerPool.java:172)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

This PR fixes the following:
- Stop building the messages if 'message.builder.invoked' is already true
- Fix passthrough threads being stuck in an infinite while loop

[1] - https://github.com/wso2/carbon-mediation/blob/b639ef89379707b5b3a4eca676c820ad707db43f/components/mediators/fastXSLT/org.wso2.carbon.mediator.fastXSLT/src/main/java/org/wso2/carbon/mediator/fastXSLT/FastXSLTMediator.java#L221
