### PR TITLE
Add headersToIncludeInHash attribute to cache mediator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ target
 *.ipr
 .idea
 components/business-adaptors/sap/lib
+
+# Ignore OS specific files
+.DS_Store

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/java/org/wso2/carbon/mediator/cache/ui/CacheMediator.java
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/java/org/wso2/carbon/mediator/cache/ui/CacheMediator.java
@@ -94,6 +94,14 @@ public class CacheMediator extends AbstractListMediator {
      */
     private static final QName HEADERS_TO_EXCLUDE_IN_HASH_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE,
                                                                         CachingConstants.HEADERS_TO_EXCLUDE_STRING);
+
+    /**
+     * QName of the headersToIncludeInHash.
+     */
+    private static final QName HEADERS_TO_INCLUDE_IN_HASH_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE,
+            CachingConstants.HEADERS_TO_INCLUDE_STRING);
+
+
     /**
      * QName of the response codes to include when hashing.
      */
@@ -157,6 +165,11 @@ public class CacheMediator extends AbstractListMediator {
      * The headers to exclude when caching.
      */
     private String headersToExcludeInHash = "";
+
+    /**
+     * The headers to include when caching.
+     */
+    private String headersToIncludeInHash = "";
 
     /**
      * The protocol type used in caching.
@@ -368,6 +381,24 @@ public class CacheMediator extends AbstractListMediator {
     }
 
     /**
+     * This method gives array of headers that would be included when hashing.
+     *
+     * @return array of headers to include in hashing
+     */
+    public String getHeadersToIncludeInHash() {
+        return headersToIncludeInHash;
+    }
+
+    /**
+     * This method sets the array of headers that would be included when hashing.
+     *
+     * @param headersToIncludeInHash array of headers to include in hashing.
+     */
+    public void setHeadersToIncludeInHash(String headersToIncludeInHash) {
+        this.headersToIncludeInHash = headersToIncludeInHash;
+    }
+
+    /**
      * This method returns whether cache-control headers need to be honored when caching.
      *
      * @return cacheControlEnabled whether enable cache control or not.
@@ -449,6 +480,12 @@ public class CacheMediator extends AbstractListMediator {
                 if (headersToExcludeInHash != null) {
                     OMElement headerElem = fac.createOMElement(CachingConstants.HEADERS_TO_EXCLUDE_STRING, synNS);
                     headerElem.setText(headersToExcludeInHash);
+                    protocolElem.addChild(headerElem);
+                }
+
+                if (headersToIncludeInHash != null) {
+                    OMElement headerElem = fac.createOMElement(CachingConstants.HEADERS_TO_INCLUDE_STRING, synNS);
+                    headerElem.setText(headersToIncludeInHash);
                     protocolElem.addChild(headerElem);
                 }
 
@@ -534,6 +571,11 @@ public class CacheMediator extends AbstractListMediator {
                                 HEADERS_TO_EXCLUDE_IN_HASH_Q);
                         if (headersToExclude != null) {
                             headersToExcludeInHash = headersToExclude.getText();
+                        }
+                        OMElement headersToInclude = protocolElem.getFirstChildWithName(
+                                HEADERS_TO_INCLUDE_IN_HASH_Q);
+                        if (headersToInclude != null) {
+                            headersToIncludeInHash = headersToInclude.getText();
                         }
                         OMElement enableCacheControlElem = protocolElem.getFirstChildWithName(ENABLE_CACHE_CONTROL_Q);
                         if (enableCacheControlElem != null) {

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/resources/org/wso2/carbon/mediator/cache/ui/i18n/Resources.properties
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/resources/org/wso2/carbon/mediator/cache/ui/i18n/Resources.properties
@@ -14,6 +14,7 @@ mediator.cache.protocoldetails=Protocol Details
 mediator.cache.protocol=Protocol Type
 mediator.cache.httpmethods=HTTP Methods To Cache (comma separated list)
 mediator.cache.headersToExclude=Headers To Exclude In Hash (comma separated list)
+mediator.cache.headersToInclude=Headers To Include In Hash (comma separated list)
 mediator.cache.responsecodes=Response Codes (regex expression)
 mediator.cache.cacheControlEnabled=Enable Cache Control Headers
 mediator.cache.includeAgeHeader=Include Age Header

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/resources/web/cache-mediator/edit-mediator.jsp
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/resources/web/cache-mediator/edit-mediator.jsp
@@ -151,6 +151,18 @@
                                 <td><input type="text" name="headersToExclude" value="" size="40" /></td>
                             </tr>
                             <%}%>
+                            <%if (cacheMediator.getHeadersToIncludeInHash() != null) {%>
+                            <tr>
+                                <td><fmt:message key="mediator.cache.headersToInclude" /></td>
+                                <td><input type="text" name="headersToExclude"
+                                           value="<%=cacheMediator.getHeadersToIncludeInHash()%>" size="40" /></td>
+                            </tr>
+                            <%} else {%>
+                            <tr>
+                                <td><fmt:message key="mediator.cache.headersToInclude" /></td>
+                                <td><input type="text" name="headersToExclude" value="" size="40" /></td>
+                            </tr>
+                            <%}%>
                             <%if (cacheMediator.getResponseCodes() != null) {%>
                             <tr>
                                 <td><fmt:message key="mediator.cache.responsecodes" /></td>

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/resources/web/cache-mediator/update-mediator.jsp
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.cache.ui/src/main/resources/web/cache-mediator/update-mediator.jsp
@@ -41,6 +41,7 @@
     String maxMsgSize = request.getParameter("maxMsgSize").trim();
     String methods = request.getParameter("methods");
     String headersToExclude = request.getParameter("headersToExclude");
+    String headersToInclude = request.getParameter("headersToInclude");
     String responseCodes = request.getParameter("responseCodes");
     String hashGen = request.getParameter("hashGen");
     String maxSize = request.getParameter("maxSize").trim();
@@ -92,6 +93,12 @@
         cacheMediator.setHeadersToExcludeInHash(headersToExclude);
     } else {
         cacheMediator.setHeadersToExcludeInHash("");
+    }
+    
+    if (notNullChecker(headersToInclude)) {
+        cacheMediator.setHeadersToIncludeInHash(headersToInclude);
+    } else {
+        cacheMediator.setHeadersToIncludeInHash("");
     }
 
     if (notNullChecker(responseCodes)) {

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
@@ -111,6 +111,11 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
     private String[] headersToExcludeInHash = {""};
 
     /**
+     * The headers to include when caching.
+     */
+    private String[] headersToIncludeInHash = {""};
+
+    /**
      * This is used to define the logic used by the mediator to evaluate the hash values of incoming messages.
      */
     private DigestGenerator digestGenerator = CachingConstants.DEFAULT_HASH_GENERATOR;
@@ -712,6 +717,24 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
      */
     public void setHeadersToExcludeInHash(String... headersToExcludeInHash) {
         this.headersToExcludeInHash = headersToExcludeInHash;
+    }
+
+    /**
+     * This method gives array of headers that would be included when hashing.
+     *
+     * @return array of headers to included in hashing
+     */
+    public String[] getHeadersToIncludeInHash() {
+        return headersToIncludeInHash;
+    }
+
+    /**
+     * This method sets the array of headers that would be included when hashing.
+     *
+     * @param headersToIncludeInHash array of headers to include in hashing.
+     */
+    public void setHeadersToIncludeInHash(String... headersToIncludeInHash) {
+        this.headersToIncludeInHash = headersToIncludeInHash;
     }
 
     /**

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediatorFactory.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediatorFactory.java
@@ -84,6 +84,14 @@ public class CacheMediatorFactory extends AbstractMediatorFactory {
      */
     private static final QName HEADERS_TO_EXCLUDE_IN_HASH_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE,
                                                                         CachingConstants.HEADERS_TO_EXCLUDE_STRING);
+
+    /**
+     * QName of the headersToIncludeInHash.
+     */
+    private static final QName HEADERS_TO_INCLUDE_IN_HASH_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE,
+            CachingConstants.HEADERS_TO_INCLUDE_STRING);
+
+
     /**
      * QName of the response codes to include when hashing.
      */
@@ -229,6 +237,18 @@ public class CacheMediatorFactory extends AbstractMediatorFactory {
                                 cache.setHTTPMethodsToCache(CachingConstants.ALL);
                             }
 
+                            OMElement headersToIncludeInHash = protocolElem.getFirstChildWithName(
+                                    HEADERS_TO_INCLUDE_IN_HASH_Q);
+                            if (headersToIncludeInHash != null) {
+                                String[] headers = headersToIncludeInHash.getText().split(",");
+                                for (int i = 0; i < headers.length; i++) {
+                                    headers[i] = headers[i].trim();
+                                }
+                                cache.setHeadersToIncludeInHash(headers);
+                            } else {
+                                cache.setHeadersToIncludeInHash("");
+                            }
+
                             OMElement headersToExcludeInHash = protocolElem.getFirstChildWithName(
                                     HEADERS_TO_EXCLUDE_IN_HASH_Q);
                             if (headersToExcludeInHash != null) {
@@ -273,7 +293,8 @@ public class CacheMediatorFactory extends AbstractMediatorFactory {
                                 cache.setCacheControlEnabled(CachingConstants.DEFAULT_ADD_AGE_HEADER);
                             }
 
-                            props.put("headers-to-exclude", cache.getHeadersToExcludeInHash());
+                            props.put(CachingConstants.INCLUDED_HEADERS_PROPERTY, cache.getHeadersToIncludeInHash());
+                            props.put(CachingConstants.EXCLUDED_HEADERS_PROPERTY, cache.getHeadersToExcludeInHash());
                         }
                     } else {
                         cache.setProtocolType(CachingConstants.HTTP_PROTOCOL_TYPE);

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediatorSerializer.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediatorSerializer.java
@@ -113,17 +113,34 @@ public class CacheMediatorSerializer extends AbstractMediatorSerializer {
                         protocolElem.addChild(methodElem);
                     }
 
-                    String[] headers = cacheMediator.getHeadersToExcludeInHash();
-                    if (!(headers.length == 0 && headers[0].isEmpty())) {
+                    // Add exclude headers to the OM element
+                    String[] excludeHeaders = cacheMediator.getHeadersToExcludeInHash();
+                    if (!(excludeHeaders.length == 0 && excludeHeaders[0].isEmpty())) {
                         StringBuilder header = new StringBuilder();
-                        for (int i = 0; i < headers.length; i++) {
-                            if (i != headers.length - 1) {
-                                header.append(headers[i]).append(", ");
+                        for (int i = 0; i < excludeHeaders.length; i++) {
+                            if (i != excludeHeaders.length - 1) {
+                                header.append(excludeHeaders[i]).append(", ");
                             } else {
-                                header.append(headers[i]);
+                                header.append(excludeHeaders[i]);
                             }
                         }
                         OMElement headerElem = fac.createOMElement(CachingConstants.HEADERS_TO_EXCLUDE_STRING, synNS);
+                        headerElem.setText(header.toString());
+                        protocolElem.addChild(headerElem);
+                    }
+
+                    // Add include headers to the OM element
+                    String[] includeHeaders = cacheMediator.getHeadersToIncludeInHash();
+                    if (!(includeHeaders.length == 0 && includeHeaders[0].isEmpty())) {
+                        StringBuilder header = new StringBuilder();
+                        for (int i = 0; i < includeHeaders.length; i++) {
+                            if (i != includeHeaders.length - 1) {
+                                header.append(includeHeaders[i]).append(", ");
+                            } else {
+                                header.append(includeHeaders[i]);
+                            }
+                        }
+                        OMElement headerElem = fac.createOMElement(CachingConstants.HEADERS_TO_INCLUDE_STRING, synNS);
                         headerElem.setText(header.toString());
                         protocolElem.addChild(headerElem);
                     }

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CachingConstants.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CachingConstants.java
@@ -111,6 +111,7 @@ public class CachingConstants {
     public static final String PROTOCOL_STRING = "protocol";
     public static final String METHODS_STRING = "methods";
     public static final String HEADERS_TO_EXCLUDE_STRING = "headersToExcludeInHash";
+    public static final String HEADERS_TO_INCLUDE_STRING = "headersToIncludeInHash";
     public static final String TYPE_STRING = "type";
     public static final String RESPONSE_CODES_STRING = "responseCodes";
     public static final String HASH_GENERATOR_STRING = "hashGenerator";
@@ -126,4 +127,6 @@ public class CachingConstants {
     public static final String ID_STRING = "id";
     public static final String SCOPE_STRING = "scope";
     public static final String PERMANENTLY_EXCLUDED_HEADERS_STRING = "permanently-excluded-headers";
+    public static final String EXCLUDED_HEADERS_PROPERTY = "headers-to-exclude";
+    public static final String INCLUDED_HEADERS_PROPERTY = "headers-to-include";
 }

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/digest/HttpRequestHashGenerator.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/digest/HttpRequestHashGenerator.java
@@ -37,6 +37,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.SortedMap;
@@ -68,84 +69,58 @@ public class HttpRequestHashGenerator implements DigestGenerator {
 
     String[] permanentlyExcludedHeaders = {};
 
+    boolean isIncludeHeadersMode = true;
+
     /**
      * {@inheritDoc}
      */
     public String getDigest(MessageContext msgContext) throws CachingException {
-        boolean excludeAllHeaders = EXCLUDE_ALL_VAL.equals(headers[0]);
+        boolean allHeaders = EXCLUDE_ALL_VAL.equals(headers[0]);
         String method = (String) msgContext.getProperty(Constants.Configuration.HTTP_METHOD);
         boolean isGet = msgContext.isDoingREST() && (PassThroughConstants.HTTP_GET.equals(method) ||
                 PassThroughConstants.HTTP_DELETE.equals(method) ||
                 PassThroughConstants.HTTP_HEAD.equals(method));
-        //If some or all headers need to be included in the hash
-        if (!excludeAllHeaders) {
-            //cloning transport headers from message context and making them case insensitive
-            Map<String, String> transportHeaders =
-                    new TreeMap<String, String>(new Comparator<String>() {
-                        public int compare(String o1, String o2) {
-                            return o1.compareToIgnoreCase(o2);
-                        }
-                    });
-            transportHeaders.putAll((Map<String, String>)msgContext.getProperty(MessageContext.TRANSPORT_HEADERS));
-            for (String header : headers) {
-                transportHeaders.remove(header);
-            }
 
-            //remove permanently excluded headers from hashing methods
-            for (String header : permanentlyExcludedHeaders) {
-                transportHeaders.remove(header);
+        if (isIncludeHeadersMode) {
+            // This is header inclusion mode
+            Map<String, String> transportHeaders = getTransportHeaders(msgContext);
+            if (!allHeaders) {
+                // remove headers except the provided ones
+                Map<String, String> tmpHeaders = new HashMap<>();
+                for (String header: headers) {
+                    tmpHeaders.put(header, transportHeaders.get(header));
+                }
+                transportHeaders.clear();
+                transportHeaders.putAll(tmpHeaders);
             }
-
-            //If the HTTP method is GET do not hash the payload. Hash only url and headers.
             if (isGet) {
-                if (msgContext.getTo() == null) {
-                    return null;
-                }
-                String toAddress = msgContext.getTo().getAddress();
-                byte[] digest = getDigest(toAddress, transportHeaders, MD5_DIGEST_ALGORITHM);
-                return digest != null ? getStringRepresentation(digest) : null;
-            } else { //If the HTTP method is POST hash the payload along with the url and the headers
-                OMNode body = msgContext.getEnvelope().getBody();
-                String toAddress = null;
-                if (msgContext.getTo() != null) {
-                    toAddress = msgContext.getTo().getAddress();
-                }
-                if (body != null) {
-                    byte[] digest;
-                    if (toAddress != null) {
-                        digest = getDigest(body, toAddress, transportHeaders, MD5_DIGEST_ALGORITHM);
-                    } else {
-                        digest = getDigest(body, MD5_DIGEST_ALGORITHM);
-                    }
-                    return digest != null ? getStringRepresentation(digest) : null;
-                } else {
-                    return null;
-                }
-            }
-        } else { //Do not hash the headers
-            if (isGet) {
-                if (msgContext.getTo() == null) {
-                    return null;
-                }
-                String toAddress = msgContext.getTo().getAddress();
-                byte[] digest = getDigest(toAddress, MD5_DIGEST_ALGORITHM);
-                return digest != null ? getStringRepresentation(digest) : null;
+                //If the HTTP method is GET do not hash the payload. Hash only url and headers.
+                return handleGetWithHeaders(msgContext, transportHeaders);
             } else {
-                OMNode body = msgContext.getEnvelope().getBody();
-                String toAddress = null;
-                if (msgContext.getTo() != null) {
-                    toAddress = msgContext.getTo().getAddress();
+                //If the HTTP method is POST hash the payload along with the url and the headers
+                return handlePostWithHeaders(msgContext, transportHeaders);
+            }
+        } else {
+            // This is header exclusion mode
+            if (!allHeaders) {
+                // Exclude only some headers
+                Map<String, String> transportHeaders = getTransportHeaders(msgContext);
+                for (String header : headers) {
+                    transportHeaders.remove(header);
                 }
-                if (body != null) {
-                    byte[] digest;
-                    if (toAddress != null) {
-                        digest = getDigest(body, toAddress, null, MD5_DIGEST_ALGORITHM);
-                    } else {
-                        digest = getDigest(body, MD5_DIGEST_ALGORITHM);
-                    }
-                    return digest != null ? getStringRepresentation(digest) : null;
+                if (isGet) {
+                    //If the HTTP method is GET do not hash the payload. Hash only url and headers.
+                    return handleGetWithHeaders(msgContext, transportHeaders);
                 } else {
-                    return null;
+                    //If the HTTP method is POST hash the payload along with the url and the headers
+                    return handlePostWithHeaders(msgContext, transportHeaders);
+                }
+            } else {
+                //Do not hash the headers (exclude all headers)
+                if (isGet) {
+                    return handleGetWithoutHeaders(msgContext);
+                } else {
+                    return handlePostWithoutHeaders(msgContext);
                 }
             }
         }
@@ -549,7 +524,88 @@ public class HttpRequestHashGenerator implements DigestGenerator {
 
     @Override
     public void init(Map<String, Object> properties) {
-        headers = (String[]) properties.get("headers-to-exclude");
+        headers = (String[]) properties.get(CachingConstants.INCLUDED_HEADERS_PROPERTY);
+        if (headers[0].isEmpty()) {
+            // if include headers have not been explicitly defined
+            // mode becomes exclude header
+            isIncludeHeadersMode = false;
+            headers = (String[]) properties.get(CachingConstants.EXCLUDED_HEADERS_PROPERTY);
+        }
         permanentlyExcludedHeaders = (String[]) properties.get(CachingConstants.PERMANENTLY_EXCLUDED_HEADERS_STRING);
+    }
+
+    private String handleGetWithHeaders(MessageContext msgContext, Map transportHeaders) {
+
+        if (msgContext.getTo() == null) {
+            return null;
+        }
+        String toAddress = msgContext.getTo().getAddress();
+        byte[] digest = getDigest(toAddress, transportHeaders, MD5_DIGEST_ALGORITHM);
+        return digest != null ? getStringRepresentation(digest) : null;
+    }
+
+    private String handlePostWithHeaders(MessageContext msgContext, Map transportHeaders) {
+        OMNode body = msgContext.getEnvelope().getBody();
+        String toAddress = null;
+        if (msgContext.getTo() != null) {
+            toAddress = msgContext.getTo().getAddress();
+        }
+        if (body != null) {
+            byte[] digest;
+            if (toAddress != null) {
+                digest = getDigest(body, toAddress, transportHeaders, MD5_DIGEST_ALGORITHM);
+            } else {
+                digest = getDigest(body, MD5_DIGEST_ALGORITHM);
+            }
+            return digest != null ? getStringRepresentation(digest) : null;
+        } else {
+            return null;
+        }
+    }
+
+    private String handleGetWithoutHeaders(MessageContext msgContext) {
+        if (msgContext.getTo() == null) {
+            return null;
+        }
+        String toAddress = msgContext.getTo().getAddress();
+        byte[] digest = getDigest(toAddress, MD5_DIGEST_ALGORITHM);
+        return digest != null ? getStringRepresentation(digest) : null;
+    }
+
+    private String handlePostWithoutHeaders(MessageContext msgContext) {
+        OMNode body = msgContext.getEnvelope().getBody();
+        String toAddress = null;
+        if (msgContext.getTo() != null) {
+            toAddress = msgContext.getTo().getAddress();
+        }
+        if (body != null) {
+            byte[] digest;
+            if (toAddress != null) {
+                digest = getDigest(body, toAddress, null, MD5_DIGEST_ALGORITHM);
+            } else {
+                digest = getDigest(body, MD5_DIGEST_ALGORITHM);
+            }
+            return digest != null ? getStringRepresentation(digest) : null;
+        } else {
+            return null;
+        }
+    }
+
+    private Map<String, String> getTransportHeaders(MessageContext msgContext) {
+        //cloning transport headers from message context and making them case insensitive
+        Map<String, String> transportHeaders =
+                new TreeMap<String, String>(new Comparator<String>() {
+                    public int compare(String o1, String o2) {
+
+                        return o1.compareToIgnoreCase(o2);
+                    }
+                });
+        transportHeaders.putAll((Map<String, String>) msgContext.
+                getProperty(MessageContext.TRANSPORT_HEADERS));
+        //remove permanently excluded headers from hashing methods
+        for (String header : permanentlyExcludedHeaders) {
+            transportHeaders.remove(header);
+        }
+        return transportHeaders;
     }
 }

--- a/components/mediators/cache/org.wso2.carbon.mediator.cache/src/test/java/org.wso2.carbon.mediator.cache/CacheMediatorTest.java
+++ b/components/mediators/cache/org.wso2.carbon.mediator.cache/src/test/java/org.wso2.carbon.mediator.cache/CacheMediatorTest.java
@@ -64,6 +64,7 @@ public class CacheMediatorTest extends XMLTestCase {
                     "            <protocol type=\"HTTP\">\n" +
                     "               <methods>POST, GET</methods>\n" +
                     "               <headersToExcludeInHash>ab, abc</headersToExcludeInHash>\n" +
+                    "               <headersToIncludeInHash>xy, xyz</headersToIncludeInHash>\n" +
                     "               <responseCodes>2|5[0-9][0-9]</responseCodes>\n" +
                     "               <enableCacheControl>true</enableCacheControl>\n" +
                     "               <includeAgeHeader>true</includeAgeHeader>\n" +
@@ -93,6 +94,7 @@ public class CacheMediatorTest extends XMLTestCase {
         assertTrue("Incorrect value for the httpMethodsToCache",
                 Arrays.equals(mediator.getHTTPMethodsToCache(), new String[]{"POST", "GET"}));
         assertTrue("Incorrect value for the headersToExcludeInHash",Arrays.equals(mediator.getHeadersToExcludeInHash(), new String[]{"ab", "abc"}));
+        assertTrue("Incorrect value for the headersToIncludeInHash",Arrays.equals(mediator.getHeadersToIncludeInHash(), new String[]{"xy", "xyz"}));
         assertEquals("Incorrect value for the for the responsecodes",mediator.getResponseCodes(), "2|5[0-9][0-9]");
         assertEquals("Incorrect value for the hashGenerator",mediator.getDigestGenerator().getClass().getName(),
                 "org.wso2.carbon.mediator.cache.digest.HttpRequestHashGenerator");


### PR DESCRIPTION
## Purpose
- Introduce **headersToIncludeInHash** attribute to the cache mediator so the users can define specifically which headers need to be considered for creating the request hash.
- This attribute is executed along with the headersToExcludeInHash thus maintaining backward compatibility.
- Priority will be assigned to the newly introduced headersToIncludeInHash property. If proper values have been defined for the headersToIncludeInHash property, the cache finder will operate in header inclusion mode.
- If no values have been defined for both headersToIncludeInHash and headersToExcludeInHash attributes, finder will operate in the header exclusion mode (nothing will be excluded).


```
         <cache collector="false" timeout="3600" maxMessageSize="2000">
            <onCacheHit sequence="cache-hit-seq"/>
            <protocol type="HTTP">
               <methods>*</methods>
               <headersToExcludeInHash/>
               <headersToIncludeInHash/>
               <responseCodes>.*</responseCodes>
               <enableCacheControl>false</enableCacheControl>
               <includeAgeHeader>false</includeAgeHeader>
               <hashGenerator>org.wso2.carbon.mediator.cache.digest.HttpRequestHashGenerator</hashGenerator>
            </protocol>
            <implementation maxSize="1000"/>
         </cache>

```
- Fixes: https://github.com/wso2/product-ei/issues/5321