### PR TITLE
Upgrading FreeMarker version of the Smooks library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2505,7 +2505,7 @@
         <jcifs.wso2.version>1.3.17.wso2v1</jcifs.wso2.version>
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
-        <org.milyn.wso2.version>1.5.1.wso2v1</org.milyn.wso2.version>
+        <org.milyn.wso2.version>1.5.1.wso2v3</org.milyn.wso2.version>
         <javax.persistence.version>1.0</javax.persistence.version>
         <org.slf4j.verison>1.7.21</org.slf4j.verison>
         <addressing.version>${orbit.version.axis2}</addressing.version>


### PR DESCRIPTION
## Purpose
Upgrading the FreeMarker lib version in the smooks library to 2.3.30 to make it compatible with the FreeMarker implementation in the PayloadFactory mediator

## Related PRs
https://github.com/wso2/orbit/pull/442