### PR TITLE
Handle graphql-ws content type

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/SubprotocolBuilderUtil.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/SubprotocolBuilderUtil.java
@@ -29,6 +29,7 @@ public class SubprotocolBuilderUtil {
     private static String SYNAPSE_SUBPROTOCOL_PREFIX = "synapse(";
     private static String SYNAPSE_SUBPROTOCOL_SUFFIX = ")";
     private static String SYNAPSE_CONTENT_TYPE = "contentType=";
+    private static String SYNAPSE_CONTENT_TYPE_GRAPHQL_WS = "graphql-ws";
 
     private static final Log log = LogFactory.getLog(SubprotocolBuilderUtil.class);
 
@@ -45,7 +46,7 @@ public class SubprotocolBuilderUtil {
     }
 
     public static String contentTypeToSyanapeSubprotocol(String contentType) {
-        if (contentType.equals("graphql-ws")) {
+        if (contentType.equals(SYNAPSE_CONTENT_TYPE_GRAPHQL_WS)) {
             return contentType;
         } else {
             return SYNAPSE_SUBPROTOCOL_PREFIX + SYNAPSE_CONTENT_TYPE + "'" + contentType +

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/SubprotocolBuilderUtil.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/SubprotocolBuilderUtil.java
@@ -29,7 +29,6 @@ public class SubprotocolBuilderUtil {
     private static String SYNAPSE_SUBPROTOCOL_PREFIX = "synapse(";
     private static String SYNAPSE_SUBPROTOCOL_SUFFIX = ")";
     private static String SYNAPSE_CONTENT_TYPE = "contentType=";
-    private static String SYNAPSE_CONTENT_TYPE_GRAPHQL_WS = "graphql-ws";
 
     private static final Log log = LogFactory.getLog(SubprotocolBuilderUtil.class);
 
@@ -46,12 +45,8 @@ public class SubprotocolBuilderUtil {
     }
 
     public static String contentTypeToSyanapeSubprotocol(String contentType) {
-        if (contentType.equals(SYNAPSE_CONTENT_TYPE_GRAPHQL_WS)) {
-            return contentType;
-        } else {
-            return SYNAPSE_SUBPROTOCOL_PREFIX + SYNAPSE_CONTENT_TYPE + "'" + contentType +
-                    "'" + SYNAPSE_SUBPROTOCOL_SUFFIX;
-        }
+        return SYNAPSE_SUBPROTOCOL_PREFIX + SYNAPSE_CONTENT_TYPE + "'" + contentType +
+                "'" + SYNAPSE_SUBPROTOCOL_SUFFIX;
     }
 
 }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/SubprotocolBuilderUtil.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/SubprotocolBuilderUtil.java
@@ -45,8 +45,12 @@ public class SubprotocolBuilderUtil {
     }
 
     public static String contentTypeToSyanapeSubprotocol(String contentType) {
-        return SYNAPSE_SUBPROTOCOL_PREFIX + SYNAPSE_CONTENT_TYPE + "'" + contentType +
-                "'" + SYNAPSE_SUBPROTOCOL_SUFFIX;
+        if (contentType.equals("graphql-ws")) {
+            return contentType;
+        } else {
+            return SYNAPSE_SUBPROTOCOL_PREFIX + SYNAPSE_CONTENT_TYPE + "'" + contentType +
+                    "'" + SYNAPSE_SUBPROTOCOL_SUFFIX;
+        }
     }
 
 }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -236,17 +236,11 @@ public class WebsocketConnectionFactory {
         return null;
     }
 
-    private static String deriveSubprotocol(String wsSubprotocol, String contentType){
-        String subprotocol = null;
+    private static String deriveSubprotocol(String wsSubprotocol, String contentType) {
         if (wsSubprotocol != null) {
-            subprotocol = wsSubprotocol;
+            return wsSubprotocol;
         }
-        else {
-            if (contentType != null) {
-                subprotocol = SubprotocolBuilderUtil.contentTypeToSyanapeSubprotocol(contentType);
-            }
-        }
-        return subprotocol;
+        return contentType != null ? SubprotocolBuilderUtil.contentTypeToSyanapeSubprotocol(contentType) : null;
     }
 
     private static void handleWssTrustStoreParameterError(String errorMsg) throws AxisFault {

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -236,7 +236,7 @@ public class WebsocketConnectionFactory {
         return null;
     }
 
-    private static String deriveSubprotocol(String wsSubprotocol, String contentType) {
+    private String deriveSubprotocol(String wsSubprotocol, String contentType) {
         if (wsSubprotocol != null) {
             return wsSubprotocol;
         }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -47,7 +47,6 @@ import org.wso2.carbon.websocket.transport.utils.SSLUtil;
 import javax.net.ssl.SSLException;
 import javax.xml.namespace.QName;
 import java.net.URI;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -199,7 +198,7 @@ public class WebsocketConnectionFactory {
             final EventLoopGroup group = new NioEventLoopGroup();
             handler = new WebSocketClientHandler(WebSocketClientHandshakerFactory.newHandshaker(uri,
                     WebSocketVersion.V13,
-                    subprotocol(wsSubprotocol, contentType),
+                    deriveSubprotocol(wsSubprotocol, contentType),
                     false, defaultHttpHeaders));
             Bootstrap b = new Bootstrap();
             b.group(group).channel(NioSocketChannel.class)
@@ -237,7 +236,7 @@ public class WebsocketConnectionFactory {
         return null;
     }
 
-    private static String subprotocol(String wsSubprotocol, String contentType){
+    private static String deriveSubprotocol(String wsSubprotocol, String contentType){
         String subprotocol = null;
         if (wsSubprotocol != null) {
             subprotocol = wsSubprotocol;

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -52,4 +52,6 @@ public class WebsocketConstants {
 
     public static final String WEBSOCKET_CUSTOM_HEADER_PREFIX = "websocket.custom.header.";
     public static final String WEBSOCKET_CUSTOM_HEADER_CONFIG = "ws.custom.header";
+
+    public static final String WEBSOCKET_SUBPROTOCOL = "websocket.subprotocol";
 }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
@@ -152,7 +152,8 @@ public class WebsocketTransportSender extends AbstractTransportSender {
                 log.debug("Fetching a Connection from the WS(WSS) Connection Factory.");
             }
             WebSocketClientHandler clientHandler = connectionFactory.getChannelHandler(new URI(targetEPR), sourceIdentier,
-                    handshakePresent, responceDispatchSequence, responceErrorSequence, messageType, wsSubProtocol, customHeaders);
+                    handshakePresent, responceDispatchSequence, responceErrorSequence, messageType, wsSubProtocol,
+                    customHeaders);
             String tenantDomain = (String) msgCtx.getProperty(MultitenantConstants.TENANT_DOMAIN);
             if (tenantDomain != null) {
                 clientHandler.setTenantDomain(tenantDomain);

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
@@ -74,6 +74,7 @@ public class WebsocketTransportSender extends AbstractTransportSender {
         String responceDispatchSequence = null;
         String responceErrorSequence = null;
         String messageType = null;
+        String wsSubProtocol = null;
         Map<String, Object> customHeaders = new HashMap<>();
 
         InboundResponseSender responseSender = null;
@@ -101,6 +102,10 @@ public class WebsocketTransportSender extends AbstractTransportSender {
 
         if (msgCtx.getProperty(WebsocketConstants.CONTENT_TYPE) != null) {
             messageType = (String) msgCtx.getProperty(WebsocketConstants.CONTENT_TYPE);
+        }
+
+        if (msgCtx.getProperty(WebsocketConstants.WEBSOCKET_SUBPROTOCOL) != null) {
+            wsSubProtocol = (String) msgCtx.getProperty(WebsocketConstants.WEBSOCKET_SUBPROTOCOL);
         }
 
         /*
@@ -147,7 +152,7 @@ public class WebsocketTransportSender extends AbstractTransportSender {
                 log.debug("Fetching a Connection from the WS(WSS) Connection Factory.");
             }
             WebSocketClientHandler clientHandler = connectionFactory.getChannelHandler(new URI(targetEPR), sourceIdentier,
-                    handshakePresent, responceDispatchSequence, responceErrorSequence, messageType, customHeaders);
+                    handshakePresent, responceDispatchSequence, responceErrorSequence, messageType, wsSubProtocol, customHeaders);
             String tenantDomain = (String) msgCtx.getProperty(MultitenantConstants.TENANT_DOMAIN);
             if (tenantDomain != null) {
                 clientHandler.setTenantDomain(tenantDomain);


### PR DESCRIPTION
**Description**

If the sequence file has the property set as following, graphql subscriptions can work via websockets with this change in this pull request.

`<property name="websocket.subprotocol" value="graphql-ws" scope="axis2"/>`
