### PR TITLE
Add empty property support for class mediator in UI

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.mediator.service/src/main/java/org/wso2/carbon/mediator/service/ui/AbstractMediator.java
+++ b/components/mediation-admin/org.wso2.carbon.mediator.service/src/main/java/org/wso2/carbon/mediator/service/ui/AbstractMediator.java
@@ -110,6 +110,10 @@ public abstract class AbstractMediator implements Mediator {
     }
 
     public static List<MediatorProperty> getMediatorProperties(OMElement elem) {
+        return getMediatorProperties(elem, false);
+    }
+
+    public static List<MediatorProperty> getMediatorProperties(OMElement elem, boolean allowEmptyValues) {
 
         List<MediatorProperty> propertyList = new ArrayList<MediatorProperty>();
 
@@ -135,11 +139,9 @@ public abstract class AbstractMediator implements Mediator {
             // if a value is specified, use it, else look for an expression
             if (attValue != null) {
 
-                if (attValue.getAttributeValue() == null ||
-                    attValue.getAttributeValue().trim().length() == 0) {
-
-                    String msg = "Entry attribute value (if specified) " +
-                        "is required for a Log property";
+                if ((attValue.getAttributeValue() == null ||
+                        attValue.getAttributeValue().trim().length() == 0) && !allowEmptyValues) {
+                    String msg = "Entry attribute value (if specified) is required for a Log property";
                     throw new MediatorException(msg);
 
                 } else {

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.clazz.ui/src/main/java/org/wso2/carbon/mediator/clazz/ClassMediator.java
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.clazz.ui/src/main/java/org/wso2/carbon/mediator/clazz/ClassMediator.java
@@ -76,7 +76,8 @@ public class ClassMediator extends AbstractMediator {
         }
         this.mediator = name.getAttributeValue();
 
-        addAllProperties(getMediatorProperties(elem));
+        // Class mediator can have properties with empty values
+        addAllProperties(getMediatorProperties(elem, true));
 
         processAuditStatus(this, elem);        
     }

--- a/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.clazz.ui/src/main/resources/web/class-mediator/edit-mediator.jsp
+++ b/components/mediation-ui/mediators-ui/org.wso2.carbon.mediator.clazz.ui/src/main/resources/web/class-mediator/edit-mediator.jsp
@@ -125,7 +125,9 @@
                                                 if(!isLiteral) {
                                                     if(synapseXPath == null) {
                                                         path = mp.getPathExpression();
-                                                        pathValue = path.toString();
+                                                        if (path != null) {
+                                                            pathValue = path.toString();
+                                                        }
                                                     } else {
                                                         path = synapseXPath;
                                                         pathValue = path.toString();


### PR DESCRIPTION
## Purpose
> Allow class mediator to have empty properties in the management console.
Fixes wso2/product-ei/issues/5306