### PR TITLE
Enable Codecov coverage reports for unit tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,48 @@
+name: CodeCov Coverage Uploader
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Build Carbon Mediation with Maven
+        run: mvn clean install --file pom.xml
+      - name: Get carbon-mediation version
+        run: mvn help:evaluate -Dexpression=project.version -q -DforceStdout > ../CARBON_MEDIATION_VERSION_FILE
+      - name: Print carbon-mediation version
+        run: |
+          echo $(cat ../CARBON_MEDIATION_VERSION_FILE)
+      - name: Checkout Micro Integrator
+        uses: actions/checkout@v1
+        with:
+          repository: wso2/micro-integrator
+          ref: refs/heads/master
+      - name: Build micro-integrator with Maven
+        run: mvn clean install -Dcarbon.mediation.version=$(cat ../CARBON_MEDIATION_VERSION_FILE) -fae --file ../micro-integrator/pom.xml
+
+      - name: Upload unit test coverage of carbon.mediation to Codecov
+        uses: codecov/codecov-action@v1.2.1
+        with:
+          flags: mediation_unit_tests,unit_tests
+      - name: Upload unit test coverage of micro.integrator to Codecov
+        uses: codecov/codecov-action@v1.2.1
+        with:
+          flags: mi_unit_tests,unit_tests
+          directory: ../micro-integrator/components/
+      - name: Upload integration test coverage of micro.integrator to Codecov
+        uses: codecov/codecov-action@v1.2.1
+        with:
+          flags: integration_tests
+          directory: ../micro-integrator/integration/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+codecov:
+  require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "40...100"


### PR DESCRIPTION
## Purpose
> $subject

Codecov merges unit and integration test coverages.
Coverage information will be shown at https://app.codecov.io/gh/wso2/carbon-mediation