### PR TITLE
Add the javax.activation package to fix the NoClassDefFoundError

### DIFF
--- a/components/mediation-connector/org.wso2.carbon.connector.core/pom.xml
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/pom.xml
@@ -44,6 +44,7 @@
                         </Export-Package>
                         <Import-Package>
                             !javax.xml.soap,
+                            javax.activation; version="${javax.activation.version}",
                             javax.xml.stream.*; version="${javax.xml.stream.imp.pkg.version}",
                             org.apache.axis2.rpc.receivers; version="${axis2.osgi.version.range}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",

--- a/pom.xml
+++ b/pom.xml
@@ -2512,6 +2512,7 @@
         <damnhandy.version>2.1.6.wso2v2</damnhandy.version>
         <netty.version>4.1.34.Final</netty.version>
         <quickfixj.wso2.version>1.4.0.wso2v2</quickfixj.wso2.version>
+        <javax.activation.version>0.0</javax.activation.version>
         <javax.servlet.imp.pkg.version>[2.4.0, 3.0.0)</javax.servlet.imp.pkg.version>
         <javax.servlet.http.imp.pkg.version>[2.4.0, 3.0.0)</javax.servlet.http.imp.pkg.version>
         <javax.xml.stream.imp.pkg.version>[1.0.1, 1.1.0)</javax.xml.stream.imp.pkg.version>


### PR DESCRIPTION
Add the javax.activation package under import packages to fix the NoClassDefFoundError thrown when a user tries to send an email with the Email Connector.

Fixes wso2/micro-integrator#1990