### PR TITLE
Fixes wso2/product-ei#5385

### DIFF
--- a/components/mediation-initializer/org.wso2.carbon.mediation.transport.handlers/src/main/java/org/wso2/carbon/mediation/transport/handlers/PassThroughNHttpGetProcessor.java
+++ b/components/mediation-initializer/org.wso2.carbon.mediation.transport.handlers/src/main/java/org/wso2/carbon/mediation/transport/handlers/PassThroughNHttpGetProcessor.java
@@ -262,16 +262,18 @@ public class PassThroughNHttpGetProcessor implements HttpGetRequestProcessor {
             //check if service listing request is blocked
             if (isServiceListBlocked(uri)) {
                 response.setStatusCode(HttpStatus.SC_FORBIDDEN);
-                sourceHandler.commitResponseHideExceptions(conn, response);
             } else {
                 generateServicesList(response, conn, outputStream, servicePath);
 
                 messageContext.setProperty("WSDL_GEN_HANDLED", true);
             }
+            SourceContext.updateState(conn, ProtocolState.WSDL_RESPONSE_DONE);
             try {
                 outputStream.flush();
                 outputStream.close();
             } catch (IOException ignore) {
+            } finally {
+                sourceHandler.commitResponseHideExceptions(conn, response);
             }
             isRequestHandled = true ;
         } else {
@@ -389,8 +391,6 @@ public class PassThroughNHttpGetProcessor implements HttpGetRequestProcessor {
             byte[] bytes = getServicesHTML(
                     servicePath.endsWith("/") ? "" : servicePath + "/").getBytes();
             response.addHeader(CONTENT_TYPE, TEXT_HTML);
-            SourceContext.updateState(conn, ProtocolState.WSDL_RESPONSE_DONE);
-            sourceHandler.commitResponseHideExceptions(conn, response);
             os.write(bytes);
 
         } catch (IOException e) {


### PR DESCRIPTION
**Description**

commitResponseHideExceptions method was called before closing the outputStream. Because of that 200 OK responses with empty bodies were sent to the client. With this fix, the outputStream is closed before calling commitResponseHideExceptions.

Fixes wso2/product-ei#5385