### PR TITLE
disable registry update on inbound endpoints

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint.persistence/src/main/java/org/wso2/carbon/inbound/endpoint/persistence/InboundEndpointsDataStore.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint.persistence/src/main/java/org/wso2/carbon/inbound/endpoint/persistence/InboundEndpointsDataStore.java
@@ -22,6 +22,7 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.inbound.InboundProcessorParams;
 import org.apache.synapse.transport.passthru.core.ssl.SSLConfiguration;
 import org.wso2.carbon.core.RegistryResources;
@@ -30,13 +31,13 @@ import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.exceptions.ResourceNotFoundException;
 
-import javax.xml.stream.XMLStreamException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.xml.stream.XMLStreamException;
 
 public class InboundEndpointsDataStore {
 
@@ -47,12 +48,14 @@ public class InboundEndpointsDataStore {
     private Map<String,Set<String>> endpointPollingInfo;
     private Registry registry = null;
     private final String rootPath = RegistryResources.ROOT + "esb/inbound/inbound-endpoints/";
-
+    public static final String STORE_ARTIFACTS_IN_REGISTRY = "synapse.artifacts.registry.storage.enabled";
     private static InboundEndpointsDataStore instance = new InboundEndpointsDataStore();
 
     public static InboundEndpointsDataStore getInstance() {
         return instance;
     }
+    private boolean saveInboundEndpointInRegistry =
+            SynapsePropertiesLoader.getBooleanProperty(STORE_ARTIFACTS_IN_REGISTRY, false);
 
     private InboundEndpointsDataStore() {
         try {
@@ -60,7 +63,7 @@ public class InboundEndpointsDataStore {
         } catch (RegistryException e) {
             handleException("Error while obtaining a registry instance", e);
         }
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
             try {
                 Resource fetchedResource = registry.get(rootPath);
                 if (fetchedResource != null) {
@@ -126,7 +129,7 @@ public class InboundEndpointsDataStore {
             endpointListeningInfo.put(port, tenantList);
         }
         tenantList.add(new InboundEndpointInfoDTO(tenantDomain, protocol, name, params));
-        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
             updateRegistry();
         }
     }
@@ -145,7 +148,7 @@ public class InboundEndpointsDataStore {
         }
         lNames.add(name);
         endpointPollingInfo.put(tenantDomain, lNames);
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
             updateRegistry();
         }
     }
@@ -170,7 +173,7 @@ public class InboundEndpointsDataStore {
         InboundEndpointInfoDTO inboundEndpointInfoDTO = new InboundEndpointInfoDTO(tenantDomain, protocol, name, params);
         inboundEndpointInfoDTO.setSslConfiguration(sslConfiguration);
         tenantList.add(inboundEndpointInfoDTO);
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
             updateRegistry();
         }
     }
@@ -213,7 +216,7 @@ public class InboundEndpointsDataStore {
         if (endpointListeningInfo.get(port) != null && endpointListeningInfo.get(port).size() == 0) {
       	  endpointListeningInfo.remove(port);
         }
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
             updateRegistry();
         }
     }
@@ -237,7 +240,7 @@ public class InboundEndpointsDataStore {
             	endpointPollingInfo.remove(tenantDomain);
             }
         }
-        if(!Boolean.parseBoolean(System.getProperty("NonRegistryMode"))) {
+        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
             updateRegistry();
         }
     }    

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint.persistence/src/main/java/org/wso2/carbon/inbound/endpoint/persistence/InboundEndpointsDataStore.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint.persistence/src/main/java/org/wso2/carbon/inbound/endpoint/persistence/InboundEndpointsDataStore.java
@@ -18,18 +18,10 @@
 
 package org.wso2.carbon.inbound.endpoint.persistence;
 
-import org.apache.axiom.om.OMElement;
-import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.inbound.InboundProcessorParams;
 import org.apache.synapse.transport.passthru.core.ssl.SSLConfiguration;
-import org.wso2.carbon.core.RegistryResources;
-import org.wso2.carbon.registry.core.Registry;
-import org.wso2.carbon.registry.core.Resource;
-import org.wso2.carbon.registry.core.exceptions.RegistryException;
-import org.wso2.carbon.registry.core.exceptions.ResourceNotFoundException;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -37,78 +29,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.xml.stream.XMLStreamException;
 
 public class InboundEndpointsDataStore {
 
     private static final Log log = LogFactory.getLog(InboundEndpointsDataStore.class);
-
-    private Map<Integer,List<InboundEndpointInfoDTO>> endpointListeningInfo;
-    //Store polling endpoints with <TenantId<Endpoint_Name>> format
-    private Map<String,Set<String>> endpointPollingInfo;
-    private Registry registry = null;
-    private final String rootPath = RegistryResources.ROOT + "esb/inbound/inbound-endpoints/";
-    public static final String STORE_ARTIFACTS_IN_REGISTRY = "synapse.artifacts.registry.storage.enabled";
     private static InboundEndpointsDataStore instance = new InboundEndpointsDataStore();
-
-    public static InboundEndpointsDataStore getInstance() {
-        return instance;
-    }
-    private boolean saveInboundEndpointInRegistry =
-            SynapsePropertiesLoader.getBooleanProperty(STORE_ARTIFACTS_IN_REGISTRY, false);
+    private Map<Integer, List<InboundEndpointInfoDTO>> endpointListeningInfo;
+    //Store polling endpoints with <TenantId<Endpoint_Name>> format
+    private Map<String, Set<String>> endpointPollingInfo;
 
     private InboundEndpointsDataStore() {
-        try {
-            registry = ServiceReferenceHolder.getInstance().getRegistry();
-        } catch (RegistryException e) {
-            handleException("Error while obtaining a registry instance", e);
-        }
-        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
-            try {
-                Resource fetchedResource = registry.get(rootPath);
-                if (fetchedResource != null) {
-                    String fetchedData = null;
-                    if (fetchedResource.getContent() instanceof byte[]) {
-                        fetchedData = new String((byte[]) fetchedResource.getContent());
-                    }
-                    OMElement fetchedOM = null;
-                    try {
-                        fetchedOM = AXIOMUtil.stringToOM(fetchedData);
-                    } catch (XMLStreamException e) {
-                        handleException("Error while converting fetched registry data to a OM", e);
-                    }
-                    endpointListeningInfo = PersistenceUtils.convertOMToEndpointListeningInfo(fetchedOM);
-                    endpointPollingInfo = PersistenceUtils.convertOMToEndpointPollingInfo(fetchedOM);
-                }
-            } catch (ResourceNotFoundException ex) {
-                log.info("Inbound endpoint registry data not found, so re-initializing registry data");
-                initRegistryData();
-            } catch (RegistryException e) {
-                handleException("Error occurred while fetching inbound endpoint data from registry", e);
-            }
-        } else {
-            endpointListeningInfo = new ConcurrentHashMap<>();
-            endpointPollingInfo = new ConcurrentHashMap<>();
-        }
+
+        endpointListeningInfo = new ConcurrentHashMap<>();
+        endpointPollingInfo = new ConcurrentHashMap<>();
     }
 
-    /**
-     * Initialize registry data
-     */
-    private void initRegistryData() {
+    public static InboundEndpointsDataStore getInstance() {
 
-        /**
-         * Note : ports in this map are not offset by the value of port offset.
-         */
-        endpointListeningInfo = new ConcurrentHashMap<Integer, List<InboundEndpointInfoDTO>>();
-        endpointPollingInfo = new ConcurrentHashMap<String, Set<String>>();
-        try {
-            Resource resource = registry.newResource();
-            resource.setContent(PersistenceUtils.convertEndpointInfoToOM(endpointListeningInfo, endpointPollingInfo).toString());
-            registry.put(rootPath, resource);
-        } catch (RegistryException e) {
-            handleException("Initializing registry data.Error while creating registry resource", e);
-        }
+        return instance;
     }
 
     /**
@@ -121,6 +59,7 @@ public class InboundEndpointsDataStore {
      */
     public void registerListeningEndpoint(int port, String tenantDomain, String protocol, String name,
                                           InboundProcessorParams params) {
+
         port = port - PersistenceUtils.getPortOffset(params.getProperties());
         List<InboundEndpointInfoDTO> tenantList = endpointListeningInfo.get(port);
         if (tenantList == null) {
@@ -129,9 +68,6 @@ public class InboundEndpointsDataStore {
             endpointListeningInfo.put(port, tenantList);
         }
         tenantList.add(new InboundEndpointInfoDTO(tenantDomain, protocol, name, params));
-        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
-            updateRegistry();
-        }
     }
 
     /**
@@ -144,15 +80,12 @@ public class InboundEndpointsDataStore {
 
         Set<String> lNames = endpointPollingInfo.get(tenantDomain);
         if (lNames == null) {
-      	   lNames = new HashSet<String>();           
+            lNames = new HashSet<String>();
         }
         lNames.add(name);
         endpointPollingInfo.put(tenantDomain, lNames);
-        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
-            updateRegistry();
-        }
     }
-    
+
     /**
      * Register SSL endpoint in the InboundEndpointsDataStore
      *
@@ -163,6 +96,7 @@ public class InboundEndpointsDataStore {
      */
     public void registerSSLListeningEndpoint(int port, String tenantDomain, String protocol, String name,
                                              SSLConfiguration sslConfiguration, InboundProcessorParams params) {
+
         port = port - PersistenceUtils.getPortOffset(params.getProperties());
         List<InboundEndpointInfoDTO> tenantList = endpointListeningInfo.get(port);
         if (tenantList == null) {
@@ -170,12 +104,10 @@ public class InboundEndpointsDataStore {
             tenantList = new ArrayList<InboundEndpointInfoDTO>();
             endpointListeningInfo.put(port, tenantList);
         }
-        InboundEndpointInfoDTO inboundEndpointInfoDTO = new InboundEndpointInfoDTO(tenantDomain, protocol, name, params);
+        InboundEndpointInfoDTO inboundEndpointInfoDTO = new InboundEndpointInfoDTO(tenantDomain, protocol, name,
+                params);
         inboundEndpointInfoDTO.setSslConfiguration(sslConfiguration);
         tenantList.add(inboundEndpointInfoDTO);
-        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
-            updateRegistry();
-        }
     }
 
     /**
@@ -186,6 +118,7 @@ public class InboundEndpointsDataStore {
      * @return endpoint name
      */
     public String getListeningEndpointName(int port, String tenantDomain) {
+
         List<InboundEndpointInfoDTO> tenantList = endpointListeningInfo.get(port);
         if (tenantList != null) {
             for (InboundEndpointInfoDTO tenantInfo : tenantList) {
@@ -204,6 +137,7 @@ public class InboundEndpointsDataStore {
      * @param tenantDomain tenant domain name
      */
     public void unregisterListeningEndpoint(int port, String tenantDomain) {
+
         List<InboundEndpointInfoDTO> tenantList = endpointListeningInfo.get(port);
         if (tenantList != null) {
             for (InboundEndpointInfoDTO tenantInfo : tenantList) {
@@ -214,55 +148,51 @@ public class InboundEndpointsDataStore {
             }
         }
         if (endpointListeningInfo.get(port) != null && endpointListeningInfo.get(port).size() == 0) {
-      	  endpointListeningInfo.remove(port);
-        }
-        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
-            updateRegistry();
+            endpointListeningInfo.remove(port);
         }
     }
 
     /**
      * Unregister an endpoint from data store
      *
-     * @param tenantId        
-     * @param name 
+     * @param tenantId
+     * @param name
      */
     public void unregisterPollingEndpoint(String tenantDomain, String name) {
+
         Set<String> lNames = endpointPollingInfo.get(tenantDomain);
         if (lNames != null && !lNames.isEmpty()) {
             for (String strName : lNames) {
                 if (strName.equals(name)) {
-               	  lNames.remove(strName);
+                    lNames.remove(strName);
                     break;
                 }
             }
-            if(lNames.isEmpty()){
-            	endpointPollingInfo.remove(tenantDomain);
+            if (lNames.isEmpty()) {
+                endpointPollingInfo.remove(tenantDomain);
             }
         }
-        if (!Boolean.parseBoolean(System.getProperty("NonRegistryMode")) || saveInboundEndpointInRegistry) {
-            updateRegistry();
-        }
-    }    
+    }
 
     /**
      * Check polling endpoint from data store
      *
-     * @param tenantDomain      
-     * @param name 
+     * @param tenantDomain
+     * @param name
      */
     public boolean isPollingEndpointRegistered(String tenantDomain, String name) {
+
         Set<String> lNames = endpointPollingInfo.get(tenantDomain);
         if (lNames != null && !lNames.isEmpty()) {
             for (String strName : lNames) {
                 if (strName.equals(name)) {
-               	  return true;
+                    return true;
                 }
             }
-        }        
+        }
         return false;
-    }   
-    
+    }
+
     /**
      * Check whether endpoint registry is empty for a particular port
      *
@@ -270,6 +200,7 @@ public class InboundEndpointsDataStore {
      * @return whether no endpoint is registered for a port
      */
     public boolean isEndpointRegistryEmpty(int port) {
+
         return endpointListeningInfo.get(port) == null;
     }
 
@@ -278,7 +209,8 @@ public class InboundEndpointsDataStore {
      *
      * @return information of all endpoints
      */
-    public  Map<Integer,List<InboundEndpointInfoDTO>> getAllListeningEndpointData() {
+    public Map<Integer, List<InboundEndpointInfoDTO>> getAllListeningEndpointData() {
+
         return endpointListeningInfo;
     }
 
@@ -287,28 +219,9 @@ public class InboundEndpointsDataStore {
      *
      * @return information of all polling endpoints
      */
-    public  Map<String,Set<String>> getAllPollingingEndpointData() {
+    public Map<String, Set<String>> getAllPollingingEndpointData() {
+
         return endpointPollingInfo;
     }
-    
-    /**
-     * Synchronize in memory endpoint data with registry
-     */
-    private synchronized void updateRegistry() {
-        OMElement dataOM = PersistenceUtils.convertEndpointInfoToOM(endpointListeningInfo, endpointPollingInfo);
-        try {
-            Resource resource = registry.get(rootPath);
-            resource.setContent(dataOM.toString());
-            registry.put(rootPath, resource);
-        } catch (RegistryException e) {
-            handleException("Exception occurred while updating registry data", e);
-        }
-    }
-
-    private void handleException(String msg, Exception ex) {
-        //TODO: check whether we need more error handling here
-        log.error(msg, ex);
-    }
-
 
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
@@ -70,5 +70,4 @@ public class InboundHttpConstants {
     public static final String INTERNAL_HTTP_INBOUND_ENDPOINT_NAME = "EI_INTERNAL_HTTP_INBOUND_ENDPOINT";
     public static final String INTERNAL_HTTPS_INBOUND_ENDPOINT_NAME = "EI_INTERNAL_HTTPS_INBOUND_ENDPOINT";
 
-    public static final String INBOUND_ENDPOINT_PARAMETER_HTTP_USE_PORT_OFFSET = "inbound.http.use.port.offset";
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
@@ -70,4 +70,5 @@ public class InboundHttpConstants {
     public static final String INTERNAL_HTTP_INBOUND_ENDPOINT_NAME = "EI_INTERNAL_HTTP_INBOUND_ENDPOINT";
     public static final String INTERNAL_HTTPS_INBOUND_ENDPOINT_NAME = "EI_INTERNAL_HTTPS_INBOUND_ENDPOINT";
 
+    public static final String INBOUND_ENDPOINT_PARAMETER_HTTP_USE_PORT_OFFSET = "inbound.http.use.port.offset";
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpListener.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpListener.java
@@ -50,14 +50,9 @@ public class InboundHttpListener implements InboundRequestProcessor {
         String portParam = params.getProperties().getProperty(
                 InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_PORT);
         try {
-            port = Integer.parseInt(portParam);
+            port = Integer.parseInt(portParam) + PersistenceUtils.getPortOffset();
         } catch (NumberFormatException e) {
             handleException("Please provide port number as integer  instead of  port  " + portParam, e);
-        }
-        boolean portOffset = Boolean.parseBoolean(params.getProperties()
-                .getProperty(InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_USE_PORT_OFFSET));
-        if (portOffset) {
-            port += PersistenceUtils.getPortOffset();
         }
         name = params.getName();
     }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpListener.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpListener.java
@@ -25,13 +25,12 @@ import org.apache.synapse.inbound.InboundEndpoint;
 import org.apache.synapse.inbound.InboundProcessorParams;
 import org.apache.synapse.inbound.InboundRequestProcessor;
 import org.apache.synapse.transport.passthru.api.PassThroughInboundEndpointHandler;
-import org.wso2.carbon.inbound.endpoint.protocol.http.config.WorkerPoolConfiguration;
+import org.wso2.carbon.inbound.endpoint.persistence.PersistenceUtils;
 import org.wso2.carbon.inbound.endpoint.protocol.http.management.HTTPEndpointManager;
 
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.Collection;
-
 
 /**
  * Listener class for HttpInboundEndpoint which is trigger by inbound core and
@@ -46,6 +45,7 @@ public class InboundHttpListener implements InboundRequestProcessor {
     private InboundProcessorParams processorParams;
 
     public InboundHttpListener(InboundProcessorParams params) {
+
         processorParams = params;
         String portParam = params.getProperties().getProperty(
                 InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_PORT);
@@ -54,14 +54,20 @@ public class InboundHttpListener implements InboundRequestProcessor {
         } catch (NumberFormatException e) {
             handleException("Please provide port number as integer  instead of  port  " + portParam, e);
         }
+        boolean portOffset = Boolean.parseBoolean(params.getProperties()
+                .getProperty(InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_USE_PORT_OFFSET));
+        if (portOffset) {
+            port += PersistenceUtils.getPortOffset();
+        }
         name = params.getName();
     }
 
     @Override
     public void init() {
+
         if (isPortUsedByAnotherApplication(port)) {
             log.warn("Port " + port + " used by inbound endpoint " + name + " is already used by another application " +
-                     "hence undeploying inbound endpoint");
+                    "hence undeploying inbound endpoint");
             throw new SynapseException("Port " + port + " used by inbound endpoint " + name + " is already used by " +
                     "another application.");
         } else {
@@ -71,19 +77,21 @@ public class InboundHttpListener implements InboundRequestProcessor {
 
     @Override
     public void destroy() {
+
         HTTPEndpointManager.getInstance().closeEndpoint(port);
     }
 
     protected void handleException(String msg, Exception e) {
+
         log.error(msg, e);
         throw new SynapseException(msg, e);
     }
 
-
     protected boolean isPortUsedByAnotherApplication(int port) {
-        if (PassThroughInboundEndpointHandler.isEndpointRunning(port) ){
+
+        if (PassThroughInboundEndpointHandler.isEndpointRunning(port)) {
             return false;
-        }  else {
+        } else {
             try {
                 ServerSocket srv = new ServerSocket(port);
                 srv.close();
@@ -95,15 +103,16 @@ public class InboundHttpListener implements InboundRequestProcessor {
         }
     }
 
-    protected void destoryInbound(){
+    protected void destoryInbound() {
+
         if (processorParams.getSynapseEnvironment() != null) {
             Collection<InboundEndpoint> inboundEndpoints = processorParams.getSynapseEnvironment().
-                       getSynapseConfiguration().getInboundEndpoints();
+                    getSynapseConfiguration().getInboundEndpoints();
             {
                 for (InboundEndpoint inboundEndpoint : inboundEndpoints) {
                     if (inboundEndpoint.getName().equals(name)) {
                         processorParams.getSynapseEnvironment().
-                                   getSynapseConfiguration().removeInboundEndpoint(name);
+                                getSynapseConfiguration().removeInboundEndpoint(name);
                         break;
                     }
                 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/https/InboundHttpsListener.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/https/InboundHttpsListener.java
@@ -16,15 +16,14 @@
 
 package org.wso2.carbon.inbound.endpoint.protocol.https;
 
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.inbound.InboundProcessorParams;
 import org.apache.synapse.transport.passthru.core.ssl.SSLConfiguration;
+import org.wso2.carbon.inbound.endpoint.persistence.PersistenceUtils;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpConstants;
 import org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpListener;
-import org.wso2.carbon.inbound.endpoint.protocol.http.config.WorkerPoolConfiguration;
 import org.wso2.carbon.inbound.endpoint.protocol.http.management.HTTPEndpointManager;
 
 public class InboundHttpsListener extends InboundHttpListener {
@@ -37,14 +36,20 @@ public class InboundHttpsListener extends InboundHttpListener {
     private InboundProcessorParams processorParams;
 
     public InboundHttpsListener(InboundProcessorParams params) {
+
         super(params);
         processorParams = params;
         String portParam = params.getProperties().getProperty(
-                   InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_PORT);
+                InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_PORT);
         try {
             port = Integer.parseInt(portParam);
         } catch (NumberFormatException e) {
             handleException("Please provide port number as integer  instead of  port  " + portParam, e);
+        }
+        boolean portOffset = Boolean.parseBoolean(params.getProperties()
+                .getProperty(InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_USE_PORT_OFFSET));
+        if (portOffset) {
+            port += PersistenceUtils.getPortOffset();
         }
         name = params.getName();
         String keyStoreParam = params.getProperties().getProperty(InboundHttpConstants.KEY_STORE);
@@ -55,17 +60,18 @@ public class InboundHttpsListener extends InboundHttpListener {
         String certificateRevocation = params.getProperties().getProperty(InboundHttpConstants.CLIENT_REVOCATION);
         String preferredCiphers = params.getProperties().getProperty(InboundHttpConstants.PREFERRED_CIPHERS);
         sslConfiguration = new SSLConfiguration(keyStoreParam, trustStoreParam, clientAuthParam,
-                                                httpsProtocols, certificateRevocation, sslProtocol, preferredCiphers);
+                httpsProtocols, certificateRevocation, sslProtocol, preferredCiphers);
 
     }
 
     @Override
     public void init() {
+
         if (isPortUsedByAnotherApplication(port)) {
             log.warn("Port " + port + "used by inbound endpoint " + name + " is already used by another application " +
-                     "hence undeploying inbound endpoint");
+                    "hence undeploying inbound endpoint");
             throw new SynapseException("Port " + port + " used by inbound endpoint " + name + " is already used by " +
-                                       "another application.");
+                    "another application.");
         } else {
             HTTPEndpointManager.getInstance().startSSLEndpoint(port, name, sslConfiguration, processorParams);
         }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/https/InboundHttpsListener.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/https/InboundHttpsListener.java
@@ -42,14 +42,9 @@ public class InboundHttpsListener extends InboundHttpListener {
         String portParam = params.getProperties().getProperty(
                 InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_PORT);
         try {
-            port = Integer.parseInt(portParam);
+            port = Integer.parseInt(portParam) + PersistenceUtils.getPortOffset();
         } catch (NumberFormatException e) {
             handleException("Please provide port number as integer  instead of  port  " + portParam, e);
-        }
-        boolean portOffset = Boolean.parseBoolean(params.getProperties()
-                .getProperty(InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_USE_PORT_OFFSET));
-        if (portOffset) {
-            port += PersistenceUtils.getPortOffset();
         }
         name = params.getName();
         String keyStoreParam = params.getProperties().getProperty(InboundHttpConstants.KEY_STORE);


### PR DESCRIPTION
## Purpose
When You start two APIM packs with port offset we couldn't offset the inbound http,https ports due to portoffset config didn't apply to those ports

resolves #https://github.com/wso2/product-apim/issues/10412
resolves #https://github.com/wso2/product-apim/issues/10461