### PR TITLE
Change log level to fix APIM:10198

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/ExternalVaultConfigLoader.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/ExternalVaultConfigLoader.java
@@ -72,7 +72,9 @@ public class ExternalVaultConfigLoader {
                 String configsFileAsString = FileUtils.readFileToString(externalVaultFile);
                 vaultConfig = AXIOMUtil.stringToOM(configsFileAsString);
             } else {
-                log.warn("No such file: " + EXTERNAL_VAULTS + " in location " + vaultConfigFilePath);
+                if (log.isDebugEnabled()) {
+                    log.debug("No such file: " + EXTERNAL_VAULTS + " in location " + vaultConfigFilePath);
+                }
             }
         } catch (IOException| XMLStreamException e) {
             log.error("Error while reading the " + EXTERNAL_VAULTS + " file in location + "


### PR DESCRIPTION


## Purpose
This is to fix https://github.com/wso2/product-apim/issues/10198

external-vaults.xml file is not shipped with the product by default and hence it shows warn message in the server startup. The fix is to make it debug logs.