### PR TITLE
Change overloading methods

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
@@ -1122,7 +1122,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
      * @return generated swagger.
      * @throws APIException error occurred while retrieving host details.
      */
-    public String generateSwaggerFromSynapseAPI(API api, boolean isJSON) throws APIException {
+    public String generateSwaggerFromSynapseAPIByFormat(API api, boolean isJSON) throws APIException {
         String swaggerJsonString = "";
         if (log.isDebugEnabled()) {
             log.debug("Generate swagger definition for the API : " + api.getAPIName());
@@ -1144,7 +1144,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
      * @throws APIException
      */
     public String generateSwaggerFromSynapseAPI(API api) throws APIException {
-        return generateSwaggerFromSynapseAPI(api,true);
+        return generateSwaggerFromSynapseAPIByFormat(api,true);
     }
 
     /**
@@ -1155,7 +1155,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
      * @throws APIException error occurred while retrieving host details.
      */
     public String generateAPIFromSwagger(String swaggerJsonString) throws APIException {
-        return generateAPIFromSwagger(swaggerJsonString,true);
+        return generateAPIFromSwaggerByFormat(swaggerJsonString,true);
     }
 
     /**
@@ -1166,7 +1166,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
      * @return generated synapse API.
      * @throws APIException error occurred while retrieving host details.
      */
-    public String generateAPIFromSwagger(String swaggerString, boolean isJSON) throws APIException {
+    public String generateAPIFromSwaggerByFormat(String swaggerString, boolean isJSON) throws APIException {
 
         if (swaggerString == null || swaggerString.isEmpty()) {
             handleException(log, "Swagger provided is empty, hence unable to generate API", null);
@@ -1241,7 +1241,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
      * @return generated synapse API.
      * @throws APIException error occurred while retrieving host details.
      */
-    public String generateUpdatedAPIFromSwagger(String swaggerJsonString, boolean isJSON, API existingApi)
+    public String generateUpdatedAPIFromSwaggerByFormat(String swaggerJsonString, boolean isJSON, API existingApi)
             throws APIException {
 
         if (swaggerJsonString == null || swaggerJsonString.isEmpty()) {
@@ -1285,8 +1285,8 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
      * @return generated synapse API
      * @throws APIException
      */
-    public String generateUpdatedAPIFromSwagger(String swaggerJsonString, API existingApi) throws APIException {
-        return generateUpdatedAPIFromSwagger(swaggerJsonString, true, existingApi);
+    public String generateUpdatedAPIFromSwaggerForAPI(String swaggerJsonString, API existingApi) throws APIException {
+        return generateUpdatedAPIFromSwaggerByFormat(swaggerJsonString, true, existingApi);
     }
 
     /**

--- a/components/mediation-admin/org.wso2.carbon.rest.api/src/test/java/org/wso2/carbon/rest/api/RestApiAdminUnitTest.java
+++ b/components/mediation-admin/org.wso2.carbon.rest.api/src/test/java/org/wso2/carbon/rest/api/RestApiAdminUnitTest.java
@@ -54,7 +54,7 @@ public class RestApiAdminUnitTest extends TestCase {
 
     public void testAPIFromSwagger() throws IOException, APIException, XMLStreamException {
         String fileContent = readResourceFile("TestSwagger.yaml");
-        String result = restApiAdmin.generateAPIFromSwagger(fileContent, false);
+        String result = restApiAdmin.generateAPIFromSwaggerByFormat(fileContent, false);
         OMElement omElement = AXIOMUtil.stringToOM(result);
         API api = APIFactory.createAPI(omElement);
         assertEquals("Mismatch in the API context", "/first", api.getContext());
@@ -63,7 +63,7 @@ public class RestApiAdminUnitTest extends TestCase {
 
     public void testAPIFromSwaggerWithTemplatedServers() throws IOException, APIException, XMLStreamException {
         String fileContent = readResourceFile("TestSwagger2.yaml");
-        String result = restApiAdmin.generateAPIFromSwagger(fileContent, false);
+        String result = restApiAdmin.generateAPIFromSwaggerByFormat(fileContent, false);
         OMElement omElement = AXIOMUtil.stringToOM(result);
         API api = APIFactory.createAPI(omElement);
         assertEquals("Mismatch in the API context", "/v2/bla/test1/hello", api.getContext());
@@ -145,7 +145,7 @@ public class RestApiAdminUnitTest extends TestCase {
 
     public void testAPIFromSwaggerWithRelativeUrl() throws IOException, APIException, XMLStreamException {
         String fileContent = readResourceFile("TestSwaggerRelativeUrl.yaml");
-        String result = restApiAdmin.generateAPIFromSwagger(fileContent, false);
+        String result = restApiAdmin.generateAPIFromSwaggerByFormat(fileContent, false);
         OMElement omElement = AXIOMUtil.stringToOM(result);
         API api = APIFactory.createAPI(omElement);
         assertEquals("Mismatch in the API context", "/firstRelative", api.getContext());

--- a/components/mediation-admin/org.wso2.carbon.rest.api/src/test/java/org/wso2/carbon/rest/api/RestApiAdminUnitTest.java
+++ b/components/mediation-admin/org.wso2.carbon.rest.api/src/test/java/org/wso2/carbon/rest/api/RestApiAdminUnitTest.java
@@ -98,7 +98,7 @@ public class RestApiAdminUnitTest extends TestCase {
         OMElement omElement = AXIOMUtil.stringToOM(fileContent);
         API oldApi = APIFactory.createAPI(omElement);
         fileContent = readResourceFile("ChangeApiSwagger.json");
-        String newApiStr = restApiAdmin.generateUpdatedAPIFromSwagger(fileContent, oldApi);
+        String newApiStr = restApiAdmin.generateUpdatedAPIFromSwaggerForAPI(fileContent, oldApi);
         omElement = AXIOMUtil.stringToOM(newApiStr);
         API newApi = APIFactory.createAPI(omElement);
         Assert.assertEquals("Version update failed", newApi.getVersion(), "1.2.4");


### PR DESCRIPTION
This is to fix https://github.com/wso2/product-apim/issues/10198

When there are overloading methods in admin services axis2 doesn't add method to the map and prints a warn message. This is to eliminate that error

