### PR TITLE
Introduce a synapse property to manage port offset for Inbound Endpoints

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
@@ -39,6 +39,7 @@ public class InboundHttpConstants {
     public static final String CLIENT_REVOCATION = "CertificateRevocationVerifier";
     public static final String HTTP = "http";
     public static final String HTTPS = "https";
+    public static final String ENABLE_PORT_OFFSET_FOR_INBOUND_ENDPOINT = "inbound.port.offset.enable";
     /**
      * Defines the core size (number of threads) of the worker thread pool.
      */

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpListener.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpListener.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.inbound.endpoint.protocol.http;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.inbound.InboundEndpoint;
 import org.apache.synapse.inbound.InboundProcessorParams;
 import org.apache.synapse.inbound.InboundRequestProcessor;
@@ -47,10 +48,13 @@ public class InboundHttpListener implements InboundRequestProcessor {
     public InboundHttpListener(InboundProcessorParams params) {
 
         processorParams = params;
+        boolean enableInboundPortOffset = SynapsePropertiesLoader.
+                getBooleanProperty(InboundHttpConstants.ENABLE_PORT_OFFSET_FOR_INBOUND_ENDPOINT, true);
         String portParam = params.getProperties().getProperty(
                 InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_PORT);
         try {
-            port = Integer.parseInt(portParam) + PersistenceUtils.getPortOffset();
+            port = enableInboundPortOffset ? Integer.parseInt(portParam) +
+                    PersistenceUtils.getPortOffset() : Integer.parseInt(portParam);
         } catch (NumberFormatException e) {
             handleException("Please provide port number as integer  instead of  port  " + portParam, e);
         }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/https/InboundHttpsListener.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/https/InboundHttpsListener.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.inbound.endpoint.protocol.https;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.inbound.InboundProcessorParams;
 import org.apache.synapse.transport.passthru.core.ssl.SSLConfiguration;
 import org.wso2.carbon.inbound.endpoint.persistence.PersistenceUtils;
@@ -39,10 +40,13 @@ public class InboundHttpsListener extends InboundHttpListener {
 
         super(params);
         processorParams = params;
+        boolean enableInboundPortOffset = SynapsePropertiesLoader.
+                getBooleanProperty(InboundHttpConstants.ENABLE_PORT_OFFSET_FOR_INBOUND_ENDPOINT, true);
         String portParam = params.getProperties().getProperty(
                 InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_PORT);
         try {
-            port = Integer.parseInt(portParam) + PersistenceUtils.getPortOffset();
+            port = enableInboundPortOffset ? Integer.parseInt(portParam) +
+                    PersistenceUtils.getPortOffset() : Integer.parseInt(portParam);
         } catch (NumberFormatException e) {
             handleException("Please provide port number as integer  instead of  port  " + portParam, e);
         }


### PR DESCRIPTION
## Purpose
This PR introduces a synapse property **inbound.port.offset.enable**  to set whether to add the server port offset value for Inbound Endpoints or not.
Related issue https://github.com/wso2/micro-integrator/issues/2223
