### PR TITLE
Enable correlation log support for inbound endpoints

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundCorrelationEnabledHttpServerWorker.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundCorrelationEnabledHttpServerWorker.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.inbound.endpoint.protocol.http;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.log4j.MDC;
+import org.apache.synapse.commons.CorrelationConstants;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.SourceRequest;
+import org.apache.synapse.transport.passthru.config.SourceConfiguration;
+
+import java.io.OutputStream;
+
+/**
+ * Extends {@link InboundHttpServerWorker} with correlation logs enabled.
+ */
+public class InboundCorrelationEnabledHttpServerWorker extends InboundHttpServerWorker {
+
+    // logger for correlation.log
+    private static final Log correlationLog = LogFactory.getLog(PassThroughConstants.CORRELATION_LOGGER);
+
+    private long initiationTimestamp;
+    private String correlationId;
+
+    InboundCorrelationEnabledHttpServerWorker(int port, String tenantDomain, SourceRequest sourceRequest,
+                                              SourceConfiguration sourceConfiguration, OutputStream outputStream,
+                                              long initiationTimestamp, String correlationId) {
+        super(port, tenantDomain, sourceRequest, sourceConfiguration, outputStream);
+        this.initiationTimestamp = initiationTimestamp;
+        this.correlationId = correlationId;
+    }
+
+    @Override
+    public void run() {
+        // Reset the correlation id MDC thread local value.
+        MDC.remove(CorrelationConstants.CORRELATION_MDC_PROPERTY);
+        MDC.put(CorrelationConstants.CORRELATION_MDC_PROPERTY, correlationId);
+        // Log the time taken to switch from the previous thread to this thread
+        correlationLog.info((System.currentTimeMillis() - initiationTimestamp) + "|Thread switch latency");
+        super.run();
+    }
+}

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
@@ -68,7 +68,7 @@ public class InboundHttpServerWorker extends ServerWorker {
 
     private static final Log log = LogFactory.getLog(InboundHttpServerWorker.class);
 
-    private SourceRequest request = null;
+    private SourceRequest request;
     private int port;
     private String tenantDomain;
     private InboundApiHandler inboundApiHandler;
@@ -139,8 +139,6 @@ public class InboundHttpServerWorker extends ServerWorker {
                     return;
                 }
 
-//                OpenEventCollector.reportEntryEvent(synCtx, endpointName, endpoint.getAspectConfiguration(),
-//                                                    ComponentType.INBOUNDENDPOINT);
 
                 CustomLogSetter.getInstance().setLogAppender(endpoint.getArtifactContainerName());
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject.
Currently Inbound Endpoints in Carbon mediation does not have Correlation logs support. This PR will add support for Inbound Endpoints