### PR TITLE
Add hyphen replace / inbound properties support

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSConstants.java
@@ -178,6 +178,18 @@ public class JMSConstants {
     /** The JMSXGroupID property */
     public static final String JMSX_GROUP_ID = "JMSXGroupID";
     /**
+     * A MessageContext property or client Option indicating the JMS destination to use on a Send
+     */
+    public static final String JMS_DESTINATION = "JMS_DESTINATION";
+    /**
+     * A MessageContext property or client Option indicating the JMS replyTo Destination
+     */
+    public static final String JMS_REPLY_TO = "JMS_REPLY_TO";
+    /**
+     * A MessageContext property indicating the JMS type String returned by {@link javax.jms.Message.getJMSType()}
+     */
+    public static final String JMS_TYPE = "JMS_TYPE";
+    /**
      * A MessageContext property or client Option indicating the JMS delivery mode as an Integer or String
      * Value 1 - javax.jms.DeliveryMode.NON_PERSISTENT
      * Value 2 - javax.jms.DeliveryMode.PERSISTENT

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
@@ -98,6 +98,13 @@ public class JMSInjectHandler {
             msgCtx.setProperty(SynapseConstants.ARTIFACT_NAME, SynapseConstants.FAIL_SAFE_MODE_INBOUND_ENDPOINT + name);
             msgCtx.setProperty(SynapseConstants.IS_INBOUND, true);
             InboundEndpoint inboundEndpoint = msgCtx.getConfiguration().getInboundEndpoint(name);
+
+            // Adding inbound endpoint parameters as synapse properties
+            Map<String, String> parametersMap = inboundEndpoint.getParametersMap();
+            for (Map.Entry<String, String> entry : parametersMap.entrySet()) {
+                msgCtx.setProperty(entry.getKey(), entry.getValue());
+            }
+
             CustomLogSetter.getInstance().setLogAppender(inboundEndpoint.getArtifactContainerName());
             String contentType = null;
 
@@ -124,6 +131,13 @@ public class JMSInjectHandler {
             }
             MessageContext axis2MsgCtx =
                     ((org.apache.synapse.core.axis2.Axis2MessageContext) msgCtx).getAxis2MessageContext();
+
+            String hyphenSupport = JMSConstants.DEFAULT_HYPHEN_SUPPORT;
+            if (inboundEndpoint.getParameter(JMSConstants.PARAM_JMS_HYPHEN_MODE) != null) {
+                hyphenSupport = inboundEndpoint.getParameter(JMSConstants.PARAM_JMS_HYPHEN_MODE);
+            }
+            axis2MsgCtx.setProperty(JMSConstants.PARAM_JMS_HYPHEN_MODE, hyphenSupport);
+
             //setting transport headers
             Map<String, Object> transportHeaders = JMSUtils.getTransportHeaders(msg, axis2MsgCtx);
             transportHeaders.put(JMSConstants.JMS_TIMESTAMP, msg.getJMSTimestamp());

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSUtils.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSUtils.java
@@ -29,8 +29,10 @@ import javax.jms.JMSException;
 import javax.jms.MapMessage;
 import javax.jms.Message;
 import javax.jms.ObjectMessage;
+import javax.jms.Queue;
 import javax.jms.StreamMessage;
 import javax.jms.TextMessage;
+import javax.jms.Topic;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NameNotFoundException;
@@ -318,7 +320,83 @@ public class JMSUtils {
      */
     public static Map<String, Object> getTransportHeaders(Message message, MessageContext msgContext) {
         // create a Map to hold transport headers
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new HashMap<String, Object>();
+
+        // correlation ID
+        try {
+            if (message.getJMSCorrelationID() != null) {
+                map.put(JMSConstants.JMS_COORELATION_ID, message.getJMSCorrelationID());
+            }
+        } catch (JMSException ignore) {
+        }
+
+        // set the delivery mode as persistent or not
+        try {
+            map.put(JMSConstants.JMS_DELIVERY_MODE, Integer.toString(message.getJMSDeliveryMode()));
+        } catch (JMSException ignore) {
+        }
+
+        // destination name
+        try {
+            if (message.getJMSDestination() != null) {
+                Destination dest = message.getJMSDestination();
+                map.put(JMSConstants.JMS_DESTINATION,
+                        dest instanceof Queue ?
+                                ((Queue) dest).getQueueName() : ((Topic) dest).getTopicName());
+            }
+        } catch (JMSException ignore) {
+        }
+
+        // expiration
+        try {
+            map.put(JMSConstants.JMS_EXPIRATION, Long.toString(message.getJMSExpiration()));
+        } catch (JMSException ignore) {
+        }
+
+        // if a JMS message ID is found
+        try {
+            if (message.getJMSMessageID() != null) {
+                map.put(JMSConstants.JMS_MESSAGE_ID, message.getJMSMessageID());
+            }
+        } catch (JMSException ignore) {
+        }
+
+        // priority
+        try {
+            map.put(JMSConstants.JMS_PRIORITY, Long.toString(message.getJMSPriority()));
+        } catch (JMSException ignore) {
+        }
+
+        // redelivered
+        try {
+            map.put(JMSConstants.JMS_REDELIVERED, Boolean.toString(message.getJMSRedelivered()));
+        } catch (JMSException ignore) {
+        }
+
+        // replyto destination name
+        try {
+            if (message.getJMSReplyTo() != null) {
+                Destination dest = message.getJMSReplyTo();
+                map.put(JMSConstants.JMS_REPLY_TO,
+                        dest instanceof Queue ?
+                                ((Queue) dest).getQueueName() : ((Topic) dest).getTopicName());
+            }
+        } catch (JMSException ignore) {
+        }
+
+        // priority
+        try {
+            map.put(JMSConstants.JMS_TIMESTAMP, Long.toString(message.getJMSTimestamp()));
+        } catch (JMSException ignore) {
+        }
+
+        // message type
+        try {
+            if (message.getJMSType() != null) {
+                map.put(JMSConstants.JMS_TYPE, message.getJMSType());
+            }
+        } catch (JMSException ignore) {
+        }
 
         try {
             Enumeration<?> propertyNamesEnm = message.getPropertyNames();


### PR DESCRIPTION
## Purpose
> Add hyphen replace support for inbound endpoints.
Inject inbound endpoint properties to the message context.
Fixes wso2/product-ei/issues/5409
Fixes wso2/product-ei/issues/5402