### PR TITLE
Fix NPE when resource path is unavailable.

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.mediation.library/src/main/java/org/wso2/carbon/mediation/library/RegistryCachingHandler.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.library/src/main/java/org/wso2/carbon/mediation/library/RegistryCachingHandler.java
@@ -96,7 +96,8 @@ public class RegistryCachingHandler extends Handler {
      * @param requestContext      path to the resource
      */
     private void resolveRegistryPathAndClear(RequestContext requestContext) {
-        String resourcePath = requestContext.getResourcePath().getPath();
+        String resourcePath = requestContext.getResourcePath() != null ?
+                requestContext.getResourcePath().getPath() : requestContext.getSourcePath();
         ConfigHolder configHolder = ConfigHolder.getInstance();
         if (configHolder.isSynapseConfigurationInitialized()) {
             try {


### PR DESCRIPTION
Fixes: https://github.com/wso2/product-ei/issues/5415
For renaming, moving and copying of registry resources, resourcePath is not set in the RequestContext in the kernel.
Hence we have to use the sourcePath to resolve and clear cache.

