### PR TITLE
Add transport.vfs.UpdateLastModified property to VFS

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/file/FilePollingConsumer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/file/FilePollingConsumer.java
@@ -842,6 +842,10 @@ public class FilePollingConsumer {
                     log.debug("Moving to file :" + VFSUtils.maskURLPassword(dest.getName().getURI()));
                 }
                 try {
+                    String updateLastModified = vfsProperties.getProperty(VFSConstants.UPDATE_LAST_MODIFIED);
+                    if (updateLastModified != null) {
+                        dest.setUpdateLastModified(Boolean.parseBoolean(updateLastModified));
+                    }
                     fileObject.moveTo(dest);
                 } catch (FileSystemException e) {
                     if (!VFSUtils.isFailRecord(fsManager, fileObject, fso)) {

--- a/pom.xml
+++ b/pom.xml
@@ -2433,7 +2433,7 @@
         <orbit.version.xmlschema>1.4.7.wso2v2</orbit.version.xmlschema>
         <commons.lang.wso2.version>2.6.0.wso2v1</commons.lang.wso2.version>
         <rampart.wso2.version>${rampart.version}</rampart.wso2.version>
-        <commons.vfs.version>2.2-wso2v9</commons.vfs.version>
+        <commons.vfs.version>2.2-wso2v10</commons.vfs.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpasyncclient.version>4.0-beta3</httpasyncclient.version>
         <!--Misc-->


### PR DESCRIPTION
## Purpose
For cases where the last modified time stamp needs to be ignored, use the property as follows. Default value of this parameter is true, hence timestamp will be set by default

```
<parameter name="transport.vfs.UpdateLastModified">false</parameter>
```

Fixes: wso2/micro-integrator#2318