### PR TITLE
Fix Issues Occurring When Disconnecting Websocket Clients

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -27,6 +27,7 @@ public class WebsocketConstants {
     public static final int WEBSOCKET_DEFAULT_WSS_PORT = 443;
 
     public static final String UNIVERSAL_SOURCE_IDENTIFIER = "universal.source.identifier";
+    public static final String WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER = "websocket.source.channel.identifier";
     public static final String WEBSOCKET_OUTFLOW_DISPATCH_SEQUENCE = "ws.outflow.dispatch.sequence";
     public static final String WEBSOCKET_OUTFLOW_DISPATCH_FAULT_SEQUENCE = "ws.outflow.dispatch.fault.sequence";
     public static final String CONTENT_TYPE = "websocket.accept.contenType";
@@ -54,4 +55,6 @@ public class WebsocketConstants {
     public static final String WEBSOCKET_CUSTOM_HEADER_CONFIG = "ws.custom.header";
 
     public static final String WEBSOCKET_SUBPROTOCOL = "websocket.subprotocol";
+
+    public static final String CONNECTION_TERMINATE = "connection.terminate";
 }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
@@ -84,8 +84,12 @@ public class WebsocketTransportSender extends AbstractTransportSender {
         if (msgCtx.getProperty(InboundEndpointConstants.INBOUND_ENDPOINT_RESPONSE_WORKER) != null) {
             responseSender = (InboundResponseSender)
                     msgCtx.getProperty(InboundEndpointConstants.INBOUND_ENDPOINT_RESPONSE_WORKER);
-            sourceIdentier = ((ChannelHandlerContext) msgCtx.
-                    getProperty(WebsocketConstants.WEBSOCKET_SOURCE_HANDLER_CONTEXT)).channel().toString();
+            if (msgCtx.getProperty(WebsocketConstants.WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER) != null) {
+                sourceIdentier = msgCtx.getProperty(WebsocketConstants.WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER).toString();
+            } else {
+                sourceIdentier = ((ChannelHandlerContext) msgCtx.
+                        getProperty(WebsocketConstants.WEBSOCKET_SOURCE_HANDLER_CONTEXT)).channel().toString();
+            }
         } else {
             sourceIdentier = WebsocketConstants.UNIVERSAL_SOURCE_IDENTIFIER;
         }
@@ -195,6 +199,8 @@ public class WebsocketTransportSender extends AbstractTransportSender {
                         LogUtil.printWebSocketFrame(log, frame, clientHandler.getChannelHandlerContext(), false);
                     }
                 }
+            } else if (Boolean.valueOf(true).equals(msgCtx.getProperty(WebsocketConstants.CONNECTION_TERMINATE))) {
+                clientHandler.getChannelHandlerContext().channel().flush();
             } else {
                 if (!handshakePresent) {
                     RelayUtils.buildMessage(msgCtx, false);

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
@@ -40,6 +40,7 @@ public class InboundWebsocketConstants {
 
     public static final String WEBSOCKET_TARGET_HANDLER_CONTEXT = "websocket.target.handler.context";
     public static final String WEBSOCKET_SOURCE_HANDLER_CONTEXT = "websocket.source.handler.context";
+    public static final String WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER = "websocket.source.channel.identifier";
 
     public static final String WEBSOCKET_BINARY_FRAME_PRESENT = "websocket.binary.frame.present";
     public static final String WEBSOCKET_BINARY_FRAME = "websocket.binary.frame";

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketSourceHandler.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketSourceHandler.java
@@ -525,6 +525,11 @@ public class InboundWebsocketSourceHandler extends ChannelInboundHandlerAdapter 
         synCtx.setProperty(InboundWebsocketConstants.WEBSOCKET_SOURCE_HANDLER_CONTEXT, wrappedContext.getChannelHandlerContext());
         ((Axis2MessageContext) synCtx).getAxis2MessageContext()
                 .setProperty(InboundWebsocketConstants.WEBSOCKET_SOURCE_HANDLER_CONTEXT, wrappedContext.getChannelHandlerContext());
+        synCtx.setProperty(InboundWebsocketConstants.WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER,
+                wrappedContext.getChannelIdentifier());
+        ((Axis2MessageContext) synCtx).getAxis2MessageContext()
+                .setProperty(InboundWebsocketConstants.WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER,
+                        wrappedContext.getChannelIdentifier());
         if (outflowDispatchSequence != null) {
             synCtx.setProperty(InboundWebsocketConstants.WEBSOCKET_OUTFLOW_DISPATCH_SEQUENCE, outflowDispatchSequence);
             ((Axis2MessageContext) synCtx).getAxis2MessageContext()


### PR DESCRIPTION
## Purpose
Fix the following issues occurring when disconnecting websocket clients.
1. Creation of a new connection when disconnecting a websocket client
2. Empty soap message being sent to the server when disconnecting a websocket client

Related Issue: https://github.com/wso2/product-apim/issues/11325

## Related PRs
[WUM] 4.7.61 branch - https://github.com/wso2-support/carbon-mediation/pull/590
[U2] 4.7.61 branch - https://github.com/wso2-support/carbon-mediation/pull/591