### PR TITLE
Send PONG as a response to the backend server's PING

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
@@ -26,6 +26,8 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
@@ -179,6 +181,11 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
                         ((handshaker.actualSubprotocol() != null) &&
                                 !handshaker.actualSubprotocol().contains(WebsocketConstants.SYNAPSE_SUBPROTOCOL_PREFIX)))) {
                     handleWebsocketBinaryFrame(frame);
+                    return;
+                } else if ((frame instanceof PingWebSocketFrame) && ((handshaker.actualSubprotocol() == null) ||
+                        ((handshaker.actualSubprotocol() != null) &&
+                                !handshaker.actualSubprotocol().contains(WebsocketConstants.SYNAPSE_SUBPROTOCOL_PREFIX)))) {
+                    ctx.channel().writeAndFlush(new PongWebSocketFrame(frame.content().retain()));
                     return;
                 } else if ((frame instanceof TextWebSocketFrame) && ((handshaker.actualSubprotocol() == null) ||
                         ((handshaker.actualSubprotocol() != null) &&

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketSourceHandler.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketSourceHandler.java
@@ -386,7 +386,6 @@ public class InboundWebsocketSourceHandler extends ChannelInboundHandlerAdapter 
                     synCtx.setEnvelope(TransportUtils.createSOAPEnvelope(documentElement));
                     injectForMediation(synCtx, endpoint);
                 } else if (frame instanceof PingWebSocketFrame) {
-                    ctx.channel().writeAndFlush(new PongWebSocketFrame(frame.content().retain()));
                     PongWebSocketFrame pongWebSocketFrame = new PongWebSocketFrame(frame.content().retain());
                     ctx.channel().writeAndFlush(pongWebSocketFrame);
                     if (log.isDebugEnabled()) {


### PR DESCRIPTION
As per the current implementation, the WSO2 server is not responding to the PING message of the backend (WebSocket) server and hence the server gets disconnected from the client(WSO2 server). In this case, the WSO2 server has to create a new connection for each and every message that is sent from the client (WSO2 server) to the backend server. This PR fixes that issue by sending a PONG from the WSO2 server as a response to the backend server's PING message.

Fixes: wso2/product-apim#11160