### PR TITLE
Adding the support for the WS to handle inbound and outbound idle connection timeout

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketChannelInitializer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketChannelInitializer.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.inbound.endpoint.protocol.websocket.ssl.InboundWebsocketSSLConfiguration;
@@ -42,6 +43,8 @@ public class InboundWebsocketChannelInitializer extends ChannelInitializer<Socke
     private boolean dispatchToCustomSequence;
     private ArrayList<AbstractSubprotocolHandler> subprotocolHandlers;
     private int portOffset;
+    private int inflowIdleTime;
+    private int outflowIdleTime;
 
     public InboundWebsocketChannelInitializer() {
     }
@@ -74,6 +77,14 @@ public class InboundWebsocketChannelInitializer extends ChannelInitializer<Socke
         this.subprotocolHandlers = subprotocolHandlers;
     }
 
+    public void setInflowIdleTime(int inflowIdleTime) {
+        this.inflowIdleTime = inflowIdleTime;
+    }
+
+    public void setOutflowIdleTime(int outflowIdleTime) {
+        this.outflowIdleTime = outflowIdleTime;
+    }
+
     @Override
     protected void initChannel(SocketChannel websocketChannel) throws Exception {
 
@@ -86,6 +97,7 @@ public class InboundWebsocketChannelInitializer extends ChannelInitializer<Socke
         p.addLast("codec", new HttpServerCodec());
         p.addLast("aggregator", new HttpObjectAggregator(65536));
         p.addLast("frameAggregator", new WebSocketFrameAggregator(Integer.MAX_VALUE));
+        p.addLast("idleStateHandler", new IdleStateHandler(inflowIdleTime, outflowIdleTime, 0));
         InboundWebsocketSourceHandler sourceHandler = new InboundWebsocketSourceHandler();
         sourceHandler.setClientBroadcastLevel(clientBroadcastLevel);
         sourceHandler.setDispatchToCustomSequence(dispatchToCustomSequence);

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConfiguration.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConfiguration.java
@@ -30,6 +30,8 @@ public class InboundWebsocketConfiguration {
     private String pipelineHandler;
     private String dispatchToCustomSequence;
     private final boolean usePortOffset;
+    private int inflowIdleTime;
+    private int outflowIdleTime;
 
     private InboundWebsocketConfiguration(InboundWebsocketConfigurationBuilder builder) {
         this.port = builder.port;
@@ -44,6 +46,8 @@ public class InboundWebsocketConfiguration {
         this.pipelineHandler = builder.pipelineHandler;
         this.dispatchToCustomSequence = builder.dispatchToCustomSequence;
         this.usePortOffset = builder.usePortOffset;
+        this.inflowIdleTime = builder.inflowIdleTime;
+        this.outflowIdleTime = builder.outflowIdleTime;
     }
 
     public int getPort() {
@@ -94,6 +98,14 @@ public class InboundWebsocketConfiguration {
         return usePortOffset;
     }
 
+    public int getInflowIdleTime() {
+        return inflowIdleTime;
+    }
+
+    public int getOutflowIdleTime() {
+        return outflowIdleTime;
+    }
+
     public static class InboundWebsocketConfigurationBuilder {
         private final int port;
         private final String name;
@@ -107,6 +119,8 @@ public class InboundWebsocketConfiguration {
         private String pipelineHandler;
         private String dispatchToCustomSequence;
         private boolean usePortOffset = false;
+        private int inflowIdleTime;
+        private int outflowIdleTime;
 
         public InboundWebsocketConfigurationBuilder(int port, String name) {
             this.port = port;
@@ -164,6 +178,16 @@ public class InboundWebsocketConfiguration {
 
         public InboundWebsocketConfigurationBuilder usePortOffset(boolean usePortOffset) {
             this.usePortOffset = usePortOffset;
+            return this;
+        }
+
+        public InboundWebsocketConfigurationBuilder inflowIdleTime(int inflowIdleTime) {
+            this.inflowIdleTime = inflowIdleTime;
+            return this;
+        }
+
+        public InboundWebsocketConfigurationBuilder outflowIdleTime(int outflowIdleTime) {
+            this.outflowIdleTime = outflowIdleTime;
             return this;
         }
     }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
@@ -77,4 +77,7 @@ public class InboundWebsocketConstants {
 
     public static final String INBOUND_PIPELINE_HANDLER_CLASS = "ws.pipeline.handler.class";
     public static final String CUSTOM_SEQUENCE = "dispatch.custom.sequence";
+
+    public static final String WEBSOCKET_DISPATCH_IDLETIME = "ws.dispatch.idleTime";
+    public static final String WEBSOCKET_OUTFLOW_DISPATCH_IDLETIME = "ws.outflow.dispatch.idleTime";
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/management/WebsocketEndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/management/WebsocketEndpointManager.java
@@ -258,10 +258,10 @@ public class WebsocketEndpointManager extends AbstractInboundEndpointManager {
                         InboundWebsocketConstants.CUSTOM_SEQUENCE))
                 .usePortOffset(Boolean.valueOf(params.getProperties().getProperty(
                         InboundWebsocketConstants.WEBSOCKET_USE_PORT_OFFSET)))
-                .inflowIdleTime(Integer.valueOf(params.getProperties()
-                        .getProperty(InboundWebsocketConstants.WEBSOCKET_DISPATCH_IDLETIME)))
-                .outflowIdleTime(Integer.valueOf(params.getProperties()
-                        .getProperty(InboundWebsocketConstants.WEBSOCKET_OUTFLOW_DISPATCH_IDLETIME)))
+                .inflowIdleTime(Integer.parseInt(params.getProperties()
+                        .getProperty(InboundWebsocketConstants.WEBSOCKET_DISPATCH_IDLETIME, "0")))
+                .outflowIdleTime(Integer.parseInt(params.getProperties()
+                        .getProperty(InboundWebsocketConstants.WEBSOCKET_OUTFLOW_DISPATCH_IDLETIME, "0")))
                 .build();
     }
 

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/management/WebsocketEndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/management/WebsocketEndpointManager.java
@@ -141,6 +141,8 @@ public class WebsocketEndpointManager extends AbstractInboundEndpointManager {
         handler.setPipelineHandler(PipelineHandlerBuilderUtil.stringToPipelineHandlers(config.getPipelineHandler()));
         handler.setDispatchToCustomSequence(config.getDispatchToCustomSequence());
         handler.setPortOffset(PersistenceUtils.getPortOffset(params.getProperties()));
+        handler.setInflowIdleTime(config.getInflowIdleTime());
+        handler.setOutflowIdleTime(config.getOutflowIdleTime());
         bootstrap.childHandler(handler);
         try {
             bootstrap.bind(new InetSocketAddress(port)).sync();
@@ -176,6 +178,8 @@ public class WebsocketEndpointManager extends AbstractInboundEndpointManager {
         handler.setPipelineHandler(PipelineHandlerBuilderUtil.stringToPipelineHandlers(config.getPipelineHandler()));
         handler.setDispatchToCustomSequence(config.getDispatchToCustomSequence());
         handler.setPortOffset(PersistenceUtils.getPortOffset(params.getProperties()));
+        handler.setInflowIdleTime(config.getInflowIdleTime());
+        handler.setOutflowIdleTime(config.getOutflowIdleTime());
         bootstrap.childHandler(handler);
         try {
             bootstrap.bind(new InetSocketAddress(port)).sync();
@@ -254,6 +258,10 @@ public class WebsocketEndpointManager extends AbstractInboundEndpointManager {
                         InboundWebsocketConstants.CUSTOM_SEQUENCE))
                 .usePortOffset(Boolean.valueOf(params.getProperties().getProperty(
                         InboundWebsocketConstants.WEBSOCKET_USE_PORT_OFFSET)))
+                .inflowIdleTime(Integer.valueOf(params.getProperties()
+                        .getProperty(InboundWebsocketConstants.WEBSOCKET_DISPATCH_IDLETIME)))
+                .outflowIdleTime(Integer.valueOf(params.getProperties()
+                        .getProperty(InboundWebsocketConstants.WEBSOCKET_OUTFLOW_DISPATCH_IDLETIME)))
                 .build();
     }
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/12444

## Approach
Refer https://netty.io/4.0/api/io/netty/handler/timeout/IdleStateHandler.html for more information regarding these params.

Considering the event time in seconds,
* For inbound WS calls, override `apim.ws.dispatch.idleTime` in deployment.toml
* For inbound WSS calls, override `apim.wss.dispatch.idleTime` in deployment.toml
* For outbound WS calls, override `apim.ws.outflow.dispatch.idleTime` in deployment.toml
* For outbound WSS calls, override `apim.wss.outflow.dispatch.idleTime` in deployment.toml

You may have to override the "userEventTriggered" of "WebsocketHandler" class after extending from it.

Example:

An example that terminates when there is no outbound traffic and inbound traffic based on the param values set above

```java
package com.bnymellon.ess.wso2.apimgt.gateway.handlers;

import io.netty.channel.ChannelHandlerContext;
import io.netty.handler.timeout.IdleState;
import io.netty.handler.timeout.IdleStateEvent;
import org.apache.commons.logging.Log;
import org.apache.commons.logging.LogFactory;
import org.wso2.carbon.apimgt.gateway.handlers.WebsocketHandler;

/**
 * Websocket handler implementing the idle connection timeout netty functions.
 *
 * @since 1.0.0
 */
public class XWebSocketHandler extends WebsocketHandler {

    private static final Log log = LogFactory.getLog(XWebSocketHandler.class);

    @Override
    public void userEventTriggered(ChannelHandlerContext channelHandlerContext, Object event) throws Exception {
        super.userEventTriggered(channelHandlerContext, event);
        if (event instanceof IdleStateEvent) {
            IdleStateEvent idleStateEvent = (IdleStateEvent) event;
            if (idleStateEvent.state() == IdleState.READER_IDLE) {
                channelHandlerContext.close();
            }
            if (idleStateEvent.state() == IdleState.WRITER_IDLE) {
                channelHandlerContext.close();
            }
        }
    }
}

```