### PR TITLE
Close WS client connection upon target connection failure.

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/pom.xml
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/pom.xml
@@ -95,5 +95,9 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.mediation</groupId>
+            <artifactId>org.wso2.carbon.inbound.endpoint</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -58,4 +58,6 @@ public class WebsocketConstants {
     public static final String WEBSOCKET_SUBPROTOCOL = "websocket.subprotocol";
 
     public static final String CONNECTION_TERMINATE = "connection.terminate";
+
+    public static final int WEBSOCKET_UPSTREAM_ERROR_SC = 1014;
 }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.websocket.transport;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import org.apache.axiom.om.OMOutputFormat;
@@ -39,12 +40,15 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.inbound.InboundEndpointConstants;
 import org.apache.synapse.inbound.InboundResponseSender;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.wso2.carbon.inbound.endpoint.protocol.websocket.InboundWebsocketResponseSender;
+import org.wso2.carbon.inbound.endpoint.protocol.websocket.InboundWebsocketSourceHandler;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.websocket.transport.utils.LogUtil;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
+import java.net.ConnectException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -229,12 +233,28 @@ public class WebsocketTransportSender extends AbstractTransportSender {
             }
         } catch (URISyntaxException e) {
             log.error("Error parsing the WS endpoint url", e);
+        } catch (ConnectException e) {
+            handleClientConnectionError(responseSender, e);
         } catch (IOException e) {
-            log.error("Error writting to the websocket channel", e);
+            log.error("Error writing to the websocket channel", e);
         } catch (InterruptedException e) {
-            log.error("Error writting to the websocket channel", e);
+            log.error("Error writing to the websocket channel", e);
         } catch (XMLStreamException e) {
             handleException("Error while building message", e);
+        }
+    }
+
+    private void handleClientConnectionError(InboundResponseSender responseSender, Exception e) {
+
+        log.error("Error writing to the websocket channel", e);
+        // we will close the client connection and notify with close frame
+        InboundWebsocketSourceHandler sourceHandler = ((InboundWebsocketResponseSender) responseSender).getSourceHandler();
+        CloseWebSocketFrame closeWebSocketFrame = new CloseWebSocketFrame(WebsocketConstants.WEBSOCKET_UPSTREAM_ERROR_SC,
+                e.getMessage());
+        try {
+            sourceHandler.handleClientWebsocketChannelTermination(closeWebSocketFrame);
+        } catch (AxisFault fault) {
+            log.error("Error occurred while sending close frames", fault);
         }
     }
 }


### PR DESCRIPTION
## Purpose
> When the web-socket backend becomes unavailable, the corresponding WS client connection needs to be terminated.
> Fixes: https://github.com/wso2/micro-integrator/issues/2657