### PR TITLE
Stop query parameter deletion from swagger upon update.

### DIFF
--- a/components/mediation-commons/src/main/java/org/wso2/carbon/mediation/commons/rest/api/swagger/OpenAPIProcessor.java
+++ b/components/mediation-commons/src/main/java/org/wso2/carbon/mediation/commons/rest/api/swagger/OpenAPIProcessor.java
@@ -444,7 +444,7 @@ public class OpenAPIProcessor {
                     }
                     // remove deleted parameters from swagger
                     if (newParameter.size() > 0) {
-                        parameters.removeIf(c -> !newParameter.contains(c));
+                        parameters.removeIf(c -> !newParameter.contains(c) && (c instanceof PathParameter));
                     }
                 } else {
                     populateParameters(pathItem, methodMap);


### PR DESCRIPTION
## Purpose
> Only path parameters need to be deleted upon update. Query parameters cannot be deleted as they do not exist in the URL.