### PR TITLE
Add log service for synapse to bridge synpase and kernel

### DIFF
--- a/components/mediation-commons/pom.xml
+++ b/components/mediation-commons/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>synapse-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>

--- a/components/mediation-commons/src/main/java/org/wso2/carbon/mediation/commons/correlation/SynapseConfigurableCorrelationLogService.java
+++ b/components/mediation-commons/src/main/java/org/wso2/carbon/mediation/commons/correlation/SynapseConfigurableCorrelationLogService.java
@@ -1,0 +1,47 @@
+/*
+ *   Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *   WSO2 LLC. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.mediation.commons.correlation;
+
+import org.apache.synapse.transport.passthru.config.PassThroughCorrelationConfigDataHolder;
+import org.osgi.service.component.annotations.Component;
+import org.wso2.carbon.logging.correlation.CorrelationLogConfigurable;
+import org.wso2.carbon.logging.correlation.bean.ImmutableCorrelationLogConfig;
+
+@Component(
+        immediate = true,
+        service = CorrelationLogConfigurable.class
+)
+public class SynapseConfigurableCorrelationLogService implements CorrelationLogConfigurable {
+
+    @Override
+    public String getName() {
+        return "synapse";
+    }
+
+    @Override
+    public ImmutableCorrelationLogConfig getConfiguration() {
+        return new ImmutableCorrelationLogConfig(PassThroughCorrelationConfigDataHolder.isEnable(),
+                new String[0], false);
+    }
+
+    @Override
+    public void onConfigure(ImmutableCorrelationLogConfig immutableCorrelationLogConfig) {
+        PassThroughCorrelationConfigDataHolder.setEnable(immutableCorrelationLogConfig.isEnable());
+    }
+}


### PR DESCRIPTION
## Purpose
> Fix: wso2/api-manager#275
> Fix: wso2/api-manager#340

## Approach
> A correlation log service component is added to bridge between the carbon kernel layer and the synapse layer. 
This will enable the correlation log manager in the carbon kernel to manipulate the correlation config dataholder for synapse pass through transport in the synapse layer

