### PR TITLE
Websocket abrupt server closure to client

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
@@ -238,10 +238,6 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
                                           + Thread.currentThread().getId());
                     }
                     handleTargetWebsocketChannelTermination(frame);
-                    if (log.isDebugEnabled()) {
-                        log.debug("Invoking fault sequence due to a CloseWebSocketFrame from the server");
-                    }
-                    invokeFaultSequenceUponServerShutdown();
                     return;
                 } else if ((frame instanceof BinaryWebSocketFrame) && ((handshaker.actualSubprotocol() == null) ||
                         ((handshaker.actualSubprotocol() != null) &&

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
@@ -130,6 +130,9 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
         }
         if (evt instanceof ChannelInputShutdownEvent) {
             try {
+                if (log.isDebugEnabled()) {
+                    log.debug("Invoking fault sequence due to a ChannelInputShutdownEvent");
+                }
                 invokeFaultSequenceUponServerShutdown();
             } catch (AxisFault axisFault) {
                 log.error("Failed to invoke fault sequence during ChannelInputShutdownEvent", axisFault);
@@ -235,6 +238,9 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
                                           + Thread.currentThread().getId());
                     }
                     handleTargetWebsocketChannelTermination(frame);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Invoking fault sequence due to a CloseWebSocketFrame from the server");
+                    }
                     invokeFaultSequenceUponServerShutdown();
                     return;
                 } else if ((frame instanceof BinaryWebSocketFrame) && ((handshaker.actualSubprotocol() == null) ||

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -23,6 +23,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -247,6 +248,7 @@ public class WebsocketConnectionFactory {
                     });
 
             Channel ch = b.connect(uri.getHost(), port).sync().channel();
+            ch.config().setOption(ChannelOption.ALLOW_HALF_CLOSURE, true);
             ch.closeFuture().addListener(new ChannelFutureListener() {
                 @Override
                 public void operationComplete(ChannelFuture channelFuture) throws Exception {

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
@@ -82,4 +82,9 @@ public class InboundWebsocketConstants {
     public static final String WEBSOCKET_DISPATCH_IDLETIME = "ws.dispatch.idleTime";
     public static final String WEBSOCKET_OUTFLOW_DISPATCH_IDLETIME = "ws.outflow.dispatch.idleTime";
     public static final String CUSTOM_HTTP_SC = "CUSTOM_HTTP_SC";
+
+    public static final String CLOSE_WEBSOCKET_CLIENT_ON_SERVER_TERMINATION =
+            "close.websocket.client.on.server.termination";
+    public static final String FAULT_SEQUENCE_INVOKED_ON_WEBSOCKET_CHANNEL_INPUT_SHUTDOWN_EVENT =
+            "fault.sequence.invoked.on.websocket.channel.input.shutdown.event";
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketResponseSender.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketResponseSender.java
@@ -222,6 +222,9 @@ public class InboundWebsocketResponseSender implements InboundResponseSender {
                                     sourceHandler.getChannelHandlerContext().getChannelHandlerContext(), false);
                         }
                         try {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Terminating the client websocket channel due to server shutdown");
+                            }
                             sourceHandler.handleClientWebsocketChannelTermination(closeWebSocketFrame);
                         } catch (IOException e) {
                             log.error("Failed while handling client websocket channel termination", e);

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketResponseSender.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketResponseSender.java
@@ -212,10 +212,6 @@ public class InboundWebsocketResponseSender implements InboundResponseSender {
                         InboundWebsocketConstants.FAULT_SEQUENCE_INVOKED_ON_WEBSOCKET_CHANNEL_INPUT_SHUTDOWN_EVENT);
                 if (Objects.equals(isFaultSequenceInvokedOnChannelInputShutdown, true)) {
                     // Fault sequence was invoked due to a 'ChannelInputShutdownEvent'
-                    if (log.isDebugEnabled()) {
-                        log.debug("Fault sequence was invoked due to a 'ChannelInputShutdownEvent'");
-                    }
-
                     Object shouldCloseClient = msgContext.getProperty(
                             InboundWebsocketConstants.CLOSE_WEBSOCKET_CLIENT_ON_SERVER_TERMINATION);
                     if (shouldCloseClient != null && Boolean.parseBoolean((String) shouldCloseClient)) {


### PR DESCRIPTION
## Purpose
$subject. Fixes https://github.com/wso2/api-manager/issues/675

This is achieved via half-closure in Netty [0] [1].
> allowHalfClosure: 
Sets whether the channel should not close itself when its remote peer shuts down output to make the connection half-closed. If true the connection is not closed when the remote peer shuts down output. Instead, [ChannelInboundHandler.userEventTriggered(ChannelHandlerContext, Object)](https://netty.io/4.1/api/io/netty/channel/ChannelInboundHandler.html#userEventTriggered-io.netty.channel.ChannelHandlerContext-java.lang.Object-) is invoked with a [ChannelInputShutdownEvent](https://netty.io/4.1/api/io/netty/channel/socket/ChannelInputShutdownEvent.html) object. If false, the connection is closed automatically.

### Activating WS Client Closure upon Server Shutdown
Users **must** set the following property in the `fault` sequence, if websocket client should be closed upon server shutdown. The default value of this will be taken as `false`.
```xml
<property name="close.websocket.client.on.server.termination" value="true"/>
```

## Approach
1. We first set `ALLOW_HALF_CLOSURE` to true, when creating the channel at [2].
2. Upon server shutdown, the `userEventTriggered` method will get hit [3], with a `ChannelInputShutdownEvent`. Then the fault sequence will be triggered.
3. At [4], we send a close frame to the client, **only if** `close.websocket.client.on.server.termination` has been set to `true`.

## Change in default behaviour after server shutdown
### Existing behaviour
Previously (without half-closure and `close.websocket.client.on.server.termination`), a server shutdown showed the following sequence of events.
- Server port: 8080
- Client port: 60061
```
<server shutdown>
1. Port occupied by the WS server (8080) is closed. (client is still open)
2. Client sends `msg1` (60061 -> 9099).
3. Client connection is closed.
```
![Screen Shot 2022-08-22 at 4 48 03 PM](https://user-images.githubusercontent.com/24828296/185909547-f8a90f1a-3fd6-4327-90a5-86bb0d51b97b.png)


### New behaviour
Current default behaviour (with half-closure, and without `close.websocket.client.on.server.termination`)
- Server port: 8080
- Client port: 60257
```
<server shutdown>
1. Port occupied by the WS server (eg: 8080) is still open, and the Client it still open.
2. Client sends `msg1` (60257 -> 9099).
3. `msg1` reaches port 8080 (60258 -> 8080).
4. Client sends `msg2` (60257 -> 9099).
5. Port occupied by the WS server (eg: 8080) is now closed.
6. Client sends `msg3` (60257 -> 9099).
7. Client connection is closed.
```
![new-behaviour](https://user-images.githubusercontent.com/24828296/185909494-378b3724-c99e-4fa3-9b49-8ebb1ba6eac7.png)


[0] https://netty.io/4.1/api/io/netty/channel/socket/DuplexChannelConfig.html#setAllowHalfClosure-boolean-
[1] https://netty.io/wiki/new-and-noteworthy-in-4.0.html#half-closed-sockets
[2] https://github.com/senthuran16/carbon-mediation/blob/9e22045334e91dc6de3ba4d61a3730a9b830b7e7/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java#L251
[3] https://github.com/senthuran16/carbon-mediation/blob/9e22045334e91dc6de3ba4d61a3730a9b830b7e7/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java#L131
[4] https://github.com/senthuran16/carbon-mediation/blob/9e22045334e91dc6de3ba4d61a3730a9b830b7e7/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketResponseSender.java#L213