### PR TITLE
Add pass through control frames support

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -38,6 +38,11 @@ public class WebsocketConstants {
     public static final String WEBSOCKET_BINARY_FRAME_PRESENT = "websocket.binary.frame.present";
     public static final String WEBSOCKET_BINARY_FRAME = "websocket.binary.frame";
 
+    public static final String WEBSOCKET_PING_FRAME_PRESENT = "websocket.ping.frame.present";
+    public static final String WEBSOCKET_PING_FRAME = "websocket.ping.frame";
+    public static final String WEBSOCKET_PONG_FRAME_PRESENT = "websocket.pong.frame.present";
+    public static final String WEBSOCKET_PONG_FRAME = "websocket.pong.frame";
+
     public static final String WEBSOCKET_TEXT_FRAME_PRESENT = "websocket.text.frame.present";
     public static final String WEBSOCKET_TEXT_FRAME = "websocket.text.frame";
 
@@ -58,6 +63,12 @@ public class WebsocketConstants {
     public static final String WEBSOCKET_SUBPROTOCOL = "websocket.subprotocol";
 
     public static final String CONNECTION_TERMINATE = "connection.terminate";
+    public static final String WEBSOCKET_CLOSE_CODE = "websocket.close.code";
+
+    public static final String WEBSOCKET_REASON_TEXT = "websocket.reason.text";
+
+    public static final int WS_CLOSE_DEFAULT_CODE = 1001;
+    public static final String WS_CLOSE_DEFAULT_REASON_TEXT = "Websocket server terminated";
 
     public static final int WEBSOCKET_UPSTREAM_ERROR_SC = 1014;
 }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/test/java/org/wso2/carbon/websocket/transport/WebSocketClientHandlerTest.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/test/java/org/wso2/carbon/websocket/transport/WebSocketClientHandlerTest.java
@@ -47,6 +47,8 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.inbound.endpoint.protocol.websocket.InboundWebsocketConstants;
+import org.wso2.carbon.inbound.endpoint.protocol.websocket.InboundWebsocketSourceHandler;
+import org.wso2.carbon.inbound.endpoint.protocol.websocket.management.WebsocketEndpointManager;
 import org.wso2.carbon.utils.ConfigurationContextService;
 import org.wso2.carbon.websocket.transport.service.ServiceReferenceHolder;
 
@@ -58,7 +60,7 @@ import java.util.HashMap;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ ServiceReferenceHolder.class,
-        MessageContextCreatorForAxis2.class, WebSocketClientHandler.class })
+        MessageContextCreatorForAxis2.class, WebSocketClientHandler.class, WebsocketEndpointManager.class })
 public class WebSocketClientHandlerTest {
 
     private static final Log log = LogFactory.getLog(WebSocketClientHandlerTest.class);
@@ -79,6 +81,13 @@ public class WebSocketClientHandlerTest {
         WebsocketConnectionFactory webSocketClientHandshakerFactory;
         webSocketClientHandshaker = WebSocketClientHandshakerFactory.newHandshaker(new URI("ws://localhost:8000"),
                 WebSocketVersion.V13, null, false, httpHeaders);
+        WebsocketEndpointManager websocketEndpointManager = Mockito.mock(WebsocketEndpointManager.class);
+        PowerMockito.mockStatic(WebsocketEndpointManager.class);
+        Mockito.when(WebsocketEndpointManager.getInstance()).thenReturn(websocketEndpointManager);
+        InboundWebsocketSourceHandler inboundWebsocketSourceHandler = Mockito.mock(InboundWebsocketSourceHandler.class);
+        inboundWebsocketSourceHandler.setPassThroughControlFrames(false);
+        Mockito.when(WebsocketEndpointManager.getInstance().getSourceHandler()).thenReturn(
+                inboundWebsocketSourceHandler);
         webSocketClientHandler = new WebSocketClientHandler(webSocketClientHandshaker);
         webSocketClientHandler.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/pom.xml
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/pom.xml
@@ -120,6 +120,7 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
                             org.wso2.carbon.inbound.endpoint.protocol.websocket,
+                            org.wso2.carbon.inbound.endpoint.protocol.websocket.management,
                             org.wso2.carbon.inbound.endpoint.protocol.http.management,
                             org.wso2.carbon.inbound.endpoint.protocol.http.multitenancy,
                             org.wso2.carbon.inbound.endpoint.protocol.generic,

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketChannelInitializer.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketChannelInitializer.java
@@ -45,6 +45,7 @@ public class InboundWebsocketChannelInitializer extends ChannelInitializer<Socke
     private int portOffset;
     private int inflowIdleTime;
     private int outflowIdleTime;
+    private boolean passThroughControlFrames;
 
     public InboundWebsocketChannelInitializer() {
     }
@@ -85,6 +86,10 @@ public class InboundWebsocketChannelInitializer extends ChannelInitializer<Socke
         this.outflowIdleTime = outflowIdleTime;
     }
 
+    public void setPassThroughControlFrames(boolean passThroughControlFrames) {
+        this.passThroughControlFrames = passThroughControlFrames;
+    }
+
     @Override
     protected void initChannel(SocketChannel websocketChannel) throws Exception {
 
@@ -102,6 +107,7 @@ public class InboundWebsocketChannelInitializer extends ChannelInitializer<Socke
         sourceHandler.setClientBroadcastLevel(clientBroadcastLevel);
         sourceHandler.setDispatchToCustomSequence(dispatchToCustomSequence);
         sourceHandler.setPortOffset(portOffset);
+        sourceHandler.setPassThroughControlFrames(passThroughControlFrames);
         if (outflowDispatchSequence != null)
             sourceHandler.setOutflowDispatchSequence(outflowDispatchSequence);
         if (outflowErrorSequence != null)

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConfiguration.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConfiguration.java
@@ -32,6 +32,7 @@ public class InboundWebsocketConfiguration {
     private final boolean usePortOffset;
     private int inflowIdleTime;
     private int outflowIdleTime;
+    private boolean passThroughControlFrames;
 
     private InboundWebsocketConfiguration(InboundWebsocketConfigurationBuilder builder) {
         this.port = builder.port;
@@ -48,6 +49,7 @@ public class InboundWebsocketConfiguration {
         this.usePortOffset = builder.usePortOffset;
         this.inflowIdleTime = builder.inflowIdleTime;
         this.outflowIdleTime = builder.outflowIdleTime;
+        this.passThroughControlFrames = builder.passThroughControlFrames;
     }
 
     public int getPort() {
@@ -106,6 +108,10 @@ public class InboundWebsocketConfiguration {
         return outflowIdleTime;
     }
 
+    public boolean passThroughControlFrames() {
+        return passThroughControlFrames;
+    }
+
     public static class InboundWebsocketConfigurationBuilder {
         private final int port;
         private final String name;
@@ -121,6 +127,7 @@ public class InboundWebsocketConfiguration {
         private boolean usePortOffset = false;
         private int inflowIdleTime;
         private int outflowIdleTime;
+        private boolean passThroughControlFrames = false;
 
         public InboundWebsocketConfigurationBuilder(int port, String name) {
             this.port = port;
@@ -190,6 +197,12 @@ public class InboundWebsocketConfiguration {
             this.outflowIdleTime = outflowIdleTime;
             return this;
         }
+
+        public InboundWebsocketConfigurationBuilder passThroughControlFrames(boolean passThroughControlFrames) {
+            this.passThroughControlFrames = passThroughControlFrames;
+            return this;
+        }
+
     }
 
 }

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
@@ -45,8 +45,17 @@ public class InboundWebsocketConstants {
     public static final String WEBSOCKET_BINARY_FRAME_PRESENT = "websocket.binary.frame.present";
     public static final String WEBSOCKET_BINARY_FRAME = "websocket.binary.frame";
 
+    public static final String WEBSOCKET_PING_FRAME_PRESENT = "websocket.ping.frame.present";
+    public static final String WEBSOCKET_PING_FRAME = "websocket.ping.frame";
+    public static final String WEBSOCKET_PONG_FRAME_PRESENT = "websocket.pong.frame.present";
+    public static final String WEBSOCKET_PONG_FRAME = "websocket.pong.frame";
+
     public static final String WEBSOCKET_TEXT_FRAME_PRESENT = "websocket.text.frame.present";
     public static final String WEBSOCKET_TEXT_FRAME = "websocket.text.frame";
+
+    public static final String WEBSOCKET_CLOSE_CODE = "websocket.close.code";
+    public static final String WEBSOCKET_CLOSE_CLIENT = "websocket.close.client";
+    public static final String WEBSOCKET_REASON_TEXT = "websocket.reason.text";
 
     public static final String WEBSOCKET_CLIENT_SIDE_BROADCAST_LEVEL = "ws.client.side.broadcast.level";
     public static final String WEBSOCKET_USE_PORT_OFFSET = "ws.use.port.offset";
@@ -55,6 +64,7 @@ public class InboundWebsocketConstants {
     public static final String WEBSOCKET_OUTFLOW_DISPATCH_FAULT_SEQUENCE = "ws.outflow.dispatch.fault.sequence";
 
     public static final String INBOUND_SUBPROTOCOL_HANDLER_CLASS = "ws.subprotocol.handler.class";
+    public static final String PASS_THROUGH_CONTROL_FRAMES = "ws.pass.through.control.frames";
     public static final String INBOUND_DEFAULT_CONTENT_TYPE = "ws.default.content.type";
     public static final String WEBSOCKET_SUBPROTOCOL = "websocket.subprotocol";
 

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/management/WebsocketEndpointManager.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/management/WebsocketEndpointManager.java
@@ -143,6 +143,7 @@ public class WebsocketEndpointManager extends AbstractInboundEndpointManager {
         handler.setPortOffset(PersistenceUtils.getPortOffset(params.getProperties()));
         handler.setInflowIdleTime(config.getInflowIdleTime());
         handler.setOutflowIdleTime(config.getOutflowIdleTime());
+        handler.setPassThroughControlFrames(config.passThroughControlFrames());
         bootstrap.childHandler(handler);
         try {
             bootstrap.bind(new InetSocketAddress(port)).sync();
@@ -180,6 +181,7 @@ public class WebsocketEndpointManager extends AbstractInboundEndpointManager {
         handler.setPortOffset(PersistenceUtils.getPortOffset(params.getProperties()));
         handler.setInflowIdleTime(config.getInflowIdleTime());
         handler.setOutflowIdleTime(config.getOutflowIdleTime());
+        handler.setPassThroughControlFrames(config.passThroughControlFrames());
         bootstrap.childHandler(handler);
         try {
             bootstrap.bind(new InetSocketAddress(port)).sync();
@@ -256,12 +258,14 @@ public class WebsocketEndpointManager extends AbstractInboundEndpointManager {
                         InboundWebsocketConstants.INBOUND_PIPELINE_HANDLER_CLASS))
                 .dispatchToCustomSequence(params.getProperties().getProperty(
                         InboundWebsocketConstants.CUSTOM_SEQUENCE))
-                .usePortOffset(Boolean.valueOf(params.getProperties().getProperty(
+                .usePortOffset(Boolean.parseBoolean(params.getProperties().getProperty(
                         InboundWebsocketConstants.WEBSOCKET_USE_PORT_OFFSET)))
                 .inflowIdleTime(Integer.parseInt(params.getProperties()
                         .getProperty(InboundWebsocketConstants.WEBSOCKET_DISPATCH_IDLETIME, "0")))
                 .outflowIdleTime(Integer.parseInt(params.getProperties()
                         .getProperty(InboundWebsocketConstants.WEBSOCKET_OUTFLOW_DISPATCH_IDLETIME, "0")))
+                .passThroughControlFrames(Boolean.parseBoolean(
+                        params.getProperties().getProperty(InboundWebsocketConstants.PASS_THROUGH_CONTROL_FRAMES)))
                 .build();
     }
 


### PR DESCRIPTION
Adds support for pass through control frames.

Adding the below config to the inbound endpoint definition for websockets will make sure that control frames such as Close frames, Ping frames and Pong frames will be passed through between the backend and the client. The default behavior will be to block these frames.

<parameter name="ws.pass.through.control.frames">true</parameter>

> Fix https://github.com/wso2/api-manager/issues/590
> Related PRs: https://github.com/wso2/carbon-apimgt/pull/11625