### PR TITLE
Add implementation to close the websocket client upon exceptionCaught

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
@@ -84,6 +84,8 @@ public class InboundWebsocketConstants {
     public static final String WS_CLOSE_FRAME_STATUS_CODE = "websocket.close.frame.status.code";
     public static final String WS_CLOSE_FRAME_REASON_TEXT = "websocket.close.frame.reason.text";
     public static final int WS_CLOSE_DEFAULT_CODE = 1001;
+    public static final String WS_CLOSE_DEFAULT_TEXT = "Websocket server terminated";
+    public static final String WS_UNEXPECTED_CONNECTION_CLOSURE_TEXT = "Unexpected connection closure";
     public static final int WS_UNAUTHORIZED_CODE = 3000;
 
     public static final String INBOUND_PIPELINE_HANDLER_CLASS = "ws.pipeline.handler.class";
@@ -93,10 +95,10 @@ public class InboundWebsocketConstants {
     public static final String WEBSOCKET_OUTFLOW_DISPATCH_IDLETIME = "ws.outflow.dispatch.idleTime";
     public static final String CUSTOM_HTTP_SC = "CUSTOM_HTTP_SC";
 
-    public static final String CLOSE_WEBSOCKET_CLIENT_ON_SERVER_TERMINATION =
-            "close.websocket.client.on.server.termination";
-    public static final String FAULT_SEQUENCE_INVOKED_ON_WEBSOCKET_CHANNEL_INPUT_SHUTDOWN_EVENT =
-            "fault.sequence.invoked.on.websocket.channel.input.shutdown.event";
+    public static final String CLOSE_WEBSOCKET_CLIENT_ON_CLIENT_HANDLER_ERROR =
+            "close.websocket.client.on.client.handler.error";
+    public static final String FAULT_SEQUENCE_INVOKED_ON_WEBSOCKET_CLIENT_HANDLER_ERROR =
+            "fault.sequence.invoked.on.websocket.client.handler.error";
     public static final String WEB_SOCKET_CLOSE_CODE = "websocket.server.close.code";
     public static final String WEB_SOCKET_REASON_TEXT = "websocket.server.reason.text";
 }


### PR DESCRIPTION
## Purpose
Previously in [PR](https://github.com/wso2/carbon-mediation/pull/1644) we introduced closing the websocket client by calling the fault sequence, when the server is shutdown without sending a closeFrame, using `userEventTriggered` method.

This PR introduces the following changes.

### Change 1
When a websocket connection is established, if we kill the server that is behind the connection using `tcpkill`, it will call the `exceptionCaught` method, and we have to call the fault sequence in that case as well. This PR introduces this particular change.

> **Note:** `exceptionCaught` captures not only server terminations like this, but also cases like `ERROR_CODE = 1009, ERROR_MESSAGE = Message too big` (See PR [2]). 
In any case, at the end of `exceptionCaught` method, we call the fault sequence.

### Change 2
The `close.websocket.client.on.server.termination` property has been renamed as `close.websocket.client.on.client.handler.error`. 
(This is because, since `exceptionCaught` doesn't get hit only for server termination, the old property name doesn't make sense).
This property should be enabled in the `fault` sequence as follows:
```xml
<sequence xmlns="http://ws.apache.org/ns/synapse" name="fault">
    <log level="custom">
        <property name="STATUS" value="Executing default 'fault' sequence"/>
        <property name="ERROR_CODE" expression="get-property('ERROR_CODE')"/>
        <property name="ERROR_MESSAGE" expression="get-property('ERROR_MESSAGE')"/>
    </log>
    <!-- THIS IS THE PROPERTY -->
    <property name="close.websocket.client.on.client.handler.error" value="true"/>

    <filter source="get-property('MESSAGE_FORMAT')" regex="soap1[1-2]">
        <then>
    . . .
```

### Change 3 
Refactoring to accommodate calling fault sequence at both `exceptionCaught` and `userEventTriggered` methods. 

### Goal
Fixes: https://github.com/wso2/api-manager/issues/716