### PR TITLE
Add more API information WebSocket API invocation flows

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
@@ -68,6 +68,8 @@ import org.wso2.carbon.websocket.transport.utils.LogUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> {
     private final WebSocketClientHandshaker handshaker;
@@ -79,6 +81,24 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
     private InboundResponseSender responseSender;
     private String tenantDomain;
     private boolean passThroughControlFrames;
+    private String correlationId;
+    private Map<String, Object> apiProperties = new HashMap<>();
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+    public Map<String, Object> getApiProperties() {
+        return apiProperties;
+    }
+
+    public void setApiProperties(Map<String, Object> apiProperties) {
+        this.apiProperties = apiProperties;
+    }
 
     public void setTenantDomain(String tenantDomain) {
         this.tenantDomain = tenantDomain;
@@ -416,6 +436,8 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
             synCtx.setProperty(SynapseConstants.IS_INBOUND, true);
             synCtx.setProperty(InboundEndpointConstants.INBOUND_ENDPOINT_RESPONSE_WORKER, responseSender);
         }
+        synCtx.setProperty(WebsocketConstants.WEBSOCKET_CORRELATION_ID, correlationId);
+        synCtx.setProperty(WebsocketConstants.API_PROPERTIES, apiProperties);
         synCtx.setProperty(WebsocketConstants.WEBSOCKET_SUBSCRIBER_PATH, handshaker.uri().toString());
         return synCtx;
     }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
@@ -275,7 +275,7 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
 
         try {
             if (log.isDebugEnabled()) {
-                LogUtil.printWebSocketFrame(log, frame, ctx, true);
+                LogUtil.printWebSocketFrame(log, frame, ctx, true, correlationId);
             }
             if (handshaker.isHandshakeComplete()) {
 

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -111,8 +111,10 @@ public class WebsocketConnectionFactory {
                         return null;
                     }
                     if (log.isDebugEnabled()) {
-                        log.debug("Caching new connection with sourceIdentifier " + sourceIdentifier + " in the Thread,"
-                                          + "ID: " + Thread.currentThread().getName() + "," + Thread.currentThread().getId());
+                        log.debug(correlationId + " -- Caching new connection with sourceIdentifier " + sourceIdentifier
+                                + " in the Thread," + "ID: " + Thread.currentThread().getName() + "," + Thread
+                                .currentThread().getId() + " API context: " + apiProperties
+                                .get(WebsocketConstants.API_CONTEXT));
                     }
                     channelHandler = cacheNewConnection(tenantDomain, uri, sourceIdentifier, dispatchSequence, dispatchErrorSequence,
                                                         contentType, wsSubprotocol, headers, inboundResponseSender,
@@ -146,7 +148,8 @@ public class WebsocketConnectionFactory {
                                                      String correlationId,
                                                      Map<String, Object> apiProperties) {
         if (log.isDebugEnabled()) {
-            log.debug("Creating a Connection for the specified WS endpoint.");
+            log.debug(correlationId + " -- Creating a Connection for the specified WS endpoint." + " API context: "
+                    + apiProperties.get(WebsocketConstants.API_CONTEXT));
         }
         final WebSocketClientHandler handler;
 
@@ -335,6 +338,15 @@ public class WebsocketConnectionFactory {
         if (handlerMap == null) {
             return null;
         } else {
+            if (log.isDebugEnabled()) {
+                if (handlerMap.get(clientIdentifier) != null) {
+                    log.debug(handlerMap.get(clientIdentifier).getCorrelationId()
+                            + " -- Fetched channel for on sourceIdentifier: " + sourceIdentifier
+                            + ", clientIdentifier: " + clientIdentifier + ", in the Thread,ID: " + Thread
+                            .currentThread().getName() + "," + Thread.currentThread().getId() + "API Context"
+                            + handlerMap.get(clientIdentifier).getApiProperties().get(WebsocketConstants.API_CONTEXT));
+                }
+            }
             return handlerMap.get(clientIdentifier);
         }
     }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -98,7 +98,9 @@ public class WebsocketConnectionFactory {
                                                     final Map<String, Object> headers,
                                                     final InboundResponseSender inboundResponseSender,
                                                     final String responseDispatchSequence,
-                                                    final String responseErrorSequence) throws InterruptedException {
+                                                    final String responseErrorSequence,
+                                                    final String correlationId,
+                                                    final Map<String, Object> apiProperties) throws InterruptedException {
         WebSocketClientHandler channelHandler = getChannelHandlerFromPool(sourceIdentifier,
                                                                           getClientHandlerIdentifier(uri));
         if (channelHandler == null) {
@@ -114,7 +116,8 @@ public class WebsocketConnectionFactory {
                     }
                     channelHandler = cacheNewConnection(tenantDomain, uri, sourceIdentifier, dispatchSequence, dispatchErrorSequence,
                                                         contentType, wsSubprotocol, headers, inboundResponseSender,
-                                                        responseDispatchSequence, responseErrorSequence);
+                                                        responseDispatchSequence, responseErrorSequence,
+                                                        correlationId, apiProperties);
                 }
             }
         }
@@ -139,7 +142,9 @@ public class WebsocketConnectionFactory {
                                                      Map<String, Object> headers,
                                                      InboundResponseSender inboundResponseSender,
                                                      String responseDispatchSequence,
-                                                     String responseErrorSequence) {
+                                                     String responseErrorSequence,
+                                                     String correlationId,
+                                                     Map<String, Object> apiProperties) {
         if (log.isDebugEnabled()) {
             log.debug("Creating a Connection for the specified WS endpoint.");
         }
@@ -231,7 +236,8 @@ public class WebsocketConnectionFactory {
                         deriveSubprotocol(wsSubprotocol, contentType),
                         false, defaultHttpHeaders));
             }
-
+            handler.setCorrelationId(correlationId);
+            handler.setApiProperties(apiProperties);
             if (tenantDomain != null) {
                 handler.setTenantDomain(tenantDomain);
             } else {

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -28,6 +28,8 @@ public class WebsocketConstants {
 
     public static final String UNIVERSAL_SOURCE_IDENTIFIER = "universal.source.identifier";
     public static final String WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER = "websocket.source.channel.identifier";
+    public static final String WEBSOCKET_CORRELATION_ID = "websocket.correlation.id";
+    public static final String API_PROPERTIES = "API_PROPERTIES";
     public static final String WEBSOCKET_OUTFLOW_DISPATCH_SEQUENCE = "ws.outflow.dispatch.sequence";
     public static final String WEBSOCKET_OUTFLOW_DISPATCH_FAULT_SEQUENCE = "ws.outflow.dispatch.fault.sequence";
     public static final String CONTENT_TYPE = "websocket.accept.contenType";

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -30,6 +30,7 @@ public class WebsocketConstants {
     public static final String WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER = "websocket.source.channel.identifier";
     public static final String WEBSOCKET_CORRELATION_ID = "websocket.correlation.id";
     public static final String API_PROPERTIES = "API_PROPERTIES";
+    public static final String API_CONTEXT = "api.ut.context";
     public static final String WEBSOCKET_OUTFLOW_DISPATCH_SEQUENCE = "ws.outflow.dispatch.sequence";
     public static final String WEBSOCKET_OUTFLOW_DISPATCH_FAULT_SEQUENCE = "ws.outflow.dispatch.fault.sequence";
     public static final String CONTENT_TYPE = "websocket.accept.contenType";

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
@@ -144,9 +144,10 @@ public class WebsocketTransportSender extends AbstractTransportSender {
             isConnectionTerminate = true;
         }
         if (log.isDebugEnabled()) {
-            log.debug("sendMessage triggered with sourceChannel: " + sourceIdentifier + ", websocket sub protocol: "
-                              + wsSubProtocol + ", in the Thread,ID: " + Thread.currentThread().getName() + ","
-                              + Thread.currentThread().getId());
+            log.debug(correlationId + " -- sendMessage triggered with sourceChannel: " + sourceIdentifier
+                    + ", websocket sub protocol: " + wsSubProtocol + ", in the Thread,ID: " + Thread.currentThread()
+                    .getName() + "," + Thread.currentThread().getId() + ", URL: " + targetEPR + " API context: "
+                    + apiProperties.get(WebsocketConstants.API_CONTEXT));
         }
         String tenantDomain = (String) msgCtx.getProperty(MultitenantConstants.TENANT_DOMAIN);
         if (tenantDomain == null) {
@@ -183,7 +184,7 @@ public class WebsocketTransportSender extends AbstractTransportSender {
                 if (headerSplits.length > 1) {
                     customHeaders.put(headerSplits[1], value);
                     if (log.isDebugEnabled()) {
-                        log.debug("Adding Custom Header " + headerSplits[1] + ":" + value);
+                        log.debug(correlationId + " -- Adding Custom Header " + headerSplits[1] + ":" + value);
                     }
                 } else {
                     log.warn("A header identified with having only the websocket custom-header prefix"
@@ -194,9 +195,11 @@ public class WebsocketTransportSender extends AbstractTransportSender {
 
         try {
             if (log.isDebugEnabled()) {
-                log.debug("Fetching a Connection from the WS(WSS) Connection Factory with sourceChannel : "
-                                  + sourceIdentifier + ", in the Thread,ID: " + Thread.currentThread().getName() + ","
-                                  + Thread.currentThread().getId());
+                log.debug(correlationId
+                        + " -- Fetching a Connection from the WS(WSS) Connection Factory with sourceChannel : "
+                        + sourceIdentifier + ", in the Thread,ID: " + Thread.currentThread().getName() + "," + Thread
+                        .currentThread().getId() + ", URL: " + targetEPR + " API context: " + apiProperties
+                        .get(WebsocketConstants.API_CONTEXT));
             }
             WebSocketClientHandler clientHandler = connectionFactory.getChannelHandler(tenantDomain,
                                                                                        new URI(targetEPR),
@@ -212,9 +215,11 @@ public class WebsocketTransportSender extends AbstractTransportSender {
                                                                                        apiProperties);
             if (clientHandler == null && isConnectionTerminate) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Backend connection does not exist. No need to send close frame to backend "
-                                      + "with sourceChannel : " + sourceIdentifier + ", in the Thread,ID: "
-                                      + Thread.currentThread().getName() + "," + Thread.currentThread().getId());
+                    log.debug(
+                            correlationId + " -- Backend connection does not exist. No need to send close frame to backend "
+                                    + "with sourceChannel : " + sourceIdentifier + ", in the Thread,ID: " + Thread
+                                    .currentThread().getName() + "," + Thread.currentThread().getId() + ", URL: "
+                                    + targetEPR + " API context: " + apiProperties.get(WebsocketConstants.API_CONTEXT));
                 }
                 return;
             }
@@ -224,13 +229,14 @@ public class WebsocketTransportSender extends AbstractTransportSender {
                 WebSocketFrame frame = (BinaryWebSocketFrame) msgCtx.getProperty(WebsocketConstants.WEBSOCKET_BINARY_FRAME);
                 try {
                     if (log.isDebugEnabled()) {
-                        log.debug("Sending the binary frame to the WS server on context id : "
+                        log.debug(correlationId + " -- Sending the binary frame to the WS server on context id : "
                                           + clientHandler.getChannelHandlerContext().channel().toString());
                     }
                     if (clientHandler.getChannelHandlerContext().channel().isActive()) {
                         clientHandler.getChannelHandlerContext().channel().writeAndFlush(frame.retain());
                         if (log.isDebugEnabled()) {
-                            LogUtil.printWebSocketFrame(log, frame, clientHandler.getChannelHandlerContext(), false);
+                            LogUtil.printWebSocketFrame(log, frame, clientHandler.getChannelHandlerContext(), false,
+                                    correlationId);
                         }
                     }
                 } finally {
@@ -241,15 +247,17 @@ public class WebsocketTransportSender extends AbstractTransportSender {
                 WebSocketFrame frame = (TextWebSocketFrame) msgCtx.getProperty(WebsocketConstants.WEBSOCKET_TEXT_FRAME);
                 try {
                     if (log.isDebugEnabled()) {
-                        log.debug("Sending the passthrough text frame to the WS server on context id: "
-                                          + clientHandler.getChannelHandlerContext().channel().toString() + ", "
-                                          + ", sourceIdentifier: " + sourceIdentifier + ", in the Thread,ID: "
-                                          + Thread.currentThread().getName() + "," + Thread.currentThread().getId());
+                        log.debug(correlationId + " -- Sending the passthrough text frame to the WS server on context id: "
+                                + clientHandler.getChannelHandlerContext().channel().toString() + ", "
+                                + ", sourceIdentifier: " + sourceIdentifier + ", in the Thread,ID: " + Thread
+                                .currentThread().getName() + "," + Thread.currentThread().getId() + ", URL: "
+                                + targetEPR + " API context: " + apiProperties.get(WebsocketConstants.API_CONTEXT));
                     }
                     if (clientHandler.getChannelHandlerContext().channel().isActive()) {
                         clientHandler.getChannelHandlerContext().channel().writeAndFlush(frame.retain());
                         if (log.isDebugEnabled()) {
-                            LogUtil.printWebSocketFrame(log, frame, clientHandler.getChannelHandlerContext(), false);
+                            LogUtil.printWebSocketFrame(log, frame, clientHandler.getChannelHandlerContext(), false,
+                                    correlationId);
                         }
                     }
                 } finally {
@@ -265,10 +273,11 @@ public class WebsocketTransportSender extends AbstractTransportSender {
             } else if (isConnectionTerminate) {
                 Channel channel = clientHandler.getChannelHandlerContext().channel();
                 if (log.isDebugEnabled()) {
-                    log.debug("Sending CloseWebsocketFrame to WS server on context id: "
-                                      + clientHandler.getChannelHandlerContext().channel().toString() + ", "
-                                      + ", sourceIdentifier: " + sourceIdentifier + ", in the Thread,ID: "
-                                      + Thread.currentThread().getName() + "," + Thread.currentThread().getId());
+                    log.debug(correlationId + " -- Sending CloseWebsocketFrame to WS server on context id: " + clientHandler
+                            .getChannelHandlerContext().channel().toString() + ", " + ", sourceIdentifier: "
+                            + sourceIdentifier + ", in the Thread,ID: " + Thread.currentThread().getName() + "," + Thread
+                            .currentThread().getId() + ", URL: " + targetEPR + " API context: " + apiProperties
+                            .get(WebsocketConstants.API_CONTEXT));
                 }
                 if (msgCtx.getProperty(WebsocketConstants.WEBSOCKET_CLOSE_CODE) != null) {
                     int statusCode = (int) msgCtx.getProperty(WebsocketConstants.WEBSOCKET_CLOSE_CODE);
@@ -291,21 +300,24 @@ public class WebsocketTransportSender extends AbstractTransportSender {
                     final String msg = sw.toString();
                     WebSocketFrame frame = new TextWebSocketFrame(msg);
                     if (log.isDebugEnabled()) {
-                        log.debug("Sending the text frame to the WS server on context id : "
-                                + clientHandler.getChannelHandlerContext().channel().toString());
+                        log.debug(correlationId + " -- Sending the text frame to the WS server on context id : "
+                                + clientHandler.getChannelHandlerContext().channel().toString() + ", URL: " + targetEPR
+                                + " API context: " + apiProperties.get(WebsocketConstants.API_CONTEXT));
                     }
                     if (clientHandler.getChannelHandlerContext().channel().isActive()) {
                         clientHandler.getChannelHandlerContext().channel().writeAndFlush(frame.retain());
                         if (log.isDebugEnabled()) {
-                            LogUtil.printWebSocketFrame(log, frame, clientHandler.getChannelHandlerContext(), false);
+                            LogUtil.printWebSocketFrame(log, frame, clientHandler.getChannelHandlerContext(), false,
+                                    correlationId);
                         }
                     }
                 } else {
                     if (log.isDebugEnabled()) {
-                        log.debug("AcknowledgeHandshake to WS server on context id: "
-                                          + clientHandler.getChannelHandlerContext().channel().toString() + ", "
-                                          + ", sourceIdentifier: " + sourceIdentifier + ", in the Thread,ID: "
-                                          + Thread.currentThread().getName() + "," + Thread.currentThread().getId());
+                        log.debug(correlationId + " -- AcknowledgeHandshake to WS server on context id: " + clientHandler
+                                .getChannelHandlerContext().channel().toString() + ", " + ", sourceIdentifier: "
+                                + sourceIdentifier + ", in the Thread,ID: " + Thread.currentThread().getName() + ","
+                                + Thread.currentThread().getId() + ", URL: " + targetEPR + " API context: "
+                                + apiProperties.get(WebsocketConstants.API_CONTEXT));
                     }
                     clientHandler.acknowledgeHandshake();
                 }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/utils/LogUtil.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/utils/LogUtil.java
@@ -74,9 +74,9 @@ public class LogUtil {
      * @param isInbound true if the frame is inbound, false if it is outbound
      */
     public static void printWebSocketFrame(Log log, WebSocketFrame frame, ChannelHandlerContext ctx,
-                                           String customMsg, boolean isInbound) {
+                                           String customMsg, boolean isInbound, String correlationID) {
         String channelContextId = resolveContextId(ctx);
-        printWebSocketFrame(log, frame, channelContextId, customMsg, isInbound);
+        printWebSocketFrame(log, frame, channelContextId, customMsg, isInbound, correlationID);
     }
 
     /**
@@ -88,9 +88,9 @@ public class LogUtil {
      * @param isInbound true if the frame is inbound, false if it is outbound
      */
     public static void printWebSocketFrame(Log log, WebSocketFrame frame, ChannelHandlerContext ctx,
-                                           boolean isInbound) {
+                                           boolean isInbound, String correlationID) {
         String channelContextId = resolveContextId(ctx);
-        printWebSocketFrame(log, frame, channelContextId, null, isInbound);
+        printWebSocketFrame(log, frame, channelContextId, null, isInbound, correlationID);
     }
 
     /**
@@ -104,7 +104,7 @@ public class LogUtil {
      * @param isInbound        true if the frame is inbound, false if it is outbound
      */
     private static void printWebSocketFrame(Log log, WebSocketFrame frame, String channelContextId,
-                                            String customMsg, boolean isInbound) {
+                                            String customMsg, boolean isInbound, String correlationID) {
 
         String logStatement = getDirectionString(isInbound) + channelContextId;
         if (frame instanceof PingWebSocketFrame) {
@@ -117,6 +117,11 @@ public class LogUtil {
             logStatement += " Binary frame";
         } else if (frame instanceof TextWebSocketFrame) {
             logStatement += " " + ((TextWebSocketFrame) frame).text();
+            if (isInbound) {
+                logStatement = correlationID + " -- Websocket API request [inbound] " + logStatement;
+            } else {
+                logStatement = correlationID + " -- Websocket API request [outbound] " + logStatement;
+            }
         }
 
         //specifically for logging close websocket frames with error status

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketChannelContext.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketChannelContext.java
@@ -46,6 +46,10 @@ public class InboundWebsocketChannelContext {
         return channelIdentifier;
     }
 
+    public String getChannelIdLongText() {
+        return ctx.channel().id().asLongText();
+    }
+
     public void addCloseListener(final ChannelHandlerContext targetCtx) {
         ChannelFuture closeFuture = ctx.channel().closeFuture();
         closeFuture.addListener(new ChannelFutureListener() {

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketConstants.java
@@ -41,6 +41,7 @@ public class InboundWebsocketConstants {
     public static final String WEBSOCKET_TARGET_HANDLER_CONTEXT = "websocket.target.handler.context";
     public static final String WEBSOCKET_SOURCE_HANDLER_CONTEXT = "websocket.source.handler.context";
     public static final String WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER = "websocket.source.channel.identifier";
+    public static final String WEBSOCKET_CORRELATION_ID = "websocket.correlation.id";
 
     public static final String WEBSOCKET_BINARY_FRAME_PRESENT = "websocket.binary.frame.present";
     public static final String WEBSOCKET_BINARY_FRAME = "websocket.binary.frame";

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketSourceHandler.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketSourceHandler.java
@@ -684,6 +684,9 @@ public class InboundWebsocketSourceHandler extends ChannelInboundHandlerAdapter 
                 .setProperty(InboundWebsocketConstants.WEBSOCKET_SOURCE_HANDLER_CONTEXT, wrappedContext.getChannelHandlerContext());
         synCtx.setProperty(InboundWebsocketConstants.WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER,
                 wrappedContext.getChannelIdentifier());
+        ((Axis2MessageContext) synCtx).getAxis2MessageContext()
+                .setProperty(InboundWebsocketConstants.WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER,
+                        wrappedContext.getChannelIdentifier());
         synCtx.setProperty(InboundWebsocketConstants.WEBSOCKET_CORRELATION_ID, wrappedContext.getChannelIdLongText());
         ((Axis2MessageContext) synCtx).getAxis2MessageContext()
                 .setProperty(InboundWebsocketConstants.WEBSOCKET_CORRELATION_ID, wrappedContext.getChannelIdLongText());

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketSourceHandler.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/InboundWebsocketSourceHandler.java
@@ -684,9 +684,9 @@ public class InboundWebsocketSourceHandler extends ChannelInboundHandlerAdapter 
                 .setProperty(InboundWebsocketConstants.WEBSOCKET_SOURCE_HANDLER_CONTEXT, wrappedContext.getChannelHandlerContext());
         synCtx.setProperty(InboundWebsocketConstants.WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER,
                 wrappedContext.getChannelIdentifier());
+        synCtx.setProperty(InboundWebsocketConstants.WEBSOCKET_CORRELATION_ID, wrappedContext.getChannelIdLongText());
         ((Axis2MessageContext) synCtx).getAxis2MessageContext()
-                .setProperty(InboundWebsocketConstants.WEBSOCKET_SOURCE_CHANNEL_IDENTIFIER,
-                        wrappedContext.getChannelIdentifier());
+                .setProperty(InboundWebsocketConstants.WEBSOCKET_CORRELATION_ID, wrappedContext.getChannelIdLongText());
         if (outflowDispatchSequence != null) {
             synCtx.setProperty(InboundWebsocketConstants.WEBSOCKET_OUTFLOW_DISPATCH_SEQUENCE, outflowDispatchSequence);
             ((Axis2MessageContext) synCtx).getAxis2MessageContext()

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/WebsocketLogUtil.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/websocket/WebsocketLogUtil.java
@@ -118,6 +118,11 @@ public class WebsocketLogUtil {
             logStatement += " Binary frame";
         } else if (frame instanceof TextWebSocketFrame) {
             logStatement += " " + ((TextWebSocketFrame) frame).text();
+            if (isInbound) {
+                logStatement = "Websocket API request [inbound] " + logStatement;
+            } else {
+                logStatement = "Websocket API request [outbound] " + logStatement;
+            }
         }
 
         //specifically for logging close websocket frames with error status


### PR DESCRIPTION
### Purpose
To add more information in the response path in WebSocket API invocations and add more debug logs to print in WebSocket API invocation flows.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/567
Fixes: https://github.com/wso2/api-manager/issues/540

### Approach
- Added channel Id for the entire channel (one per each WebSocket connection). We will expose this channelId as a synapse property and from the customer's WebSocket log handler. This ID can be logged with every frame. All the Websocket frames that are passing through this channel will bear this ID.

Please note that this ID is not unique to each frame that we send in a channel, but is common to all the frames **but unique for a channel.**

- Besides that API_PROPRTIES map is also added as a synapse property

#### To test the fix I followed the below approach
Logged information via log mediator:
`[2022-09-02 10:07:14,340]  INFO - LogMediator OUT = correaltion ID - b0a460fffedf69ed-0005f6d4-00000002-920b80a2091c1824-528d9de4, OUT = API property - {api.ut.api=ifelseWebSocket, api.ut.version=1.0.0, api.ut.context=/ifelse/1.0.0, api.ut.apiPublisher=admin, api.ut.userId=admin@carbon.super, api.ut.application.name=DefaultApplication, api.ut.consumerKey=KqsyTBLWZ0njCZtc6Uuv8gZNYSEa, api.ut.api_version=ifelseWebSocket:v1.0.0, api.ut.userName=admin@carbon.super, api.ut.api_type=API, api.ut.hostName=localhost, api.ut.application.id=1}, OUT = path - ws://ws.ifelse.io:80`

Out sequence XML changes(please note that the API_PROPERTIES map is printed in the log by patching the code with map.toString()) :
```
<log level="custom">
      <property name="OUT" expression="fn:concat('correaltion ID - ',get-property('websocket.correlation.id'))"/>
      <property name="OUT" expression="fn:concat('API property - ',get-property('API_PROPERTIES'))"/>
      <property name="OUT" expression="fn:concat('path - ',get-property('websocket.subscriber.path'))"/>
 </log>
```
- Added the correlationId and API context to the debug logs where those data are available.
- Furthermore, this has updated the debug logs specific to in and out flows with inbound and outbound tags.