### PR TITLE
Remove additional reference count release during ping websocket frame read

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebSocketClientHandler.java
@@ -318,7 +318,6 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
                                               + ", in the Thread,ID: " + Thread.currentThread().getName() + ","
                                               + Thread.currentThread().getId());
                         }
-                        ReferenceCountUtil.release(frame);
                     }
                 } else if (frame instanceof PongWebSocketFrame) {
                     if (passThroughControlFrames) {
@@ -337,7 +336,6 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
                                               + ", in the Thread,ID: " + Thread.currentThread().getName() + ","
                                               + Thread.currentThread().getId());
                         }
-                        ReferenceCountUtil.release(frame);
                     }
                 } else if ((frame instanceof TextWebSocketFrame) && ((handshaker.actualSubprotocol() == null) ||
                         ((handshaker.actualSubprotocol() != null) &&


### PR DESCRIPTION
## Purpose
fix https://github.com/wso2/api-manager/issues/1122

With the changes of https://github.com/wso2/carbon-mediation/pull/1648/files, we are releasing the reference counter when a ping websocket frame is received to WebsocketClientHandler. However WebsocketClientHandler extends the SimpleChannelInboundHandler.

If `SimpleChannelInboundHandler` is used no need to anything special to release of resources. It releases resources automatically. Should not store references to any message for later use, those become invalid. 