### PR TITLE
Add aged connection timeout mechanism to connector core

### DIFF
--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/pool/Configuration.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/pool/Configuration.java
@@ -26,6 +26,8 @@ public class Configuration {
     private Integer maxIdleConnections;
     private Integer minIdleConnections;
     private Long maxWaitTime;
+    private long poolConnectionAgedTimeout = 0;
+    private boolean isAgedTimeoutEnabled = false;
     private Long minEvictionTime;
     private Long evictionCheckInterval;
     private String exhaustedAction;
@@ -153,5 +155,22 @@ public class Configuration {
     public void setSoftMinEvictableIdleTimeMillis(Long softMinEvictableIdleTimeMillis) {
 
         this.softMinEvictableIdleTimeMillis = softMinEvictableIdleTimeMillis;
+    }
+
+
+    public long getPoolConnectionAgedTimeout() {
+        return poolConnectionAgedTimeout;
+    }
+
+    public void setPoolConnectionAgedTimeout(long poolConnectionAgedTimeout) {
+        this.poolConnectionAgedTimeout = poolConnectionAgedTimeout;
+    }
+
+    public boolean isAgedTimeoutEnabled() {
+        return isAgedTimeoutEnabled;
+    }
+
+    public void setAgedTimeoutEnabled(boolean agedTimeoutEnabled) {
+        isAgedTimeoutEnabled = agedTimeoutEnabled;
     }
 }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2-extensions/esb-connector-file/issues/190

With this what we changed in the design is that we have used a connection pool for each destination rather than the previously used single cached connection.

So when there is more concurrency the number of connections will increase and improve the performance.

Also, the main feature was to support "Aged Connection Timeout " for pools
where you can configure "sftpPoolConnectionAgedTimeout" property in init section and define a life span for each pool.
The difference here is with this timeout unlike other timeouts we could gracefully clear existing connections while handing over the new operations to another pool once the time out reached.


