### PR TITLE
Initialize API before adding it to Registry

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.rest.api/src/main/java/org/wso2/carbon/rest/api/service/RestApiAdmin.java
@@ -854,8 +854,6 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
                     API api = APIFactory.createAPI(apiElement, properties);
 
                     try {
-						getSynapseConfiguration().addAPI(api.getName(), api);
-
 						//addParameterObserver(api.getName());
 
 						if (log.isDebugEnabled()) {
@@ -881,6 +879,7 @@ public class RestApiAdmin extends AbstractServiceBusAdmin{
 							}
 						}
                         api.init(getSynapseEnvironment());
+                        getSynapseConfiguration().addAPI(api.getName(), api);
 						persistApi(api);
 
 					} catch (Exception e) {


### PR DESCRIPTION
$subject

API should be initialized before adding to the SynapseConfiguration registry. Else, the API would be allowed to serve traffic and it causes ConcurrentModification exception if Handler initialization and API invocation occurs parallely.

Resolves https://github.com/wso2/api-manager/issues/1538