### PR TITLE
Support invalidating connections when related local entry changed

### DIFF
--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/connection/LocalEntryUndeployCallBack.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/connection/LocalEntryUndeployCallBack.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.connector.core.connection;
+
+public interface LocalEntryUndeployCallBack {
+    /**
+     * Listen for local entry un deploy events
+     * and cleanup connections originated by that local entry.
+     */
+    void onLocalEntryUndeploy(String localEntryKey);
+}

--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/connection/LocalEntryUndeployObserver.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/connection/LocalEntryUndeployObserver.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.connector.core.connection;
+
+
+import org.apache.synapse.config.AbstractSynapseObserver;
+import org.apache.synapse.config.Entry;
+
+/**
+ * Listen for local entry un deploy events
+ * and cleanup connections originated by that local entry.
+ */
+public class LocalEntryUndeployObserver extends AbstractSynapseObserver {
+    private final String localEntryName;
+
+    private LocalEntryUndeployCallBack callback;
+
+    public LocalEntryUndeployObserver(String localEntryName) {
+        this.localEntryName = localEntryName;
+    }
+
+    @Override
+    public void entryRemoved(Entry entry) {
+        if (this.callback != null && entry.getKey().equals(localEntryName)) {
+            this.callback.onLocalEntryUndeploy(entry.getKey());
+        }
+    }
+    public void setCallback(LocalEntryUndeployCallBack callback) {
+        this.callback = callback;
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LocalEntryUndeployObserver localEntryUndeployObserver = (LocalEntryUndeployObserver) o;
+        return localEntryName.equals(localEntryUndeployObserver.localEntryName);
+    }
+
+    public int hashCode() {
+        return localEntryName.hashCode();
+    }
+
+}

--- a/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/util/Constants.java
+++ b/components/mediation-connector/org.wso2.carbon.connector.core/src/main/java/org/wso2/carbon/connector/core/util/Constants.java
@@ -29,4 +29,5 @@ public class Constants {
     public static final String MAX_EVICTION_TIME = "minEvictionTime";
     public static final String EVICTION_CHECK_INTERVAL = "evictionCheckInterval";
     public static final String EXHAUSTED_ACTION = "exhaustedAction";
+    public static final String INIT_CONFIG_KEY = "INIT_CONFIG_KEY";
 }


### PR DESCRIPTION

## Purpose
I introduced an enhancement to the way we handle connections in relation to local entries.
A mechanism was established where the key associated with a localEntry is passed from the InvokeMediator
to the TemplateMediator then further propagated to the TemplateContext, ensuring that the specific localEntry is accessible from the connection handling code.

With the availability of the localEntry key, each active connection(dynamic/static) has been bound to its respective localEntry in a map.

So when a localEntry is undeployed or removed, this change is detected by the Synapse Observer, and the connections associated with that specific localEntry are invalidated.

 Fixes: https://github.com/wso2/micro-integrator/issues/3002
