### PR TITLE
[Master] Add web socket transport sender hostname verification

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -62,6 +62,7 @@ public class WebsocketConstants {
 
     public static final String WEBSOCKET_CUSTOM_HEADER_PREFIX = "websocket.custom.header.";
     public static final String WEBSOCKET_CUSTOM_HEADER_CONFIG = "ws.custom.header";
+    public static final String WEBSOCKET_HOSTNAME_VERIFICATION_CONFIG = "ws.client.enable.hostname.verification";
 
     public static final String WEBSOCKET_SUBPROTOCOL = "websocket.subprotocol";
 


### PR DESCRIPTION
## Purpose
Allow enabling hostname verification

The following configuration is required in the `deployment.toml` to enable hostname verification if it is disabled.

```toml
[transport.wss.sender.parameters]
"ws.client.enable.hostname.verification" = true
```