### PR TITLE
Add implementation to preserve websocket headers with null check for preserved header value

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -62,6 +62,7 @@ public class WebsocketConstants {
 
     public static final String WEBSOCKET_CUSTOM_HEADER_PREFIX = "websocket.custom.header.";
     public static final String WEBSOCKET_CUSTOM_HEADER_CONFIG = "ws.custom.header";
+    public static final String WEBSOCKET_HEADERS_PRESERVE_CONFIG = "ws.headers.preserve";
     public static final String WEBSOCKET_HOSTNAME_VERIFICATION_CONFIG = "ws.client.enable.hostname.verification";
 
     public static final String WEBSOCKET_SUBPROTOCOL = "websocket.subprotocol";

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
@@ -155,6 +155,23 @@ public class WebsocketTransportSender extends AbstractTransportSender {
         }
 
         /*
+        * Preserve the specified headers from the original request by adding to the customHeaders map.
+        * Headers present in this map won't be set at Netty level.
+        */
+        Parameter preserveWebSocketHeadersParameter = msgCtx.getTransportOut()
+                .getParameter(WebsocketConstants.WEBSOCKET_HEADERS_PRESERVE_CONFIG);
+        if (preserveWebSocketHeadersParameter != null && preserveWebSocketHeadersParameter.getValue() != null &&
+                !preserveWebSocketHeadersParameter.getValue().toString().isEmpty()) {
+            String preservableHeaders = preserveWebSocketHeadersParameter.getValue().toString();
+            for (String header : preservableHeaders.split(",")) {
+                Object headerValue = msgCtx.getProperty(header);
+                if (headerValue != null) {
+                    customHeaders.put(header, headerValue);
+                }
+            }
+        }
+
+        /*
         * Get all the message property names and check whether the properties with the websocket custom header
         * prefix are exist in the property map.
         *


### PR DESCRIPTION
## Purpose
$Subject.

## Approach
- This is achieved via the `ws.headers.preserve` property. (This property name is kept on par with the HTTP property - `http.headers.preserve` which appears in `passthru-http.properties`).
Websocket headers that should be preserved from the original request should be added as follows, in the `deployment.toml`:
```toml
[transport.ws] # or [transport.wss]
sender.parameters."ws.headers.preserve" = "Origin,host"
```
The above example would preserve the `Origin` and `host` headers.
- In order to address the NPE when providing the following configurations in `deployment.toml` and sending request with either `origin` or `host` header missing.
```toml
[transport.ws] # or [transport.wss]
sender.parameters."ws.headers.preserve" = "Origin,host"
```

## Sample `wscat` request
**Request:**
```
wscat -c ws://localhost:9099/newwebsocket/1.0.0 -H "Authorization:Bearer $token" -H "Origin: TestOriginValue" -H "host: localhost:1234"
```

WebSocket Backend runs at `localhost:8080`.
**Headers received at the WebSocket Backend**
- with `sender.parameters."ws.headers.preserve" = "Origin,host"`
   ```
   Headers:  {
     origin: 'TestOriginValue',
     host: 'localhost:1234',
     upgrade: 'websocket',
     connection: 'upgrade',
     'sec-websocket-key': 'OyvS4Vc92SZLe551NQsK5A==',
     'sec-websocket-version': '13'
   }
   ```
- without `sender.parameters."ws.headers.preserve"`
   ```
   Headers:  {
     host: 'localhost:8080',
     upgrade: 'websocket',
     connection: 'upgrade',
     'sec-websocket-key': 'ABpqHsLXQ1hEhIojL3JMLw==',
     origin: 'http://localhost:8080',
     'sec-websocket-version': '13'
   }
   ```