### PR TITLE
Fix inconsistent behaviour with the preserved headers

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -235,12 +235,12 @@ public class WebsocketConnectionFactory {
                 handler = new WebSocketClientHandler(WebSocketClientHandshakerFactory.newHandshaker(uri,
                         WebSocketVersion.V13,
                         deriveSubprotocol(wsSubprotocol, contentType),
-                        false, defaultHttpHeaders, maxLength));
+                        false, defaultHttpHeaders, maxLength, true, false, -1L, false, false));
             } else {
                 handler = new WebSocketClientHandler(WebSocketClientHandshakerFactory.newHandshaker(uri,
                         WebSocketVersion.V13,
                         deriveSubprotocol(wsSubprotocol, contentType),
-                        false, defaultHttpHeaders));
+                        false, defaultHttpHeaders, 65536, true, false, -1L, false, false));
             }
             handler.setCorrelationId(correlationId);
             handler.setApiProperties(apiProperties);

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
@@ -165,6 +165,13 @@ public class WebsocketTransportSender extends AbstractTransportSender {
             String preservableHeaders = preserveWebSocketHeadersParameter.getValue().toString();
             for (String header : preservableHeaders.split(",")) {
                 Object headerValue = msgCtx.getProperty(header);
+                Iterator<String> headerNames = msgCtx.getPropertyNames();
+                while (headerValue == null && headerNames.hasNext()) {
+                    String headerName = headerNames.next();
+                    if (headerName.equalsIgnoreCase(header)) {
+                        headerValue = msgCtx.getProperty(headerName);
+                    }
+                }
                 if (headerValue != null) {
                     customHeaders.put(header, headerValue);
                 }


### PR DESCRIPTION
### Purpose
When the following configuration is used, the gateway does not honour the scenarios where headers are received in lowercase from the client or headers are not received at all.

```toml
[transport.ws] 
sender.parameters."ws.headers.preserve" = "Origin,Host"
```
This PR fixes the above mentioned inconsistent behaviour with the preserved websocket headers.

Related issue: https://github.com/wso2/api-manager/issues/2395

### Approach
- Added a case insensitive check for headers
- Used a new overloaded method for WebSockesetClientHandshakerFactory.newHandshaker [1]. This method allows us to disable generating the Origin header when it is not present in the client request. This will prevent the header value being set to the target incorrectly by netty.

[1] - https://netty.io/4.1/api/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerFactory.html