### PR TITLE
Upgrade Netty, Fasterxml, Guava, Snakeyaml, Analytics Common, and Swagger Parser dependencies

### DIFF
--- a/components/mediation-initializer/org.wso2.carbon.mediation.transport.handlers/pom.xml
+++ b/components/mediation-initializer/org.wso2.carbon.mediation.transport.handlers/pom.xml
@@ -80,7 +80,7 @@
             <artifactId>synapse-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.org.yaml</groupId>
+            <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
         <dependency>

--- a/components/mediation-initializer/org.wso2.carbon.mediation.transport.handlers/pom.xml
+++ b/components/mediation-initializer/org.wso2.carbon.mediation.transport.handlers/pom.xml
@@ -51,7 +51,7 @@
                             javax.servlet.http;version="${imp.pkg.version.javax.servlet}",
                             org.apache.commons.logging; version="${import.package.version.commons.logging}",
                             org.apache.axis2.*; version="${axis2.osgi.version.range}",
-                            org.yaml.snakeyaml.*; version="${orbit.snakeyaml.import.version.range}",
+                            org.yaml.snakeyaml.*; version="${snakeyaml.import.version.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <Fragment-Host>synapse-nhttp-transport</Fragment-Host>

--- a/features/mediation-initializer-features/org.wso2.carbon.mediation.initializer.server.feature/pom.xml
+++ b/features/mediation-initializer-features/org.wso2.carbon.mediation.initializer.server.feature/pom.xml
@@ -54,7 +54,7 @@
             <type>zip</type>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.org.yaml</groupId>
+            <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
         <dependency>

--- a/features/mediation-initializer-features/org.wso2.carbon.mediation.light.initializer.server.feature/pom.xml
+++ b/features/mediation-initializer-features/org.wso2.carbon.mediation.light.initializer.server.feature/pom.xml
@@ -52,7 +52,7 @@
             <type>zip</type>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.org.yaml</groupId>
+            <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
     </dependencies>
@@ -85,7 +85,7 @@
                                 <bundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.dependency.mgt</bundleDef>
                                 <bundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.startup</bundleDef>
                                 <bundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.registry</bundleDef>
-                                <bundleDef>org.wso2.orbit.org.yaml:snakeyaml:${orbit.version.snakeyaml}</bundleDef>
+                                <bundleDef>org.yaml:snakeyaml:${orbit.version.snakeyaml}</bundleDef>
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.apache.synapse.wso2:${synapse.version}</importFeatureDef>

--- a/features/mediation-initializer-features/org.wso2.carbon.mediation.light.initializer.server.feature/pom.xml
+++ b/features/mediation-initializer-features/org.wso2.carbon.mediation.light.initializer.server.feature/pom.xml
@@ -85,7 +85,7 @@
                                 <bundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.dependency.mgt</bundleDef>
                                 <bundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.startup</bundleDef>
                                 <bundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.registry</bundleDef>
-                                <bundleDef>org.yaml:snakeyaml:${orbit.version.snakeyaml}</bundleDef>
+                                <bundleDef>org.yaml:snakeyaml:${version.snakeyaml}</bundleDef>
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.apache.synapse.wso2:${synapse.version}</importFeatureDef>

--- a/pom.xml
+++ b/pom.xml
@@ -2378,7 +2378,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>${orbit.version.snakeyaml}</version>
+                <version>${version.snakeyaml}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
@@ -2667,8 +2667,8 @@
         <esotericsoftware.kryo.version>3.0.3</esotericsoftware.kryo.version>
         <org.objenesis.version>2.1</org.objenesis.version>
         <esotericsoftware.minlog.version>1.3.0</esotericsoftware.minlog.version>
-        <orbit.version.snakeyaml>2.0</orbit.version.snakeyaml>
-        <orbit.snakeyaml.import.version.range>[2.0, 3.0.0)</orbit.snakeyaml.import.version.range>
+        <version.snakeyaml>2.2</version.snakeyaml>
+        <snakeyaml.import.version.range>[2.0, 3.0.0)</snakeyaml.import.version.range>
         <!-- OWASP encoder versions -->
         <owasp.encoder.wso2.version>1.2.0.wso2v1</owasp.encoder.wso2.version>
         <owasp.encoder.wso2.imp.pkg.version>[1.2.0,1.3.0)</owasp.encoder.wso2.imp.pkg.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2376,7 +2376,7 @@
                 <version>${google.guava.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.orbit.org.yaml</groupId>
+                <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${orbit.version.snakeyaml}</version>
             </dependency>
@@ -2526,7 +2526,7 @@
         <carbon.registry.version>4.7.24</carbon.registry.version>
         <carbon.registry.imp.pkg.version>[4.7.0, 5.0.0)</carbon.registry.imp.pkg.version>
         <!-- Analytic Commons version-->
-        <carbon.analytics.common.version>5.2.18</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.6</carbon.analytics.common.version>
         <carbon.analytics.common.imp.pkg.version>[5.2.0, 6.0.0)</carbon.analytics.common.imp.pkg.version>
         <!-- carbon.identity.framework.version-->
         <carbon.identity.framework.version>5.15.17</carbon.identity.framework.version>
@@ -2638,7 +2638,7 @@
         <saxon.wso2.version>8.9.0.wso2v2</saxon.wso2.version>
         <json.smart.version>2.4.7</json.smart.version>
         <damnhandy.version>2.1.6.wso2v2</damnhandy.version>
-        <netty.version>4.1.100.Final</netty.version>
+        <netty.version>4.1.104.Final</netty.version>
         <netty.tcnative.version>2.0.47.Final</netty.tcnative.version>
         <javax.activation.version>0.0</javax.activation.version>
         <javax.servlet.imp.pkg.version>[2.4.0, 3.0.0)</javax.servlet.imp.pkg.version>
@@ -2652,7 +2652,7 @@
         <fge.json.schema.validator.version>2.2.6.wso2v8</fge.json.schema.validator.version>
         <com.googlecode.libphonenumber.version>7.4.2.wso2v1</com.googlecode.libphonenumber.version>
         <joda-time.version>2.9.4.wso2v1</joda-time.version>
-        <google.guava.version>32.1.3-jre</google.guava.version>
+        <google.guava.version>33.0.0-jre</google.guava.version>
         <!-- publishEvent mediator versions -->
         <javax.xml.namespace.version>0.0.0</javax.xml.namespace.version>
         <org.apache.axiom.om.version>0.0.0</org.apache.axiom.om.version>
@@ -2662,13 +2662,13 @@
         <jetty.wso2.version>8.1.17.v20150415.wso2v1</jetty.wso2.version>
         <libthrift.version>0.16.0.wso2v1</libthrift.version>
         <opencsv.version>2.3</opencsv.version>
-        <fasterxml.jackson.version>2.14.1</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
         <json.simple.version>1.1.1</json.simple.version>
         <esotericsoftware.kryo.version>3.0.3</esotericsoftware.kryo.version>
         <org.objenesis.version>2.1</org.objenesis.version>
         <esotericsoftware.minlog.version>1.3.0</esotericsoftware.minlog.version>
-        <orbit.version.snakeyaml>1.33.0.wso2v1</orbit.version.snakeyaml>
-        <orbit.snakeyaml.import.version.range>[1.16.0.wso2v1, 2.0.0)</orbit.snakeyaml.import.version.range>
+        <orbit.version.snakeyaml>2.0</orbit.version.snakeyaml>
+        <orbit.snakeyaml.import.version.range>[2.0, 3.0.0)</orbit.snakeyaml.import.version.range>
         <!-- OWASP encoder versions -->
         <owasp.encoder.wso2.version>1.2.0.wso2v1</owasp.encoder.wso2.version>
         <owasp.encoder.wso2.imp.pkg.version>[1.2.0,1.3.0)</owasp.encoder.wso2.imp.pkg.version>
@@ -2690,15 +2690,14 @@
         <maven.bundle.plugin.version>3.3.0</maven.bundle.plugin.version>
         <saml.common.util.version>1.3.0</saml.common.util.version>
         <opensaml.orbit.version>3.3.1.wso2v4</opensaml.orbit.version>
-        <jackson.dataformat.yaml.version>2.10.3</jackson.dataformat.yaml.version>
+        <jackson.dataformat.yaml.version>2.16.1</jackson.dataformat.yaml.version>
         <javax.validation.version>1.1.0.Final</javax.validation.version>
-        <snakeyaml.version>1.33</snakeyaml.version>
         <glassfish.cobra.version>4.2.1</glassfish.cobra.version>
         <nashorn.core.version>15.4</nashorn.core.version>
         <bsf.version>3.0.0.wso2v5</bsf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- OAS3 Versions -->
-        <swagger.parser.orbit.version>2.0.20.wso2v1</swagger.parser.orbit.version>
+        <swagger.parser.orbit.version>2.1.18.wso2v1</swagger.parser.orbit.version>
         <transport.http.netty>6.3.35</transport.http.netty>
     </properties>
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -2526,7 +2526,7 @@
         <carbon.registry.version>4.7.24</carbon.registry.version>
         <carbon.registry.imp.pkg.version>[4.7.0, 5.0.0)</carbon.registry.imp.pkg.version>
         <!-- Analytic Commons version-->
-        <carbon.analytics.common.version>5.3.6</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.7</carbon.analytics.common.version>
         <carbon.analytics.common.imp.pkg.version>[5.2.0, 6.0.0)</carbon.analytics.common.imp.pkg.version>
         <!-- carbon.identity.framework.version-->
         <carbon.identity.framework.version>5.15.17</carbon.identity.framework.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2698,7 +2698,7 @@
         <powermock.version>2.0.9</powermock.version>
         <!-- OAS3 Versions -->
         <swagger.parser.orbit.version>2.1.18.wso2v1</swagger.parser.orbit.version>
-        <transport.http.netty>6.3.35</transport.http.netty>
+        <transport.http.netty>6.3.50</transport.http.netty>
     </properties>
     <pluginRepositories>
         <pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -2535,7 +2535,7 @@
         <carbon.rule.version>4.5.6</carbon.rule.version>
         <carbon.rule.imp.pkg.version>[4.5.0, 4.6.0)</carbon.rule.imp.pkg.version>
         <!-- Synapse Version -->
-        <synapse.version>4.0.0-wso2v61</synapse.version>
+        <synapse.version>4.0.0-wso2v75</synapse.version>
         <carbon.identity.entitlement.proxy.version>5.4.4</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.2.0, 6.0.0)
         </carbon.identity.entitlement.proxy.imp.pkg.version>


### PR DESCRIPTION
### Purpose

Upgrade the following dependencies to their latest:

- Netty dependency version to 4.1.104.Final,
- Fasterxml Jackson-databind, and Jackson Dataformat Yaml versions to 2.16.1,
- Google Guava version to 33.0.0-jre,
- Carbon Analytics Common version to 5.3.7,
- Snakeyaml version to 2.0,
- Swagger Parser Orbit version to 2.1.18.wso2v1.