### PR TITLE
Fix issues while deploying APIs during high traffic

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
+++ b/components/mediation-admin/org.wso2.carbon.endpoint/src/main/java/org/wso2/carbon/endpoint/service/EndpointAdmin.java
@@ -1075,7 +1075,7 @@ public class EndpointAdmin extends AbstractServiceBusAdmin {
             lock.lock();
             assertNameNotEmpty(endpointName);
             log.debug("Check Endpoint Existence : " + endpointName + " in the configuration");
-            return getSynapseConfiguration().getLocalRegistry().containsKey(endpointName.trim());
+            return getSynapseConfiguration().getLocalRegistry().get(endpointName.trim()) instanceof Endpoint;
         } catch (SynapseException syne) {
             handleFault("Unable to check existence ", syne);
         } finally {


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/2484

During high traffic scenarios, issues arose with the deployment of APIs due to the limited functionality of the isEndpointExist function. This function solely checked for the existence of keys in the localregistry <String, Object> map, leading to complications when other objects, such as 'Entry', were present. Specifically highlighted in the https://github.com/wso2/api-manager/issues/2484 scenario, the function inaccurately returned true even in the presence of non-Endpoint type objects, disrupting both the API deployment and invocation flows because after checking this, we try to delete an Endpoint which is not there. This pull request addresses these challenges by refining the behavior of isEndpointExist, ensuring it accurately identifies only Endpoint type objects, thereby enhancing the reliability of API deployment processes, especially under high traffic conditions.