### PR TITLE
Fix netty limitation for length URIs exceeding 4096 bytes

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -56,6 +56,10 @@ public class WebsocketConstants {
     public static final String TRUST_STORE_PASSWORD = "ws.trust.store.Password";
     public static final String TRUST_STORE_CONFIG_ELEMENT = "ws.trust.store";
     public static final String WEBSOCKET_MAX_FRAME_PAYLOAD_LENGTH = "wsMaxFrameLength";
+    public static final String WEBSOCKET_MAX_HTTP_CODEC_INIT_LENGTH = "wsMaxHttpCodecInitLength";
+    public static final String WEBSOCKET_MAX_HTTP_CODEC_HEADER_SIZE = "wsMaxHttpCodecHeaderSize";
+    public static final String WEBSOCKET_MAX_HTTP_CODEC_CHUNK_SIZE = "wsMaxHttpCodecChunkSize";
+    public static final String WEBSOCKET_MAX_HTTP_AGGREGATOR_CONTENT_LENGTH = "wsMaxHttpAggregateContentLength";
 
     public static final String SYNAPSE_SUBPROTOCOL_PREFIX = "synapse";
     public static final String WEBSOCKET_SUBSCRIBER_PATH = "websocket.subscriber.path";

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
@@ -30,5 +30,12 @@ public class Constants {
     public static final String INTERNAL_APIS_FILE = "internal-apis.xml";
     public static final String PREFIX_TO_ENABLE_INTERNAL_APIS = "enable";
     public static final String WEBSOCKET_TRANSPORT_MAX_FRAME_PAYLOAD_LENGTH = "ws.transport.max.frame.payload.length";
-
+    public static final String WEBSOCKET_TRANSPORT_MAX_HTTP_CODEC_INIT_LENGTH
+            = "ws.transport.max.http.codec.init.length";
+    public static final String WEBSOCKET_TRANSPORT_MAX_HTTP_CODEC_HEADER_SIZE
+            = "ws.transport.max.http.codec.header.size";
+    public static final String WEBSOCKET_TRANSPORT_MAX_HTTP_CODEC_CHUNK_SIZE
+            = "ws.transport.max.http.codec.chunk.size";
+    public static final String WEBSOCKET_TRANSPORT_MAX_HTTP_AGGREGATOR_CONTENT_LENGTH
+            = "ws.transport.max.http.aggregator.content.length";
 }


### PR DESCRIPTION
This PR fixes the issue in web-socket transport when the invoking URL length exceeds 4096 bytes. This is because 4096 is set as the default HTTP server codec initial length size.

The above issue is fixed by introducing new configurations to set maximum values for below parameters in both inbound and outbound Netty websocket transport. These are typically used during the websocket handshake process, which involves upgrading an HTTP connection to a websocket connection.

- http server/client codec initial line length : Related to HTTPServerCodec and HTTPClientCodec which handles conversion between bytes and HTTP messages. Increasing this value allows for longer URLs.

- http server/client codec header size : Defined the maximum size allowed for HTTP headers. By increasing this value, you can accommodate larger headers, which may be necessary when dealing with lengthy URLs or multiple headers.

- http server/client codec chunk size : Determines the maximum size of an individual HTTP chunk when using chunked transfer encoding. Although WebSocket handshake messages typically aren't chunked, increasing this value may be beneficial in handling large payloads during WebSocket communication.

- http aggregator content length : Increasing the size parameter allows HttpObjectAggregator to handle larger HTTP messages. With a larger size, HttpObjectAggregator can buffer more data before aggregating it into a single FullHttpRequest or FullHttpResponse.

Important :  In scenarios where your application needs to handle large payloads or lengthy URLs, increasing the above parameter values will be beneficial. However, larger values for these parameters can increase memory usage, especially when handling many concurrent connections. This is because Netty needs to allocate more memory to store and process larger HTTP messages. It's essential to carefully consider the trade-offs between performance and security when adjusting these values and also make sure to test both client and back-end websocket applications thoroughly to ensure compatibility of Gateway with a wide range of clients and servers.

To change the maximum values for http server codec and object aggregator parameters in inbound websocket transport (Client to GW communication), add the following to deployment.toml in Gateway node.

[synapse_properties]
'ws.transport.max.http.codec.init.length' = <value>
'ws.transport.max.http.codec.header.size' = <value>
'ws.transport.max.http.codec.chunk.size' = <value>
'ws.transport.max.http.aggregator.content.length' = <value>

To change the maximum values for http client codec and object aggregator parameters in outbound websocket transport (GW to Backend communication), add the following to deployment.toml in Gateway node.

[transport.ws.sender.parameters]
'wsMaxHttpCodecInitLength' = <value>
'wsMaxHttpCodecHeaderSize' = <value>
'wsMaxHttpCodecChunkSize' = <value>
'wsMaxHttpAggregateContentLength' = <value>

Following are the default values if not set explicitly.

ws.transport.max.http.codec.init.length = 4096
ws.transport.max.http.codec.header.size = 8192
ws.transport.max.http.codec.chunk.size = 8192
ws.transport.max.http.aggregator.content.length = 65536
wsMaxHttpCodecInitLength = 4096
wsMaxHttpCodecHeaderSize = 8192
wsMaxHttpCodecChunkSize = 8192
wsMaxHttpAggregateContentLength = 8192
