### PR TITLE
Simplify datamapper map function name

### DIFF
--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/executors/ScriptExecutor.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/executors/ScriptExecutor.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.DEFAULT_ENGINE_NAME;
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.ENCODE_CHAR_HYPHEN;
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.HYPHEN;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.INPUT_VARIABLE_IDENTIFIER;
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.NASHORN_ENGINE_NAME;
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.PROPERTIES_OBJECT_NAME;
 
@@ -50,7 +51,6 @@ import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineC
 public class ScriptExecutor implements Executor {
 
     public static final String PROPERTIES_IDENTIFIER = "properties";
-    public static final String INPUT_VARIABLE_IDENTIFIER = "inputVariables";
     public static final String OPENJDK_NASHORN_CLASSNAME = "org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory";
     private static final Log log = LogFactory.getLog(ScriptExecutor.class);
     private ScriptEngine scriptEngine;

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/MappingResource.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/mapper/MappingResource.java
@@ -39,6 +39,8 @@ import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineC
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.JS_STRINGIFY;
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.HYPHEN;
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.ENCODE_CHAR_HYPHEN;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.MAP_FUNCTION;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.MAP_FUNCTION_NAME;
 
 public class MappingResource {
 
@@ -145,6 +147,10 @@ public class MappingResource {
 
         while (match.find()) {
             propertiesList.add(match.group(2) + "['" + match.group(3) + "']");
+        }
+
+        if (jsFunctionBody.contains(MAP_FUNCTION_NAME)) {
+            fnName = MAP_FUNCTION;
         }
 
         if (fnName != null) {

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/utils/DataMapperEngineConstants.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/utils/DataMapperEngineConstants.java
@@ -55,6 +55,9 @@ public class DataMapperEngineConstants {
     public static final String BRACKET_CLOSE = ")";
     public static final String FUNCTION_NAME_CONST_1 = "map_S_";
     public static final String FUNCTION_NAME_CONST_2 = "_S_";
+    public static final String INPUT_VARIABLE_IDENTIFIER = "inputVariables";
+    public static final String MAP_FUNCTION_NAME = "mapFunction";
+    public static final String MAP_FUNCTION = "mapFunction(JSON.parse(" + INPUT_VARIABLE_IDENTIFIER + ")";
     public static final String NAME_SEPERATOR = "_Separat0r_";
     public static final String ENCODE_CHAR_HYPHEN = "_EnC0DeCHaRHyPh3n_";
     public static final String HYPHEN = "-";

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/DataMapperMediator.java
@@ -85,8 +85,8 @@ import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorC
 import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.SYNAPSE_CONTEXT;
 import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.TRANSPORT_CONTEXT;
 import static org.wso2.carbon.mediator.datamapper.config.xml.DataMapperMediatorConstants.TRANSPORT_HEADERS;
+import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.INPUT_VARIABLE_IDENTIFIER;
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.ORG_APACHE_SYNAPSE_DATAMAPPER_EXECUTOR_POOL_SIZE;
-import static org.wso2.carbon.mediator.datamapper.engine.core.executors.ScriptExecutor.INPUT_VARIABLE_IDENTIFIER;
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.ENCODE_CHAR_HYPHEN;
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.HYPHEN;
 import static org.wso2.carbon.mediator.datamapper.engine.utils.DataMapperEngineConstants.PROPERTIES_OBJECT_NAME;


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

With the new MI VSCode extension, the DMC file is generated during build time. Hence, to simplify the process, the map function name is fixed as a constant.

