### PR TITLE
Fix issues in SynapseArtifactUploaderAdmin service

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.mediation.artifactuploader/src/main/java/org/wso2/carbon/mediation/artifactuploader/util/SynapseArtifactUploaderUtil.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.artifactuploader/src/main/java/org/wso2/carbon/mediation/artifactuploader/util/SynapseArtifactUploaderUtil.java
@@ -1,6 +1,7 @@
 package org.wso2.carbon.mediation.artifactuploader.util;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 
 /**
@@ -29,6 +30,31 @@ public class SynapseArtifactUploaderUtil {
             artifacts.toArray(artifactList);
         }
         return artifactList;
+    }
+
+    /**
+     * Finds the extension of a given file
+     *
+     * @param fileName - name of the file
+     * @return - extension
+     */
+    public static String getFileExtension(String fileName) {
+        int index = fileName.lastIndexOf('.');
+        return fileName.substring(index + 1);
+    }
+
+    /**
+     * Validates whether the destinationFile is copied to the target directory
+     *
+     * @param destinationFile - file to be uploaded or removed
+     * @param targetDirectory - target directory
+     * @return true if the destination file is copied to the target directory
+     * @throws IOException
+     */
+    public static boolean validateFilePath(File destinationFile, File targetDirectory) throws IOException {
+        String canonicalPathToFile = destinationFile.getCanonicalPath();
+        String canonicalPathToArtifactDir = targetDirectory.getCanonicalPath();
+        return canonicalPathToFile.startsWith(canonicalPathToArtifactDir);
     }
 
 }


### PR DESCRIPTION
## Purpose
This PR,

- Adds a filetype restriction to uploadArtifacts operation to allow only xml files.
- Adds a check in uploadArtifacts operation to allow file uploads only inside the extensions folder.
- Adds a check in removeArtifacts operation to allow removal of file inside the extensions folder only.

