### PR TITLE
[APIM-4.4.0] Upgrade swagger-parser version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2699,7 +2699,7 @@
         <bsf.version>3.0.0.wso2v5</bsf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- OAS3 Versions -->
-        <swagger.parser.orbit.version>2.1.18.wso2v1</swagger.parser.orbit.version>
+        <swagger.parser.orbit.version>2.1.22.wso2v1</swagger.parser.orbit.version>
         <transport.http.netty>6.3.50</transport.http.netty>
         <graalvm.version>22.3.4</graalvm.version>
         <icu.version>72.1</icu.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2540,7 +2540,7 @@
         <carbon.rule.version>4.5.6</carbon.rule.version>
         <carbon.rule.imp.pkg.version>[4.5.0, 4.6.0)</carbon.rule.imp.pkg.version>
         <!-- Synapse Version -->
-        <synapse.version>4.0.0-wso2v125</synapse.version>
+        <synapse.version>4.0.0-wso2v128</synapse.version>
         <carbon.identity.entitlement.proxy.version>5.4.4</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.2.0, 6.0.0)
         </carbon.identity.entitlement.proxy.imp.pkg.version>


### PR DESCRIPTION
### Purpose

This PR Upgrades the swagger-parser version to 2.1.22.

#### Related PRs:

Orbit bundles: https://github.com/wso2/orbit/pull/1133
carbon-apimgt PR: https://github.com/wso2/carbon-apimgt/pull/12586
product-apim PR: https://github.com/wso2/product-apim/pull/13540