### PR TITLE
Upgrade commons-text version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2680,7 +2680,7 @@
         <activemq.version>5.2.0</activemq.version>
         <activemq.broker.version>5.15.2</activemq.broker.version>
         <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
-        <wso2.commons.text.orbit.version>1.6.wso2v1</wso2.commons.text.orbit.version>
+        <wso2.commons.text.orbit.version>1.10.0.wso2v2</wso2.commons.text.orbit.version>
         <osgi.framework.imp.pkg.version>[1.7.0,2.0.0)</osgi.framework.imp.pkg.version>
         <imp.package.version.osgi.services>[1.2.0,2.0.0)</imp.package.version.osgi.services>
         <org.ow2.asm.asm.version>9.2</org.ow2.asm.asm.version>


### PR DESCRIPTION
### Purpose

Upgrades commons-text version from 1.6.0.wso2v1 to 1.10.0.wso2v2.