### PR TITLE
Avoid schema validation and implement minimal datamapper

### DIFF
--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/executors/ScriptRunner.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper.engine/src/main/java/org/wso2/carbon/mediator/datamapper/engine/core/executors/ScriptRunner.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.mediator.datamapper.engine.core.executors;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+
+public class ScriptRunner {
+
+    private final Context context;
+    private final Value mapFunction;
+
+    public ScriptRunner(String jsCode) {
+        this.context = Context.create("js");
+        // we need to evaluate the script only once
+        this.mapFunction = context.eval("js", jsCode);
+    }
+
+    public String runScript(String inputJson, String variablesJson) {
+        // provide input/payload and variables as JSON objects
+        Value input = context.eval("js", "(" + inputJson + ")");
+        Value variables = context.eval("js", "(" + variablesJson + ")");
+        Value result = mapFunction.execute(input, variables);
+        return result.toString();
+    }
+
+    public void close() {
+        context.close();
+    }
+}

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorConstants.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorConstants.java
@@ -29,6 +29,9 @@ public class DataMapperMediatorConstants {
     public static final String INPUT_TYPE = "inputType";
     public static final String OUTPUT_TYPE = "outputType";
     public static final String XSLT_STYLE_SHEET = "xsltStyleSheet";
+    public static final String TARGET_VARIABLE = "variable";
+    public static final String TARGET = "target";
+    public static final String TARGET_BODY = "body";
 
     /* Names of the different contexts used in the ESB */
     public static final String DEFAULT_CONTEXT = "DEFAULT";

--- a/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorFactory.java
+++ b/components/mediators/datamapper/org.wso2.carbon.mediator.datamapper/src/main/java/org/wso2/carbon/mediator/datamapper/config/xml/DataMapperMediatorFactory.java
@@ -75,7 +75,8 @@ public class DataMapperMediatorFactory extends AbstractMediatorFactory {
         OMAttribute outputTypeAttribute = element.getAttribute(new QName(DataMapperMediatorConstants.OUTPUT_TYPE));
         OMAttribute xsltStyleSheetKeyAttribute = element.getAttribute(new QName
                 (DataMapperMediatorConstants.XSLT_STYLE_SHEET));
-
+        OMAttribute targetVariableAttribute = element.getAttribute(new QName(DataMapperMediatorConstants.TARGET_VARIABLE));
+        OMAttribute targetAttribute = element.getAttribute(new QName(DataMapperMediatorConstants.TARGET));
 
         /*
          * ValueFactory for creating dynamic or static Value and provide methods
@@ -118,6 +119,14 @@ public class DataMapperMediatorFactory extends AbstractMediatorFactory {
             Value xsltStyleSheetKeyValue = keyFac.createValue(xsltStyleSheetKeyAttribute
                     .getLocalName(), element);
             datamapperMediator.setXsltStyleSheetKey(xsltStyleSheetKeyValue);
+        }
+
+        if (targetAttribute != null) {
+            datamapperMediator.setTarget(targetAttribute.getAttributeValue());
+        }
+
+        if (targetVariableAttribute != null) {
+            datamapperMediator.setTargetVariableName(targetVariableAttribute.getAttributeValue());
         }
 
         processAuditStatus(datamapperMediator, element);

--- a/pom.xml
+++ b/pom.xml
@@ -2540,7 +2540,7 @@
         <carbon.rule.version>4.5.6</carbon.rule.version>
         <carbon.rule.imp.pkg.version>[4.5.0, 4.6.0)</carbon.rule.imp.pkg.version>
         <!-- Synapse Version -->
-        <synapse.version>4.0.0-wso2v165</synapse.version>
+        <synapse.version>4.0.0-wso2v178</synapse.version>
         <carbon.identity.entitlement.proxy.version>5.4.4</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.2.0, 6.0.0)
         </carbon.identity.entitlement.proxy.imp.pkg.version>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Eg DM script:
```
export function mapFunction(input: Root, vars: Record<string, any>): OutputRoot {
    return {
        test: input.hello + " " + vars.inputKey + " " + vars.inputKey2.name
    }
}
```

Synapse API:

```
<?xml version="1.0" encoding="UTF-8"?>
<api context="/dmapi" name="DMAPI" xmlns="http://ws.apache.org/ns/synapse">
    <resource methods="POST" uri-template="/">

        <inSequence>
            <variable name="inputKey" type="STRING" value="Nauran" />
            <variable name="inputKey2" type="JSON" value="{&quot;name&quot; : &quot;doe&quot;}" />

           <datamapper
                config="resources:datamapper/dm1/dm1.dmc"
                inputSchema="resources:datamapper/dm1/dm1_inputSchema.json"
                outputSchema="resources:datamapper/dm1/dm1_outputSchema.json" target="body" />
            <respond />
        </inSequence>
        <faultSequence>
        </faultSequence>
    </resource>
</api>
```