### PR TITLE
Upgrade json-smart version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2531,7 +2531,7 @@
         <carbon.registry.version>4.7.24</carbon.registry.version>
         <carbon.registry.imp.pkg.version>[4.7.0, 5.0.0)</carbon.registry.imp.pkg.version>
         <!-- Analytic Commons version-->
-        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.18</carbon.analytics.common.version>
         <carbon.analytics.common.imp.pkg.version>[5.2.0, 6.0.0)</carbon.analytics.common.imp.pkg.version>
         <!-- carbon.identity.framework.version-->
         <carbon.identity.framework.version>5.15.17</carbon.identity.framework.version>
@@ -2540,7 +2540,7 @@
         <carbon.rule.version>4.5.6</carbon.rule.version>
         <carbon.rule.imp.pkg.version>[4.5.0, 4.6.0)</carbon.rule.imp.pkg.version>
         <!-- Synapse Version -->
-        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
+        <synapse.version>4.0.0-wso2v218</synapse.version>
         <carbon.identity.entitlement.proxy.version>5.4.4</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.2.0, 6.0.0)
         </carbon.identity.entitlement.proxy.imp.pkg.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2531,7 +2531,7 @@
         <carbon.registry.version>4.7.24</carbon.registry.version>
         <carbon.registry.imp.pkg.version>[4.7.0, 5.0.0)</carbon.registry.imp.pkg.version>
         <!-- Analytic Commons version-->
-        <carbon.analytics.common.version>5.3.7</carbon.analytics.common.version>
+        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
         <carbon.analytics.common.imp.pkg.version>[5.2.0, 6.0.0)</carbon.analytics.common.imp.pkg.version>
         <!-- carbon.identity.framework.version-->
         <carbon.identity.framework.version>5.15.17</carbon.identity.framework.version>
@@ -2540,7 +2540,7 @@
         <carbon.rule.version>4.5.6</carbon.rule.version>
         <carbon.rule.imp.pkg.version>[4.5.0, 4.6.0)</carbon.rule.imp.pkg.version>
         <!-- Synapse Version -->
-        <synapse.version>4.0.0-wso2v215</synapse.version>
+        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
         <carbon.identity.entitlement.proxy.version>5.4.4</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.2.0, 6.0.0)
         </carbon.identity.entitlement.proxy.imp.pkg.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2531,7 +2531,7 @@
         <carbon.registry.version>4.7.24</carbon.registry.version>
         <carbon.registry.imp.pkg.version>[4.7.0, 5.0.0)</carbon.registry.imp.pkg.version>
         <!-- Analytic Commons version-->
-        <carbon.analytics.common.version>5.3.18</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.19</carbon.analytics.common.version>
         <carbon.analytics.common.imp.pkg.version>[5.2.0, 6.0.0)</carbon.analytics.common.imp.pkg.version>
         <!-- carbon.identity.framework.version-->
         <carbon.identity.framework.version>5.15.17</carbon.identity.framework.version>


### PR DESCRIPTION
### Purpose
To upgrade json-smart version from 2.5.0 to the non-vulnerable 2.5.2 version.

#### Related PRs:

Identity-inbound-auth-oauth: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2730
Carbon-identity-framework: https://github.com/wso2/carbon-identity-framework/pull/6543
Identity-inbound-auth-openid: https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/109
Identity-outbound-auth-oidc: https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/199
Carbon-analytics-common: https://github.com/wso2/carbon-analytics-common/pull/862
Carbon-apimgt: https://github.com/wso2/carbon-apimgt/pull/12953
Product-apim: https://github.com/wso2/product-apim/pull/13688
