### PR TITLE
Introduce a config to turn off websocket subprotocol negotiation

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/Constants.java
@@ -38,4 +38,6 @@ public class Constants {
             = "ws.transport.max.http.codec.chunk.size";
     public static final String WEBSOCKET_TRANSPORT_MAX_HTTP_AGGREGATOR_CONTENT_LENGTH
             = "ws.transport.max.http.aggregator.content.length";
+    public static final String ENABLE_WEBSOCKET_TRANSPORT_SUBPROTOCOL_NEGOTIATE
+            = "ws.transport.subprotocol.negotiate";
 }


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/3871

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
When below configuration is set to false, Gateway will not negotiate subprotocols sent in the `Sec-Websocket-Protocol` header. Instead it will simply pass all the protocols mentioned in the header to netty which will internally pick a protocol.

```
[synapse_properties]
'ws.transport.subprotocol.negotiate' = false
```

**Known Limitations**
- In this approach, when multiple protocols are sent in the request header netty will always pick the first protocol [1] (Since GW is unware of the protocols supported by the actual BE at this point). This will be addressed with https://github.com/wso2/api-manager/issues/3871

[1]. https://github.com/netty/netty/blob/4.2/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java#L465-L488

