### PR TITLE
Share the event loop group from WebsocketConnectionFactory

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -60,6 +60,7 @@ public class WebsocketConstants {
     public static final String WEBSOCKET_MAX_HTTP_CODEC_HEADER_SIZE = "wsMaxHttpCodecHeaderSize";
     public static final String WEBSOCKET_MAX_HTTP_CODEC_CHUNK_SIZE = "wsMaxHttpCodecChunkSize";
     public static final String WEBSOCKET_MAX_HTTP_AGGREGATOR_CONTENT_LENGTH = "wsMaxHttpAggregateContentLength";
+    public static final String WEBSOCKET_SHARED_EVENT_LOOP_POOL_SIZE = "wsSharedEventLoopPoolSize";
 
     public static final String SYNAPSE_SUBPROTOCOL_PREFIX = "synapse";
     public static final String WEBSOCKET_SUBSCRIBER_PATH = "websocket.subscriber.path";


### PR DESCRIPTION
### Shared `EventLoopGroup` Support in `WebsocketConnectionFactory`

This update refactors `WebsocketConnectionFactory` to use a shared, configurable `EventLoopGroup` for managing WebSocket client connections. It improves resource efficiency by eliminating the need to create a new thread pool for each connection.

The shared event loop group size can be configured using the following configurations. For example, in `deployment.toml`:

```toml
[transport.ws.sender.parameters]
'wsSharedEventLoopPoolSize' = 5
```

```toml
[transport.wss.sender.parameters]
'wsSharedEventLoopPoolSize' = 5
```

Fix: https://github.com/wso2/api-manager/issues/3889