### PR TITLE
Add target endpoint to the inbound websocket channel

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -83,4 +83,7 @@ public class WebsocketConstants {
     public static final int WEBSOCKET_UPSTREAM_ERROR_SC = 1014;
     public static final String ERROR_CODE = "ERROR_CODE";
     public static final String ERROR_MESSAGE = "ERROR_MESSAGE";
+
+    public static final String TARGET_ENDPOINT_ADDRESS = "ENDPOINT_ADDRESS";
+    public static final String WSO2_PROPERTIES = "WSO2_PROPERTIES";
 }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
@@ -94,6 +94,18 @@ public class WebsocketTransportSender extends AbstractTransportSender {
         if (log.isDebugEnabled()) {
             log.debug("Endpoint url: " + targetEPR);
         }
+
+        // Store the target endpoint address in the channel attributes to make it available throughout the lifecycle of the connection
+        AttributeKey<Map<String, Object>> WSO2_PROPERTIES = AttributeKey.valueOf(WebsocketConstants.WSO2_PROPERTIES);
+        Map<String, Object> propertiesMap = ((ChannelHandlerContext) (msgCtx.getProperty(
+                WebsocketConstants.WEBSOCKET_SOURCE_HANDLER_CONTEXT))).channel().attr(WSO2_PROPERTIES).get();
+        if (propertiesMap == null) {
+            propertiesMap = new HashMap<>();
+        }
+        propertiesMap.put(WebsocketConstants.TARGET_ENDPOINT_ADDRESS, targetEPR);
+        ((ChannelHandlerContext) msgCtx.getProperty(WebsocketConstants.WEBSOCKET_SOURCE_HANDLER_CONTEXT)).channel()
+                .attr(WSO2_PROPERTIES).set(propertiesMap);
+
         InboundResponseSender responseSender = null;
         if (msgCtx.getProperty(InboundEndpointConstants.INBOUND_ENDPOINT_RESPONSE_WORKER) != null) {
             responseSender = (InboundResponseSender)


### PR DESCRIPTION
### Purpose
For adding dynamic endpoint support via mediation policies to websocket apis as requested in [1], there is a requirement to preserve the target endpoint address throughout the connection. Since the Netty channel remains constant throughout the connection, we set the target endpoint at the handshake request to the channel's attribute map under a custom key.

[1]. https://github.com/wso2/api-manager/issues/3893