### PR TITLE
Add truststore password resolution using secure vault for websokcet apis

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -47,6 +47,8 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.inbound.InboundResponseSender;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.websocket.transport.utils.SSLUtil;
+import org.wso2.securevault.SecretResolverFactory;
+import org.wso2.securevault.commons.MiscellaneousUtil;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
@@ -202,7 +204,9 @@ public class WebsocketConnectionFactory {
                                     TRUST_STORE_PASSWORD));
 
                     final String location = trustStoreLocationElem.getText();
-                    final String storePassword = trustStorePasswordElem.getText();
+                    String storePassword = trustStorePasswordElem.getText();
+                    storePassword = MiscellaneousUtil.resolve(storePassword,
+                            SecretResolverFactory.create(trustParam.getParameterElement(), false));
                     sslCtx = SslContextBuilder.forClient()
                             .trustManager(SSLUtil.createTrustmanager(location,
                                     storePassword))


### PR DESCRIPTION
### Purpose
Fix password verification failure issue for WebSocket APIs when the truststore password is encrypted with Secure Vault.

### Approach
Resolve the encrypted truststore password using MiscellaneousUtil.resolve with SecretResolverFactory before loading the keystore.

Fixes: https://github.com/wso2/api-manager/issues/4151
