### PR TITLE
Update multiple dependencies (json-smart, Netty, saml.common.util, transport.http, carbon.analytics.common, synapse)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2700,7 +2700,7 @@
         <powermock.version>2.0.9</powermock.version>
         <!-- OAS3 Versions -->
         <swagger.parser.orbit.version>2.1.22.wso2v2</swagger.parser.orbit.version>
-        <transport.http.netty>6.3.53</transport.http.netty>
+        <transport.http.netty>6.3.55</transport.http.netty>
         <graalvm.version>22.3.4</graalvm.version>
         <icu.version>72.1</icu.version>
         <runtime.diagnostics.version>1.1.0</runtime.diagnostics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2638,7 +2638,7 @@
         <geronimo-jpa.version>1.1</geronimo-jpa.version>
         <geronimo-jta.version>1.1.1</geronimo-jta.version>
         <saxon.wso2.version>8.9.0.wso2v2</saxon.wso2.version>
-        <json.smart.version>2.5.2</json.smart.version>
+        <json.smart.version>2.6.0</json.smart.version>
         <damnhandy.version>2.1.6.wso2v2</damnhandy.version>
         <netty.version>4.1.118.Final</netty.version>
         <netty.tcnative.version>2.0.65.Final</netty.tcnative.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2640,7 +2640,7 @@
         <saxon.wso2.version>8.9.0.wso2v2</saxon.wso2.version>
         <json.smart.version>2.6.0</json.smart.version>
         <damnhandy.version>2.1.6.wso2v2</damnhandy.version>
-        <netty.version>4.1.118.Final</netty.version>
+        <netty.version>4.1.126.Final</netty.version>
         <netty.tcnative.version>2.0.65.Final</netty.tcnative.version>
         <javax.activation.version>0.0</javax.activation.version>
         <javax.servlet.imp.pkg.version>[2.4.0, 3.0.0)</javax.servlet.imp.pkg.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2540,7 +2540,7 @@
         <carbon.rule.version>4.5.6</carbon.rule.version>
         <carbon.rule.imp.pkg.version>[4.5.0, 4.6.0)</carbon.rule.imp.pkg.version>
         <!-- Synapse Version -->
-        <synapse.version>4.0.0-wso2v240</synapse.version>
+        <synapse.version>4.0.0-wso2v245</synapse.version>
         <carbon.identity.entitlement.proxy.version>5.4.8</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.2.0, 6.0.0)
         </carbon.identity.entitlement.proxy.imp.pkg.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2531,7 +2531,7 @@
         <carbon.registry.version>4.7.24</carbon.registry.version>
         <carbon.registry.imp.pkg.version>[4.7.0, 5.0.0)</carbon.registry.imp.pkg.version>
         <!-- Analytic Commons version-->
-        <carbon.analytics.common.version>5.3.23</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
         <carbon.analytics.common.imp.pkg.version>[5.2.0, 6.0.0)</carbon.analytics.common.imp.pkg.version>
         <!-- carbon.identity.framework.version-->
         <carbon.identity.framework.version>5.15.17</carbon.identity.framework.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2690,7 +2690,7 @@
         <activemq.broker.version>5.15.2</activemq.broker.version>
         <version.org.wso2.orbit.javax.activation>1.1.1.wso2v1</version.org.wso2.orbit.javax.activation>
         <maven.bundle.plugin.version>3.3.0</maven.bundle.plugin.version>
-        <saml.common.util.version>1.3.0</saml.common.util.version>
+        <saml.common.util.version>1.3.1</saml.common.util.version>
         <opensaml.orbit.version>3.3.1.wso2v11</opensaml.orbit.version>
         <jackson.dataformat.yaml.version>2.17.2</jackson.dataformat.yaml.version>
         <javax.validation.version>1.1.0.Final</javax.validation.version>


### PR DESCRIPTION
This PR updates multiple dependencies to their latest stable versions to improve security, performance, and compatibility.

### Changes Made

**JSON Processing Libraries:**
- **json-smart**: `2.5.2` → `2.6.0`

**Networking Libraries:**
- **io.netty**: `4.1.118.Final` → `4.1.126.Final`
- **transport.http**: `6.3.53` → `6.3.55`

**Identity Libraries:**
- **saml.common.util**: `1.3.0` → `1.3.1`

**Carbon Libraries:**
- **carbon.analytics.common**: `5.3.23` → `5.3.27`

**Integration Libraries:**
- **synapse**: `4.0.0-wso2v240` → `4.0.0-wso2v245`

Related Issue: https://github.com/wso2/api-manager/issues/3870
