### PR TITLE
Upgrade axiom and identity-entitlement-proxy versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2541,7 +2541,7 @@
         <carbon.rule.imp.pkg.version>[4.5.0, 4.6.0)</carbon.rule.imp.pkg.version>
         <!-- Synapse Version -->
         <synapse.version>4.0.0-wso2v250</synapse.version>
-        <carbon.identity.entitlement.proxy.version>5.4.8</carbon.identity.entitlement.proxy.version>
+        <carbon.identity.entitlement.proxy.version>5.4.9</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.2.0, 6.0.0)
         </carbon.identity.entitlement.proxy.imp.pkg.version>
         <carbon.identity.oauth.version>6.1.0</carbon.identity.oauth.version>
@@ -2553,7 +2553,7 @@
         <axis2.osgi.version.range>[1.6.1, 1.7.0)</axis2.osgi.version.range>
         <axis2.json.version>${orbit.version.axis2}</axis2.json.version>
         <!-- Axiom Version -->
-        <axiom.version>1.2.11-wso2v29</axiom.version>
+        <axiom.version>1.2.11-wso2v30</axiom.version>
         <axiom.api.wso2.version>${axiom.version}</axiom.api.wso2.version>
         <orbit.version.axiom>${axiom.version}</orbit.version.axiom>
         <axiom.wso2.version>${axiom.version}</axiom.wso2.version>


### PR DESCRIPTION
## Purpose
This pull request updates dependency versions in the `pom.xml` file to ensure the project uses the latest compatible libraries.

Dependency version updates:

* Upgraded the `carbon.identity.entitlement.proxy.version` from `5.4.8` to `5.4.9` to use the latest entitlement proxy library.
* Updated the `axiom.version` from `1.2.11-wso2v29` to `1.2.11-wso2v30` for improved compatibility and bug fixes.