### PR TITLE
Introduce timeouts for hashicorp vault lookup from synapse mediation

### DIFF
--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultConstant.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultConstant.java
@@ -39,5 +39,7 @@ public class HashiCorpVaultConstant {
     static final String KEY_STORE_PARAMETER = "keyStoreFile";
     static final String KEY_STORE_PASSWORD_PARAMETER = "keyStorePassword";
     static final String HTTPS_PARAMETER = "https";
+    static final String OPEN_TIMEOUT_PARAMETER = "openTimeout";
+    static final String READ_TIMEOUT_PARAMETER = "readTimeout";
     static final long LEAST_TTL_VALUE = -2000L;
 }

--- a/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultLookupHandlerImpl.java
+++ b/components/mediation-admin/org.wso2.carbon.mediation.security/src/main/java/org/wso2/carbon/mediation/security/vault/external/hashicorp/HashiCorpVaultLookupHandlerImpl.java
@@ -67,6 +67,9 @@ public class HashiCorpVaultLookupHandlerImpl implements ExternalVaultLookupHandl
 
 	private String currentAliasPassword;
 
+    private Integer openTimeout = 5;
+    private Integer readTimeout = 10;
+
 	private HashiCorpVaultLookupHandlerImpl() throws ExternalVaultException {
 		try {
 			initialize();
@@ -249,6 +252,20 @@ public class HashiCorpVaultLookupHandlerImpl implements ExternalVaultLookupHandl
 		if (parameters.containsKey(HashiCorpVaultConstant.ROLE_ID_PARAMETER)) {
 			roleId = parameters.get(HashiCorpVaultConstant.ROLE_ID_PARAMETER);
 		}
+
+        if (parameters.containsKey(HashiCorpVaultConstant.OPEN_TIMEOUT_PARAMETER) &&
+                !parameters.get(HashiCorpVaultConstant.OPEN_TIMEOUT_PARAMETER).isEmpty() &&
+                parameters.get(HashiCorpVaultConstant.OPEN_TIMEOUT_PARAMETER)
+                        .matches(HashiCorpVaultConstant.NUMBER_REGEX)) {
+            openTimeout = Integer.parseInt(parameters.get(HashiCorpVaultConstant.OPEN_TIMEOUT_PARAMETER));
+        }
+
+        if (parameters.containsKey(HashiCorpVaultConstant.READ_TIMEOUT_PARAMETER) &&
+                !parameters.get(HashiCorpVaultConstant.READ_TIMEOUT_PARAMETER).isEmpty() &&
+                parameters.get(HashiCorpVaultConstant.READ_TIMEOUT_PARAMETER)
+                        .matches(HashiCorpVaultConstant.NUMBER_REGEX)) {
+            readTimeout = Integer.parseInt(parameters.get(HashiCorpVaultConstant.READ_TIMEOUT_PARAMETER));
+        }
 	}
 
 	/**
@@ -310,6 +327,8 @@ public class HashiCorpVaultLookupHandlerImpl implements ExternalVaultLookupHandl
 		if (vaultNamespace != null) {
 			config = config.nameSpace(vaultNamespace);
 		}
+
+        config.openTimeout(openTimeout).readTimeout(readTimeout);
 
 		return config.build();
 	}


### PR DESCRIPTION
## Purpose

This PR adds configurable connection and read timeouts for HashiCorp Vault lookups used by the `hashicorp:vault-lookup` XPath function.

Previously, when the configured Vault address was incorrect or unreachable, the gateway request could wait until the underlying JVM/OS network timeout completed, which could take around a minute before returning a runtime error. This happened because the Vault client did not explicitly configure connection or read timeouts.

## Changes

- Added `openTimeout` and `readTimeout` parameters for HashiCorp Vault configuration.
- Introduced default timeout values:
  - `openTimeout`: `5` seconds
  - `readTimeout`: `10` seconds
- Applied these timeout values to the BetterCloud `VaultConfig`.

## Behavior

- If timeout parameters are not configured, the default values `5` and `10` are used.
- If both timeout values are configured as `0`, the behavior is the same as not having client-side timeouts, since Java treats zero timeout as infinite.
- With AppRole authentication, the timeout applies during `authenticateHashiCorpVault()`, where the client attempts to connect to Vault and generate a client token.
- With root token authentication, initialization bypasses `authenticateHashiCorpVault()` because the token is already configured. In that case, the timeouts are not used in the flow as if the request to get secret fails, it throws an exception at the right moment.

## Timeout Semantics

- `openTimeout`: Maximum time the client waits to establish a connection to the Vault server.
- `readTimeout`: Maximum time the client waits for data after the connection has been established.

## Testing

Tested the following scenarios:

- Timeout parameters not configured: default values `5` and `10` are applied.
- Timeout parameters are configured: timeouts are corresponding to the added values.
- Both timeout parameters configured as `0`: behavior matches the previous no-timeout scenario.
- Root token authentication: initialization bypasses AppRole authentication, and throws an error if the host is incorrect.
