### PR TITLE
[APIM] WebSocket Transport Proxy Support via Proxy Profiles

### DIFF
--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/pom.xml
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/pom.xml
@@ -89,6 +89,10 @@
             <artifactId>netty-codec</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-base</artifactId>
         </dependency>

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -65,6 +65,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 public class WebsocketConnectionFactory {
 
@@ -72,10 +74,10 @@ public class WebsocketConnectionFactory {
 
     private static final QName Q_PROFILE        = new QName("profile");
     private static final QName Q_TARGET_HOSTS   = new QName("targetHosts");
-    private static final QName Q_PROXY_HOST_EL  = new QName("proxyHost");
-    private static final QName Q_PROXY_PORT_EL  = new QName("proxyPort");
-    private static final QName Q_PROXY_USER     = new QName("proxyUserName");
-    private static final QName Q_PROXY_PASS     = new QName("proxyPassword");
+    private static final QName Q_PROXY_HOST      = new QName("proxyHost");
+    private static final QName Q_PROXY_PORT      = new QName("proxyPort");
+    private static final QName Q_PROXY_USERNAME  = new QName("proxyUserName");
+    private static final QName Q_PROXY_PASSWORD  = new QName("proxyPassword");
     private static final QName Q_BYPASS         = new QName("bypass");
 
     /**
@@ -161,6 +163,7 @@ public class WebsocketConnectionFactory {
             return;
         }
         OMElement profilesElt = profilesParam.getParameterElement();
+        SecretResolver secretResolver = SecretResolverFactory.create(profilesElt, false);
         Iterator<?> profiles = profilesElt.getChildrenWithName(Q_PROFILE);
         while (profiles.hasNext()) {
             OMElement profile = (OMElement) profiles.next();
@@ -169,38 +172,64 @@ public class WebsocketConnectionFactory {
                 log.warn("Skipping ws proxy profile: missing or empty <targetHosts>");
                 continue;
             }
-            OMElement proxyHostElt = profile.getFirstChildWithName(Q_PROXY_HOST_EL);
-            OMElement proxyPortElt = profile.getFirstChildWithName(Q_PROXY_PORT_EL);
+            OMElement proxyHostElt = profile.getFirstChildWithName(Q_PROXY_HOST);
+            OMElement proxyPortElt = profile.getFirstChildWithName(Q_PROXY_PORT);
             if (proxyHostElt == null || proxyPortElt == null) {
                 log.warn("Skipping ws proxy profile for [" + targetHostsElt.getText()
                         + "]: missing <proxyHost> or <proxyPort>");
                 continue;
             }
-            String pHost = proxyHostElt.getText().trim();
-            int pPort = Integer.parseInt(proxyPortElt.getText().trim());
-            String pUser = null;
-            String pPass = null;
-            OMElement userElt = profile.getFirstChildWithName(Q_PROXY_USER);
-            OMElement passElt = profile.getFirstChildWithName(Q_PROXY_PASS);
-            if (userElt != null) {
-                pUser = userElt.getText().trim();
-                pPass = passElt != null ? passElt.getText().trim() : "";
+            String proxyHost = proxyHostElt.getText().trim();
+            int proxyPort;
+            try {
+                proxyPort = Integer.parseInt(proxyPortElt.getText().trim());
+            } catch (NumberFormatException e) {
+                log.warn("Skipping ws proxy profile for [" + targetHostsElt.getText()
+                        + "]: invalid <proxyPort> value '" + proxyPortElt.getText().trim() + "'");
+                continue;
+            }
+            String proxyUsername = null;
+            String proxyPassword = null;
+            OMElement usernameElt = profile.getFirstChildWithName(Q_PROXY_USERNAME);
+            OMElement passwordElt = profile.getFirstChildWithName(Q_PROXY_PASSWORD);
+            if (usernameElt != null) {
+                proxyUsername = usernameElt.getText().trim();
+                proxyPassword = passwordElt != null
+                        ? MiscellaneousUtil.resolve(passwordElt.getText().trim(), secretResolver)
+                        : "";
             }
             Set<String> bypassSet = new HashSet<>();
             OMElement bypassElt = profile.getFirstChildWithName(Q_BYPASS);
             if (bypassElt != null && !bypassElt.getText().trim().isEmpty()) {
-                for (String b : bypassElt.getText().split(",")) {
-                    bypassSet.add(b.trim());
+                for (String rawEntry : bypassElt.getText().split(",")) {
+                    String bypassPattern = rawEntry.trim();
+                    try {
+                        Pattern.compile(bypassPattern);
+                        bypassSet.add(bypassPattern);
+                    } catch (PatternSyntaxException e) {
+                        log.warn("Skipping invalid bypass regex '" + bypassPattern
+                                + "' in ws proxy profile for [" + targetHostsElt.getText()
+                                + "]: " + e.getMessage());
+                    }
                 }
             }
-            WsProxyProfileConfig config =
-                    new WsProxyProfileConfig(pHost, pPort, pUser, pPass, bypassSet);
-            for (String target : targetHostsElt.getText().split(",")) {
-                target = target.trim();
-                if (!proxyProfileMap.containsKey(target)) {
-                    proxyProfileMap.put(target, config);
+            WsProxyProfileConfig profileConfig =
+                    new WsProxyProfileConfig(proxyHost, proxyPort, proxyUsername, proxyPassword, bypassSet);
+            for (String targetHostPattern : targetHostsElt.getText().split(",")) {
+                targetHostPattern = targetHostPattern.trim();
+                if (!"*".equals(targetHostPattern)) {
+                    try {
+                        Pattern.compile(targetHostPattern);
+                    } catch (PatternSyntaxException e) {
+                        log.warn("Skipping invalid targetHost regex '" + targetHostPattern
+                                + "' in ws proxy profile: " + e.getMessage());
+                        continue;
+                    }
+                }
+                if (!proxyProfileMap.containsKey(targetHostPattern)) {
+                    proxyProfileMap.put(targetHostPattern, profileConfig);
                 } else {
-                    log.warn("Duplicate ws proxy profile for targetHost [" + target
+                    log.warn("Duplicate ws proxy profile for targetHost [" + targetHostPattern
                             + "] — ignoring");
                 }
             }
@@ -471,10 +500,10 @@ public class WebsocketConnectionFactory {
      */
     private HttpProxyHandler resolveProxyHandler(String targetHost) {
         if (!proxyProfileMap.isEmpty()) {
-            WsProxyProfileConfig profile = getProfileForHost(targetHost);
-            if (profile != null) {
-                return buildProxyHandler(profile.proxyHost, profile.proxyPort,
-                        profile.proxyUsername, profile.proxyPassword);
+            WsProxyProfileConfig matchedProfile = getProfileForHost(targetHost);
+            if (matchedProfile != null) {
+                return buildProxyHandler(matchedProfile.proxyHost, matchedProfile.proxyPort,
+                        matchedProfile.proxyUsername, matchedProfile.proxyPassword);
             }
         }
         return null;
@@ -504,17 +533,17 @@ public class WebsocketConnectionFactory {
         if (knownDirectHosts.contains(targetHost)) {
             return null;
         }
-        boolean defaultProfile = false;
-        for (String key : proxyProfileMap.keySet()) {
-            if ("*".equals(key)) {
-                defaultProfile = true;
+        boolean hasCatchAllProfile = false;
+        for (String profileKey : proxyProfileMap.keySet()) {
+            if ("*".equals(profileKey)) {
+                hasCatchAllProfile = true;
                 continue;
             }
-            if (targetHost.matches(key)) {
-                return resolveWithBypass(targetHost, key);
+            if (targetHost.matches(profileKey)) {
+                return resolveWithBypass(targetHost, profileKey);
             }
         }
-        if (defaultProfile) {
+        if (hasCatchAllProfile) {
             return resolveWithBypass(targetHost, "*");
         }
         return null;
@@ -529,24 +558,24 @@ public class WebsocketConnectionFactory {
      * {@link #knownProxyConfigMap} and returned so the host is proxied on this and all
      * subsequent connections.
      *
-     * @param targetHost the backend WebSocket host that matched the profile keyed by {@code key}
-     * @param key        the key in {@link #proxyProfileMap} whose profile was matched ({@code "*"} for the default)
+     * @param targetHost the backend WebSocket host that matched the profile keyed by {@code profileKey}
+     * @param profileKey the key in {@link #proxyProfileMap} whose profile was matched ({@code "*"} for the default)
      * @return the matched {@link WsProxyProfileConfig} to proxy through, or {@code null} to connect directly
      */
-    private WsProxyProfileConfig resolveWithBypass(String targetHost, String key) {
-        WsProxyProfileConfig profile = proxyProfileMap.get(key);
-        for (String bypass : profile.bypass) {
-            if (targetHost.matches(bypass)) {
+    private WsProxyProfileConfig resolveWithBypass(String targetHost, String profileKey) {
+        WsProxyProfileConfig matchedProfile = proxyProfileMap.get(profileKey);
+        for (String bypassPattern : matchedProfile.bypass) {
+            if (targetHost.matches(bypassPattern)) {
                 knownDirectHosts.add(targetHost);
                 if (log.isDebugEnabled()) {
                     log.debug("ws proxy bypass matched: host=" + targetHost
-                            + " bypass=" + bypass);
+                            + " bypass=" + bypassPattern);
                 }
                 return null;
             }
         }
-        knownProxyConfigMap.put(targetHost, profile);
-        return profile;
+        knownProxyConfigMap.put(targetHost, matchedProfile);
+        return matchedProfile;
     }
 
     /**

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -58,18 +58,57 @@ import javax.net.ssl.SSLParameters;
 import javax.xml.namespace.QName;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class WebsocketConnectionFactory {
 
     private static final Log log = LogFactory.getLog(WebsocketConnectionFactory.class);
 
+    private static final QName Q_PROFILE        = new QName("profile");
+    private static final QName Q_TARGET_HOSTS   = new QName("targetHosts");
+    private static final QName Q_PROXY_HOST_EL  = new QName("proxyHost");
+    private static final QName Q_PROXY_PORT_EL  = new QName("proxyPort");
+    private static final QName Q_PROXY_USER     = new QName("proxyUserName");
+    private static final QName Q_PROXY_PASS     = new QName("proxyPassword");
+    private static final QName Q_BYPASS         = new QName("bypass");
+
+    private static class WsProxyProfileConfig {
+        final String proxyHost;
+        final int proxyPort;
+        final String proxyUsername;
+        final String proxyPassword;
+        final Set<String> bypass;
+
+        WsProxyProfileConfig(String proxyHost, int proxyPort,
+                             String proxyUsername, String proxyPassword,
+                             Set<String> bypass) {
+            this.proxyHost    = proxyHost;
+            this.proxyPort    = proxyPort;
+            this.proxyUsername = proxyUsername;
+            this.proxyPassword = proxyPassword;
+            this.bypass       = bypass;
+        }
+    }
+
     private final EventLoopGroup sharedEventLoopGroup;
     private final TransportOutDescription transportOut;
     private ConcurrentHashMap<String, ConcurrentHashMap<String, WebSocketClientHandler>>
             channelHandlerPool = new ConcurrentHashMap<String, ConcurrentHashMap<String, WebSocketClientHandler>>();
 
+    // proxyProfiles path — populated from ws.proxyProfiles parameter
+    private Map<String, WsProxyProfileConfig> proxyProfileMap = new HashMap<>();
+    private final Set<String> knownDirectHosts =
+            Collections.synchronizedSet(new HashSet<>());
+    private final Map<String, WsProxyProfileConfig> knownProxyConfigMap =
+            new ConcurrentHashMap<>();
+
+    // flat proxy path — only used when proxyProfileMap is empty
     private String proxyHost;
     private int proxyPort = -1;
     private String proxyUsername;
@@ -106,6 +145,65 @@ public class WebsocketConnectionFactory {
             }
         }
 
+        loadProxyConfig(transportOut);
+    }
+
+    private void loadProxyConfig(TransportOutDescription transportOut) {
+        Parameter profilesParam = transportOut.getParameter(WebsocketConstants.PROXY_PROFILES);
+        if (profilesParam != null) {
+            OMElement profilesElt = profilesParam.getParameterElement();
+            Iterator<?> profiles = profilesElt.getChildrenWithName(Q_PROFILE);
+            while (profiles.hasNext()) {
+                OMElement profile = (OMElement) profiles.next();
+                OMElement targetHostsElt = profile.getFirstChildWithName(Q_TARGET_HOSTS);
+                if (targetHostsElt == null || targetHostsElt.getText().trim().isEmpty()) {
+                    log.warn("Skipping ws proxy profile: missing or empty <targetHosts>");
+                    continue;
+                }
+                OMElement proxyHostElt = profile.getFirstChildWithName(Q_PROXY_HOST_EL);
+                OMElement proxyPortElt = profile.getFirstChildWithName(Q_PROXY_PORT_EL);
+                if (proxyHostElt == null || proxyPortElt == null) {
+                    log.warn("Skipping ws proxy profile for [" + targetHostsElt.getText()
+                            + "]: missing <proxyHost> or <proxyPort>");
+                    continue;
+                }
+                String pHost = proxyHostElt.getText().trim();
+                int pPort = Integer.parseInt(proxyPortElt.getText().trim());
+                String pUser = null;
+                String pPass = null;
+                OMElement userElt = profile.getFirstChildWithName(Q_PROXY_USER);
+                OMElement passElt = profile.getFirstChildWithName(Q_PROXY_PASS);
+                if (userElt != null) {
+                    pUser = userElt.getText().trim();
+                    pPass = passElt != null ? passElt.getText().trim() : "";
+                }
+                Set<String> bypassSet = new HashSet<>();
+                OMElement bypassElt = profile.getFirstChildWithName(Q_BYPASS);
+                if (bypassElt != null && !bypassElt.getText().trim().isEmpty()) {
+                    for (String b : bypassElt.getText().split(",")) {
+                        bypassSet.add(b.trim());
+                    }
+                }
+                WsProxyProfileConfig config =
+                        new WsProxyProfileConfig(pHost, pPort, pUser, pPass, bypassSet);
+                for (String target : targetHostsElt.getText().split(",")) {
+                    target = target.trim();
+                    if (!proxyProfileMap.containsKey(target)) {
+                        proxyProfileMap.put(target, config);
+                    } else {
+                        log.warn("Duplicate ws proxy profile for targetHost [" + target
+                                + "] — ignoring");
+                    }
+                }
+            }
+            if (!proxyProfileMap.isEmpty()) {
+                log.info(transportOut.getName() + " ws proxy profiles loaded for "
+                        + proxyProfileMap.size() + " targetHost(s)");
+                return;
+            }
+        }
+
+        // No profiles — fall back to flat params
         Parameter proxyHostParam = transportOut.getParameter(WebsocketConstants.PROXY_HOST);
         if (proxyHostParam != null) {
             this.proxyHost = proxyHostParam.getParameterElement().getText();
@@ -122,7 +220,8 @@ public class WebsocketConnectionFactory {
                 this.proxyPassword = proxyPasswordParam.getParameterElement().getText();
             }
             if (log.isDebugEnabled()) {
-                log.debug("WebSocket outbound proxy configured: " + this.proxyHost + ":" + this.proxyPort);
+                log.debug(transportOut.getName()
+                        + " ws flat proxy configured: " + this.proxyHost + ":" + this.proxyPort);
             }
         }
     }
@@ -323,13 +422,9 @@ public class WebsocketConnectionFactory {
                                         + ", ThreadID: " + Thread.currentThread().getId());
                             }
                             ChannelPipeline p = ch.pipeline();
-                            if (proxyHost != null && proxyPort > 0) {
-                                InetSocketAddress proxyAddress = new InetSocketAddress(proxyHost, proxyPort);
-                                if (proxyUsername != null && !proxyUsername.isEmpty()) {
-                                    p.addLast(new HttpProxyHandler(proxyAddress, proxyUsername, proxyPassword));
-                                } else {
-                                    p.addLast(new HttpProxyHandler(proxyAddress));
-                                }
+                            HttpProxyHandler proxyHandler = resolveProxyHandler(host);
+                            if (proxyHandler != null) {
+                                p.addLast(proxyHandler);
                             }
                             if (sslCtx != null) {
                                 SslHandler sslHandler = sslCtx.newHandler(ch.alloc(), host, port);
@@ -377,6 +472,69 @@ public class WebsocketConnectionFactory {
         }
 
         return null;
+    }
+
+    private HttpProxyHandler resolveProxyHandler(String targetHost) {
+        if (!proxyProfileMap.isEmpty()) {
+            WsProxyProfileConfig profile = getProfileForHost(targetHost);
+            if (profile != null) {
+                return buildProxyHandler(profile.proxyHost, profile.proxyPort,
+                        profile.proxyUsername, profile.proxyPassword);
+            }
+            return null;
+        }
+        if (proxyHost != null && proxyPort > 0) {
+            return buildProxyHandler(proxyHost, proxyPort, proxyUsername, proxyPassword);
+        }
+        return null;
+    }
+
+    private WsProxyProfileConfig getProfileForHost(String targetHost) {
+        if (knownProxyConfigMap.containsKey(targetHost)) {
+            return knownProxyConfigMap.get(targetHost);
+        }
+        if (knownDirectHosts.contains(targetHost)) {
+            return null;
+        }
+        boolean defaultProfile = false;
+        for (String key : proxyProfileMap.keySet()) {
+            if ("*".equals(key)) {
+                defaultProfile = true;
+                continue;
+            }
+            if (targetHost.matches(key)) {
+                return resolveWithBypass(targetHost, key);
+            }
+        }
+        if (defaultProfile) {
+            return resolveWithBypass(targetHost, "*");
+        }
+        return null;
+    }
+
+    private WsProxyProfileConfig resolveWithBypass(String targetHost, String key) {
+        WsProxyProfileConfig profile = proxyProfileMap.get(key);
+        for (String bypass : profile.bypass) {
+            if (targetHost.matches(bypass)) {
+                knownDirectHosts.add(targetHost);
+                if (log.isDebugEnabled()) {
+                    log.debug("ws proxy bypass matched: host=" + targetHost
+                            + " bypass=" + bypass);
+                }
+                return null;
+            }
+        }
+        knownProxyConfigMap.put(targetHost, profile);
+        return profile;
+    }
+
+    private HttpProxyHandler buildProxyHandler(String host, int port,
+                                               String username, String password) {
+        InetSocketAddress proxyAddress = new InetSocketAddress(host, port);
+        if (username != null && !username.isEmpty()) {
+            return new HttpProxyHandler(proxyAddress, username, password);
+        }
+        return new HttpProxyHandler(proxyAddress);
     }
 
     private String deriveSubprotocol(String wsSubprotocol, String contentType) {

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -49,6 +49,7 @@ import org.apache.synapse.inbound.InboundResponseSender;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.websocket.transport.utils.SSLUtil;
 import org.wso2.securevault.SecretResolver;
+import org.wso2.securevault.SecretResolverFactory;
 import org.wso2.securevault.commons.MiscellaneousUtil;
 
 import javax.net.ssl.SSLEngine;

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -112,12 +112,6 @@ public class WebsocketConnectionFactory {
     private final Map<String, WsProxyProfileConfig> knownProxyConfigMap =
             new ConcurrentHashMap<>();
 
-    // flat proxy path — only used when proxyProfileMap is empty
-    private String proxyHost;
-    private int proxyPort = -1;
-    private String proxyUsername;
-    private String proxyPassword;
-
     public WebsocketConnectionFactory(TransportOutDescription transportOut) throws AxisFault {
         this.transportOut = transportOut;
         int sharedEventLoopPoolSize = getMaxValueOrDefault(
@@ -153,94 +147,67 @@ public class WebsocketConnectionFactory {
     }
 
     /**
-     * Reads proxy configuration from the transport sender descriptor at startup.
+     * Reads proxy profile configuration from the transport sender descriptor at startup.
      * <p>
      * If a {@code ws.proxyProfiles} parameter is present, each {@code <profile>} child is
      * parsed into a {@link WsProxyProfileConfig} and stored in {@link #proxyProfileMap} keyed
-     * by each comma-separated targetHost pattern. When at least one profile is loaded the method
-     * returns immediately — flat proxy parameters are ignored entirely.
-     * <p>
-     * If no profiles are defined (or the parameter is absent), the flat parameters
-     * {@code ws.proxy.host}, {@code ws.proxy.port}, {@code ws.proxy.username}, and
-     * {@code ws.proxy.password} are read instead.
+     * by each comma-separated targetHost pattern.
      *
      * @param transportOut the transport sender descriptor from axis2.xml
      */
     private void loadProxyConfig(TransportOutDescription transportOut) {
         Parameter profilesParam = transportOut.getParameter(WebsocketConstants.PROXY_PROFILES);
-        if (profilesParam != null) {
-            OMElement profilesElt = profilesParam.getParameterElement();
-            Iterator<?> profiles = profilesElt.getChildrenWithName(Q_PROFILE);
-            while (profiles.hasNext()) {
-                OMElement profile = (OMElement) profiles.next();
-                OMElement targetHostsElt = profile.getFirstChildWithName(Q_TARGET_HOSTS);
-                if (targetHostsElt == null || targetHostsElt.getText().trim().isEmpty()) {
-                    log.warn("Skipping ws proxy profile: missing or empty <targetHosts>");
-                    continue;
-                }
-                OMElement proxyHostElt = profile.getFirstChildWithName(Q_PROXY_HOST_EL);
-                OMElement proxyPortElt = profile.getFirstChildWithName(Q_PROXY_PORT_EL);
-                if (proxyHostElt == null || proxyPortElt == null) {
-                    log.warn("Skipping ws proxy profile for [" + targetHostsElt.getText()
-                            + "]: missing <proxyHost> or <proxyPort>");
-                    continue;
-                }
-                String pHost = proxyHostElt.getText().trim();
-                int pPort = Integer.parseInt(proxyPortElt.getText().trim());
-                String pUser = null;
-                String pPass = null;
-                OMElement userElt = profile.getFirstChildWithName(Q_PROXY_USER);
-                OMElement passElt = profile.getFirstChildWithName(Q_PROXY_PASS);
-                if (userElt != null) {
-                    pUser = userElt.getText().trim();
-                    pPass = passElt != null ? passElt.getText().trim() : "";
-                }
-                Set<String> bypassSet = new HashSet<>();
-                OMElement bypassElt = profile.getFirstChildWithName(Q_BYPASS);
-                if (bypassElt != null && !bypassElt.getText().trim().isEmpty()) {
-                    for (String b : bypassElt.getText().split(",")) {
-                        bypassSet.add(b.trim());
-                    }
-                }
-                WsProxyProfileConfig config =
-                        new WsProxyProfileConfig(pHost, pPort, pUser, pPass, bypassSet);
-                for (String target : targetHostsElt.getText().split(",")) {
-                    target = target.trim();
-                    if (!proxyProfileMap.containsKey(target)) {
-                        proxyProfileMap.put(target, config);
-                    } else {
-                        log.warn("Duplicate ws proxy profile for targetHost [" + target
-                                + "] — ignoring");
-                    }
+        if (profilesParam == null) {
+            return;
+        }
+        OMElement profilesElt = profilesParam.getParameterElement();
+        Iterator<?> profiles = profilesElt.getChildrenWithName(Q_PROFILE);
+        while (profiles.hasNext()) {
+            OMElement profile = (OMElement) profiles.next();
+            OMElement targetHostsElt = profile.getFirstChildWithName(Q_TARGET_HOSTS);
+            if (targetHostsElt == null || targetHostsElt.getText().trim().isEmpty()) {
+                log.warn("Skipping ws proxy profile: missing or empty <targetHosts>");
+                continue;
+            }
+            OMElement proxyHostElt = profile.getFirstChildWithName(Q_PROXY_HOST_EL);
+            OMElement proxyPortElt = profile.getFirstChildWithName(Q_PROXY_PORT_EL);
+            if (proxyHostElt == null || proxyPortElt == null) {
+                log.warn("Skipping ws proxy profile for [" + targetHostsElt.getText()
+                        + "]: missing <proxyHost> or <proxyPort>");
+                continue;
+            }
+            String pHost = proxyHostElt.getText().trim();
+            int pPort = Integer.parseInt(proxyPortElt.getText().trim());
+            String pUser = null;
+            String pPass = null;
+            OMElement userElt = profile.getFirstChildWithName(Q_PROXY_USER);
+            OMElement passElt = profile.getFirstChildWithName(Q_PROXY_PASS);
+            if (userElt != null) {
+                pUser = userElt.getText().trim();
+                pPass = passElt != null ? passElt.getText().trim() : "";
+            }
+            Set<String> bypassSet = new HashSet<>();
+            OMElement bypassElt = profile.getFirstChildWithName(Q_BYPASS);
+            if (bypassElt != null && !bypassElt.getText().trim().isEmpty()) {
+                for (String b : bypassElt.getText().split(",")) {
+                    bypassSet.add(b.trim());
                 }
             }
-            if (!proxyProfileMap.isEmpty()) {
-                log.info(transportOut.getName() + " ws proxy profiles loaded for "
-                        + proxyProfileMap.size() + " targetHost(s)");
-                return;
+            WsProxyProfileConfig config =
+                    new WsProxyProfileConfig(pHost, pPort, pUser, pPass, bypassSet);
+            for (String target : targetHostsElt.getText().split(",")) {
+                target = target.trim();
+                if (!proxyProfileMap.containsKey(target)) {
+                    proxyProfileMap.put(target, config);
+                } else {
+                    log.warn("Duplicate ws proxy profile for targetHost [" + target
+                            + "] — ignoring");
+                }
             }
         }
-
-        // No profiles — fall back to flat params
-        Parameter proxyHostParam = transportOut.getParameter(WebsocketConstants.PROXY_HOST);
-        if (proxyHostParam != null) {
-            this.proxyHost = proxyHostParam.getParameterElement().getText();
-            Parameter proxyPortParam = transportOut.getParameter(WebsocketConstants.PROXY_PORT);
-            if (proxyPortParam != null) {
-                this.proxyPort = Integer.parseInt(proxyPortParam.getParameterElement().getText());
-            }
-            Parameter proxyUsernameParam = transportOut.getParameter(WebsocketConstants.PROXY_USERNAME);
-            if (proxyUsernameParam != null) {
-                this.proxyUsername = proxyUsernameParam.getParameterElement().getText();
-            }
-            Parameter proxyPasswordParam = transportOut.getParameter(WebsocketConstants.PROXY_PASSWORD);
-            if (proxyPasswordParam != null) {
-                this.proxyPassword = proxyPasswordParam.getParameterElement().getText();
-            }
-            if (log.isDebugEnabled()) {
-                log.debug(transportOut.getName()
-                        + " ws flat proxy configured: " + this.proxyHost + ":" + this.proxyPort);
-            }
+        if (!proxyProfileMap.isEmpty()) {
+            log.info(transportOut.getName() + " ws proxy profiles loaded for "
+                    + proxyProfileMap.size() + " targetHost(s)");
         }
     }
 
@@ -496,9 +463,8 @@ public class WebsocketConnectionFactory {
      * Returns a configured {@link HttpProxyHandler} for the given backend host, or {@code null}
      * if no proxy applies.
      * <p>
-     * When proxy profiles are defined, delegates to {@link #getProfileForHost(String)} to select
-     * the matching profile. When only flat proxy parameters were configured, uses those directly.
-     * Returns {@code null} in both cases when no proxy configuration matches the host.
+     * Delegates to {@link #getProfileForHost(String)} to select the matching profile from
+     * {@link #proxyProfileMap}. Returns {@code null} when no profile matches.
      *
      * @param targetHost the backend WebSocket host being connected to (e.g., {@code backend.example.com})
      * @return a ready-to-use {@link HttpProxyHandler}, or {@code null} for a direct connection
@@ -510,10 +476,6 @@ public class WebsocketConnectionFactory {
                 return buildProxyHandler(profile.proxyHost, profile.proxyPort,
                         profile.proxyUsername, profile.proxyPassword);
             }
-            return null;
-        }
-        if (proxyHost != null && proxyPort > 0) {
-            return buildProxyHandler(proxyHost, proxyPort, proxyUsername, proxyPassword);
         }
         return null;
     }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -393,6 +393,14 @@ public class WebsocketConnectionFactory {
         return null;
     }
 
+    /**
+     * Returns a configured {@link HttpProxyHandler} for the given backend host by delegating
+     * to {@link WsProxyProfileRegistry#resolveProxyHandler(String)}, or {@code null} if no
+     * proxy profiles are configured or the host should connect directly.
+     *
+     * @param targetHost the backend WebSocket host to match against configured proxy profiles
+     * @return a ready-to-use {@link HttpProxyHandler}, or {@code null} for a direct connection
+     */
     private HttpProxyHandler resolveProxyHandler(String targetHost) {
         if (proxyRegistry == null) {
             return null;

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -49,7 +49,6 @@ import org.apache.synapse.inbound.InboundResponseSender;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.websocket.transport.utils.SSLUtil;
 import org.wso2.securevault.SecretResolver;
-import org.wso2.securevault.SecretResolverFactory;
 import org.wso2.securevault.commons.MiscellaneousUtil;
 
 import javax.net.ssl.SSLEngine;
@@ -71,7 +70,39 @@ public class WebsocketConnectionFactory {
 
     private final WsProxyProfileRegistry proxyRegistry;
 
+    /**
+     * Creates a new factory using a fallback {@link SecretResolver} derived from the
+     * {@code ws.proxyProfiles} parameter element. Proxy passwords protected with
+     * {@code $secret{alias}} will only be resolved if the element carries the SecureVault
+     * namespace; prefer {@link #WebsocketConnectionFactory(TransportOutDescription, SecretResolver)}
+     * when an initialized resolver is available (e.g. from
+     * {@code AxisConfiguration.getSecretResolver()}).
+     *
+     * @param transportOut the WS/WSS transport-sender descriptor from axis2.xml
+     * @throws AxisFault if the WSS trust-store parameters are missing or malformed
+     */
     public WebsocketConnectionFactory(TransportOutDescription transportOut) throws AxisFault {
+        this(transportOut, null);
+    }
+
+    /**
+     * Creates a new factory with an explicitly supplied {@link SecretResolver}.
+     *
+     * <p>Pass the globally initialized resolver (obtained from
+     * {@code ConfigurationContext.getAxisConfiguration().getSecretResolver()}) so that
+     * proxy passwords stored as {@code $secret{alias}} in axis2.xml are decrypted at
+     * startup rather than transmitted as literal strings. When {@code secretResolver} is
+     * {@code null} the constructor falls back to deriving a resolver from the
+     * {@code ws.proxyProfiles} parameter element (same behaviour as the single-argument
+     * constructor).
+     *
+     * @param transportOut   the WS/WSS transport-sender descriptor from axis2.xml
+     * @param secretResolver an initialized SecureVault resolver, or {@code null} to use
+     *                       the element-scoped fallback
+     * @throws AxisFault if the WSS trust-store parameters are missing or malformed
+     */
+    public WebsocketConnectionFactory(TransportOutDescription transportOut,
+                                      SecretResolver secretResolver) throws AxisFault {
         this.transportOut = transportOut;
         int sharedEventLoopPoolSize = getMaxValueOrDefault(
                 transportOut.getParameter(WebsocketConstants.WEBSOCKET_SHARED_EVENT_LOOP_POOL_SIZE), -1);
@@ -105,8 +136,10 @@ public class WebsocketConnectionFactory {
         Parameter profilesParam = transportOut.getParameter(WebsocketConstants.PROXY_PROFILES);
         if (profilesParam != null) {
             OMElement profilesElement = profilesParam.getParameterElement();
-            SecretResolver secretResolver = SecretResolverFactory.create(profilesElement, false);
-            this.proxyRegistry = new WsProxyProfileRegistry(profilesElement, secretResolver);
+            SecretResolver resolverToUse = secretResolver != null
+                    ? secretResolver
+                    : SecretResolverFactory.create(profilesElement, false);
+            this.proxyRegistry = new WsProxyProfileRegistry(profilesElement, resolverToUse);
         } else {
             this.proxyRegistry = null;
         }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -72,38 +72,14 @@ public class WebsocketConnectionFactory {
     private final WsProxyProfileRegistry proxyRegistry;
 
     /**
-     * Creates a new factory using a fallback {@link SecretResolver} derived from the
-     * {@code ws.proxyProfiles} parameter element. Proxy passwords protected with
-     * {@code $secret{alias}} will only be resolved if the element carries the SecureVault
-     * namespace; prefer {@link #WebsocketConnectionFactory(TransportOutDescription, SecretResolver)}
-     * when an initialized resolver is available (e.g. from
-     * {@code AxisConfiguration.getSecretResolver()}).
+     * Creates a new factory. Proxy passwords are stored as raw text during startup and
+     * resolved via SecureVault at connection time using the {@link SecretResolver} threaded
+     * through from {@link #getChannelHandler}.
      *
      * @param transportOut the WS/WSS transport-sender descriptor from axis2.xml
      * @throws AxisFault if the WSS trust-store parameters are missing or malformed
      */
     public WebsocketConnectionFactory(TransportOutDescription transportOut) throws AxisFault {
-        this(transportOut, null);
-    }
-
-    /**
-     * Creates a new factory with an explicitly supplied {@link SecretResolver}.
-     *
-     * <p>Pass the globally initialized resolver (obtained from
-     * {@code ConfigurationContext.getAxisConfiguration().getSecretResolver()}) so that
-     * proxy passwords stored as {@code $secret{alias}} in axis2.xml are decrypted at
-     * startup rather than transmitted as literal strings. When {@code secretResolver} is
-     * {@code null} the constructor falls back to deriving a resolver from the
-     * {@code ws.proxyProfiles} parameter element (same behaviour as the single-argument
-     * constructor).
-     *
-     * @param transportOut   the WS/WSS transport-sender descriptor from axis2.xml
-     * @param secretResolver an initialized SecureVault resolver, or {@code null} to use
-     *                       the element-scoped fallback
-     * @throws AxisFault if the WSS trust-store parameters are missing or malformed
-     */
-    public WebsocketConnectionFactory(TransportOutDescription transportOut,
-                                      SecretResolver secretResolver) throws AxisFault {
         this.transportOut = transportOut;
         int sharedEventLoopPoolSize = getMaxValueOrDefault(
                 transportOut.getParameter(WebsocketConstants.WEBSOCKET_SHARED_EVENT_LOOP_POOL_SIZE), -1);
@@ -136,11 +112,7 @@ public class WebsocketConnectionFactory {
 
         Parameter profilesParam = transportOut.getParameter(WebsocketConstants.PROXY_PROFILES);
         if (profilesParam != null) {
-            OMElement profilesElement = profilesParam.getParameterElement();
-            SecretResolver resolverToUse = secretResolver != null
-                    ? secretResolver
-                    : SecretResolverFactory.create(profilesElement, false);
-            this.proxyRegistry = new WsProxyProfileRegistry(profilesElement, resolverToUse);
+            this.proxyRegistry = new WsProxyProfileRegistry(profilesParam.getParameterElement());
         } else {
             this.proxyRegistry = null;
         }
@@ -342,7 +314,7 @@ public class WebsocketConnectionFactory {
                                         + ", ThreadID: " + Thread.currentThread().getId());
                             }
                             ChannelPipeline p = ch.pipeline();
-                            HttpProxyHandler proxyHandler = resolveProxyHandler(host);
+                            HttpProxyHandler proxyHandler = resolveProxyHandler(host, resolver);
                             if (proxyHandler != null) {
                                 p.addLast(proxyHandler);
                             }
@@ -396,17 +368,18 @@ public class WebsocketConnectionFactory {
 
     /**
      * Returns a configured {@link HttpProxyHandler} for the given backend host by delegating
-     * to {@link WsProxyProfileRegistry#resolveProxyHandler(String)}, or {@code null} if no
-     * proxy profiles are configured or the host should connect directly.
+     * to {@link WsProxyProfileRegistry#resolveProxyHandler(String, SecretResolver)}, or
+     * {@code null} if no proxy profiles are configured or the host should connect directly.
      *
      * @param targetHost the backend WebSocket host to match against configured proxy profiles
+     * @param resolver   SecureVault resolver used to decrypt proxy passwords; may be {@code null}
      * @return a ready-to-use {@link HttpProxyHandler}, or {@code null} for a direct connection
      */
-    private HttpProxyHandler resolveProxyHandler(String targetHost) {
+    private HttpProxyHandler resolveProxyHandler(String targetHost, SecretResolver resolver) {
         if (proxyRegistry == null) {
             return null;
         }
-        return proxyRegistry.resolveProxyHandler(targetHost);
+        return proxyRegistry.resolveProxyHandler(targetHost, resolver);
     }
 
     private String deriveSubprotocol(String wsSubprotocol, String contentType) {

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -35,6 +35,7 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import io.netty.handler.proxy.HttpProxyHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
@@ -55,6 +56,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.xml.namespace.QName;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -67,6 +69,11 @@ public class WebsocketConnectionFactory {
     private final TransportOutDescription transportOut;
     private ConcurrentHashMap<String, ConcurrentHashMap<String, WebSocketClientHandler>>
             channelHandlerPool = new ConcurrentHashMap<String, ConcurrentHashMap<String, WebSocketClientHandler>>();
+
+    private String proxyHost;
+    private int proxyPort = -1;
+    private String proxyUsername;
+    private String proxyPassword;
 
     public WebsocketConnectionFactory(TransportOutDescription transportOut) throws AxisFault {
         this.transportOut = transportOut;
@@ -96,6 +103,26 @@ public class WebsocketConnectionFactory {
                 handleWssTrustStoreParameterError("Unable to read parameter(s) "
                         + WebsocketConstants.TRUST_STORE_LOCATION + " and/or "
                         + WebsocketConstants.TRUST_STORE_PASSWORD + " from Transport configurations");
+            }
+        }
+
+        Parameter proxyHostParam = transportOut.getParameter(WebsocketConstants.PROXY_HOST);
+        if (proxyHostParam != null) {
+            this.proxyHost = proxyHostParam.getParameterElement().getText();
+            Parameter proxyPortParam = transportOut.getParameter(WebsocketConstants.PROXY_PORT);
+            if (proxyPortParam != null) {
+                this.proxyPort = Integer.parseInt(proxyPortParam.getParameterElement().getText());
+            }
+            Parameter proxyUsernameParam = transportOut.getParameter(WebsocketConstants.PROXY_USERNAME);
+            if (proxyUsernameParam != null) {
+                this.proxyUsername = proxyUsernameParam.getParameterElement().getText();
+            }
+            Parameter proxyPasswordParam = transportOut.getParameter(WebsocketConstants.PROXY_PASSWORD);
+            if (proxyPasswordParam != null) {
+                this.proxyPassword = proxyPasswordParam.getParameterElement().getText();
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("WebSocket outbound proxy configured: " + this.proxyHost + ":" + this.proxyPort);
             }
         }
     }
@@ -296,6 +323,14 @@ public class WebsocketConnectionFactory {
                                         + ", ThreadID: " + Thread.currentThread().getId());
                             }
                             ChannelPipeline p = ch.pipeline();
+                            if (proxyHost != null && proxyPort > 0) {
+                                InetSocketAddress proxyAddress = new InetSocketAddress(proxyHost, proxyPort);
+                                if (proxyUsername != null && !proxyUsername.isEmpty()) {
+                                    p.addLast(new HttpProxyHandler(proxyAddress, proxyUsername, proxyPassword));
+                                } else {
+                                    p.addLast(new HttpProxyHandler(proxyAddress));
+                                }
+                            }
                             if (sslCtx != null) {
                                 SslHandler sslHandler = sslCtx.newHandler(ch.alloc(), host, port);
                                 Parameter wsEnableHostnameVerification = transportOut

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -56,64 +56,20 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.xml.namespace.QName;
-import java.net.InetSocketAddress;
 import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 public class WebsocketConnectionFactory {
 
     private static final Log log = LogFactory.getLog(WebsocketConnectionFactory.class);
-
-    private static final QName Q_PROFILE        = new QName("profile");
-    private static final QName Q_TARGET_HOSTS   = new QName("targetHosts");
-    private static final QName Q_PROXY_HOST      = new QName("proxyHost");
-    private static final QName Q_PROXY_PORT      = new QName("proxyPort");
-    private static final QName Q_PROXY_USERNAME  = new QName("proxyUserName");
-    private static final QName Q_PROXY_PASSWORD  = new QName("proxyPassword");
-    private static final QName Q_BYPASS         = new QName("bypass");
-
-    /**
-     * Holds the resolved proxy settings for a single ws.proxyProfiles profile entry.
-     * Instances are immutable after construction and shared across threads via the profile maps.
-     */
-    private static class WsProxyProfileConfig {
-        final String proxyHost;
-        final int proxyPort;
-        final String proxyUsername;
-        final String proxyPassword;
-        final Set<String> bypass;
-
-        WsProxyProfileConfig(String proxyHost, int proxyPort,
-                             String proxyUsername, String proxyPassword,
-                             Set<String> bypass) {
-            this.proxyHost    = proxyHost;
-            this.proxyPort    = proxyPort;
-            this.proxyUsername = proxyUsername;
-            this.proxyPassword = proxyPassword;
-            this.bypass       = bypass;
-        }
-    }
 
     private final EventLoopGroup sharedEventLoopGroup;
     private final TransportOutDescription transportOut;
     private ConcurrentHashMap<String, ConcurrentHashMap<String, WebSocketClientHandler>>
             channelHandlerPool = new ConcurrentHashMap<String, ConcurrentHashMap<String, WebSocketClientHandler>>();
 
-    // proxyProfiles path — populated from ws.proxyProfiles parameter
-    private final Map<String, WsProxyProfileConfig> proxyProfileMap = new LinkedHashMap<>();
-    private final Set<String> knownDirectHosts =
-            Collections.synchronizedSet(new HashSet<>());
-    private final Map<String, WsProxyProfileConfig> knownProxyConfigMap =
-            new ConcurrentHashMap<>();
+    private final WsProxyProfileRegistry proxyRegistry;
 
     public WebsocketConnectionFactory(TransportOutDescription transportOut) throws AxisFault {
         this.transportOut = transportOut;
@@ -146,109 +102,13 @@ public class WebsocketConnectionFactory {
             }
         }
 
-        loadProxyConfig(transportOut);
-    }
-
-    /**
-     * Reads proxy profile configuration from the transport sender descriptor at startup.
-     * <p>
-     * If a {@code ws.proxyProfiles} parameter is present, each {@code <profile>} child is
-     * parsed into a {@link WsProxyProfileConfig} and stored in {@link #proxyProfileMap} keyed
-     * by each comma-separated targetHost pattern.
-     *
-     * @param transportOut the transport sender descriptor from axis2.xml
-     */
-    private void loadProxyConfig(TransportOutDescription transportOut) {
         Parameter profilesParam = transportOut.getParameter(WebsocketConstants.PROXY_PROFILES);
-        if (profilesParam == null) {
-            return;
-        }
-        OMElement profilesElement = profilesParam.getParameterElement();
-        SecretResolver secretResolver = SecretResolverFactory.create(profilesElement, false);
-        Iterator<?> profiles = profilesElement.getChildrenWithName(Q_PROFILE);
-        while (profiles.hasNext()) {
-            OMElement profile = (OMElement) profiles.next();
-            OMElement targetHostsElement = profile.getFirstChildWithName(Q_TARGET_HOSTS);
-            if (targetHostsElement == null || targetHostsElement.getText().trim().isEmpty()) {
-                log.warn("Skipping ws proxy profile: missing or empty <targetHosts>");
-                continue;
-            }
-            OMElement proxyHostElement = profile.getFirstChildWithName(Q_PROXY_HOST);
-            OMElement proxyPortElement = profile.getFirstChildWithName(Q_PROXY_PORT);
-            if (proxyHostElement == null || proxyPortElement == null) {
-                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
-                        + "]: missing <proxyHost> or <proxyPort>");
-                continue;
-            }
-            String proxyHost = proxyHostElement.getText().trim();
-            if (proxyHost.isEmpty()) {
-                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
-                        + "]: empty <proxyHost>");
-                continue;
-            }
-            int proxyPort;
-            String proxyPortText = proxyPortElement.getText().trim();
-            try {
-                proxyPort = Integer.parseInt(proxyPortText);
-            } catch (NumberFormatException e) {
-                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
-                        + "]: invalid <proxyPort> value '" + proxyPortText + "'");
-                continue;
-            }
-            if (proxyPort < 1 || proxyPort > 65535) {
-                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
-                        + "]: invalid <proxyPort> value '" + proxyPortText + "'");
-                continue;
-            }
-            String proxyUsername = null;
-            String proxyPassword = null;
-            OMElement usernameElement = profile.getFirstChildWithName(Q_PROXY_USERNAME);
-            OMElement passwordElement = profile.getFirstChildWithName(Q_PROXY_PASSWORD);
-            if (usernameElement != null) {
-                proxyUsername = usernameElement.getText().trim();
-                proxyPassword = passwordElement != null
-                        ? MiscellaneousUtil.resolve(passwordElement.getText().trim(), secretResolver)
-                        : "";
-            }
-            Set<String> bypassSet = new HashSet<>();
-            OMElement bypassElement = profile.getFirstChildWithName(Q_BYPASS);
-            if (bypassElement != null && !bypassElement.getText().trim().isEmpty()) {
-                for (String rawEntry : bypassElement.getText().split(",")) {
-                    String bypassPattern = rawEntry.trim();
-                    try {
-                        Pattern.compile(bypassPattern);
-                        bypassSet.add(bypassPattern);
-                    } catch (PatternSyntaxException e) {
-                        log.warn("Skipping invalid bypass regex '" + bypassPattern
-                                + "' in ws proxy profile for [" + targetHostsElement.getText()
-                                + "]: " + e.getMessage());
-                    }
-                }
-            }
-            WsProxyProfileConfig profileConfig =
-                    new WsProxyProfileConfig(proxyHost, proxyPort, proxyUsername, proxyPassword, bypassSet);
-            for (String targetHostPattern : targetHostsElement.getText().split(",")) {
-                targetHostPattern = targetHostPattern.trim();
-                if (!"*".equals(targetHostPattern)) {
-                    try {
-                        Pattern.compile(targetHostPattern);
-                    } catch (PatternSyntaxException e) {
-                        log.warn("Skipping invalid targetHost regex '" + targetHostPattern
-                                + "' in ws proxy profile: " + e.getMessage());
-                        continue;
-                    }
-                }
-                if (!proxyProfileMap.containsKey(targetHostPattern)) {
-                    proxyProfileMap.put(targetHostPattern, profileConfig);
-                } else {
-                    log.warn("Duplicate ws proxy profile for targetHost [" + targetHostPattern
-                            + "] — ignoring");
-                }
-            }
-        }
-        if (!proxyProfileMap.isEmpty()) {
-            log.info(transportOut.getName() + " ws proxy profiles loaded for "
-                    + proxyProfileMap.size() + " targetHost(s)");
+        if (profilesParam != null) {
+            OMElement profilesElement = profilesParam.getParameterElement();
+            SecretResolver secretResolver = SecretResolverFactory.create(profilesElement, false);
+            this.proxyRegistry = new WsProxyProfileRegistry(profilesElement, secretResolver);
+        } else {
+            this.proxyRegistry = null;
         }
     }
 
@@ -500,113 +360,11 @@ public class WebsocketConnectionFactory {
         return null;
     }
 
-    /**
-     * Returns a configured {@link HttpProxyHandler} for the given backend host, or {@code null}
-     * if no proxy applies.
-     * <p>
-     * Delegates to {@link #getProfileForHost(String)} to select the matching profile from
-     * {@link #proxyProfileMap}. Returns {@code null} when no profile matches.
-     *
-     * @param targetHost the backend WebSocket host being connected to (e.g., {@code backend.example.com})
-     * @return a ready-to-use {@link HttpProxyHandler}, or {@code null} for a direct connection
-     */
     private HttpProxyHandler resolveProxyHandler(String targetHost) {
-        if (!proxyProfileMap.isEmpty()) {
-            WsProxyProfileConfig matchedProfile = getProfileForHost(targetHost);
-            if (matchedProfile != null) {
-                return buildProxyHandler(matchedProfile.proxyHost, matchedProfile.proxyPort,
-                        matchedProfile.proxyUsername, matchedProfile.proxyPassword);
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Selects the proxy profile for the given target host using the following precedence:
-     * <ol>
-     *   <li>Returns the cached result from {@link #knownProxyConfigMap} if already resolved.</li>
-     *   <li>Returns {@code null} (direct) if the host is already in {@link #knownDirectHosts}.</li>
-     *   <li>Iterates {@link #proxyProfileMap}: matches specific patterns first (Java regex via
-     *       {@link String#matches}), then falls back to the {@code "*"} default profile if present.</li>
-     * </ol>
-     * The bypass check is delegated to {@link #resolveWithBypass(String, String)}, which also
-     * populates the caches so subsequent lookups for the same host return immediately.
-     * <p>
-     * Note: {@code targetHosts} patterns use Java regex syntax, not glob. The wildcard default
-     * profile must be configured as {@code <targetHosts>*</targetHosts>} (literal asterisk).
-     *
-     * @param targetHost the backend WebSocket host to match against configured profiles
-     * @return the matching {@link WsProxyProfileConfig}, or {@code null} if the host should connect directly
-     */
-    private WsProxyProfileConfig getProfileForHost(String targetHost) {
-        if (knownProxyConfigMap.containsKey(targetHost)) {
-            return knownProxyConfigMap.get(targetHost);
-        }
-        if (knownDirectHosts.contains(targetHost)) {
+        if (proxyRegistry == null) {
             return null;
         }
-        boolean hasCatchAllProfile = false;
-        for (String profileKey : proxyProfileMap.keySet()) {
-            if ("*".equals(profileKey)) {
-                hasCatchAllProfile = true;
-                continue;
-            }
-            if (targetHost.matches(profileKey)) {
-                return resolveWithBypass(targetHost, profileKey);
-            }
-        }
-        if (hasCatchAllProfile) {
-            return resolveWithBypass(targetHost, "*");
-        }
-        return null;
-    }
-
-    /**
-     * Checks the bypass list of the matched profile and caches the outcome.
-     * <p>
-     * If any bypass pattern in the profile matches {@code targetHost} (Java regex full-string
-     * match), the host is added to {@link #knownDirectHosts} and {@code null} is returned,
-     * causing the caller to make a direct connection. Otherwise the profile is cached in
-     * {@link #knownProxyConfigMap} and returned so the host is proxied on this and all
-     * subsequent connections.
-     *
-     * @param targetHost the backend WebSocket host that matched the profile keyed by {@code profileKey}
-     * @param profileKey the key in {@link #proxyProfileMap} whose profile was matched ({@code "*"} for the default)
-     * @return the matched {@link WsProxyProfileConfig} to proxy through, or {@code null} to connect directly
-     */
-    private WsProxyProfileConfig resolveWithBypass(String targetHost, String profileKey) {
-        WsProxyProfileConfig matchedProfile = proxyProfileMap.get(profileKey);
-        for (String bypassPattern : matchedProfile.bypass) {
-            if (targetHost.matches(bypassPattern)) {
-                knownDirectHosts.add(targetHost);
-                if (log.isDebugEnabled()) {
-                    log.debug("ws proxy bypass matched: host=" + targetHost
-                            + " bypass=" + bypassPattern);
-                }
-                return null;
-            }
-        }
-        knownProxyConfigMap.put(targetHost, matchedProfile);
-        return matchedProfile;
-    }
-
-    /**
-     * Constructs a Netty {@link HttpProxyHandler} for the given proxy coordinates.
-     * Uses the authenticated constructor when credentials are provided, anonymous otherwise.
-     *
-     * @param host     proxy server hostname or IP
-     * @param port     proxy server port
-     * @param username proxy username, or {@code null} for anonymous access
-     * @param password proxy password; ignored when {@code username} is {@code null}
-     * @return a configured {@link HttpProxyHandler} ready to be added to the Netty pipeline
-     */
-    private HttpProxyHandler buildProxyHandler(String host, int port,
-                                               String username, String password) {
-        InetSocketAddress proxyAddress = new InetSocketAddress(host, port);
-        if (username != null && !username.isEmpty()) {
-            return new HttpProxyHandler(proxyAddress, username, password);
-        }
-        return new HttpProxyHandler(proxyAddress);
+        return proxyRegistry.resolveProxyHandler(targetHost);
     }
 
     private String deriveSubprotocol(String wsSubprotocol, String contentType) {

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -71,14 +71,6 @@ public class WebsocketConnectionFactory {
 
     private final WsProxyProfileRegistry proxyRegistry;
 
-    /**
-     * Creates a new factory. Proxy passwords are stored as raw text during startup and
-     * resolved via SecureVault at connection time using the {@link SecretResolver} threaded
-     * through from {@link #getChannelHandler}.
-     *
-     * @param transportOut the WS/WSS transport-sender descriptor from axis2.xml
-     * @throws AxisFault if the WSS trust-store parameters are missing or malformed
-     */
     public WebsocketConnectionFactory(TransportOutDescription transportOut) throws AxisFault {
         this.transportOut = transportOut;
         int sharedEventLoopPoolSize = getMaxValueOrDefault(

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -61,6 +61,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -108,7 +109,7 @@ public class WebsocketConnectionFactory {
             channelHandlerPool = new ConcurrentHashMap<String, ConcurrentHashMap<String, WebSocketClientHandler>>();
 
     // proxyProfiles path — populated from ws.proxyProfiles parameter
-    private Map<String, WsProxyProfileConfig> proxyProfileMap = new HashMap<>();
+    private final Map<String, WsProxyProfileConfig> proxyProfileMap = new LinkedHashMap<>();
     private final Set<String> knownDirectHosts =
             Collections.synchronizedSet(new HashSet<>());
     private final Map<String, WsProxyProfileConfig> knownProxyConfigMap =
@@ -162,60 +163,71 @@ public class WebsocketConnectionFactory {
         if (profilesParam == null) {
             return;
         }
-        OMElement profilesElt = profilesParam.getParameterElement();
-        SecretResolver secretResolver = SecretResolverFactory.create(profilesElt, false);
-        Iterator<?> profiles = profilesElt.getChildrenWithName(Q_PROFILE);
+        OMElement profilesElement = profilesParam.getParameterElement();
+        SecretResolver secretResolver = SecretResolverFactory.create(profilesElement, false);
+        Iterator<?> profiles = profilesElement.getChildrenWithName(Q_PROFILE);
         while (profiles.hasNext()) {
             OMElement profile = (OMElement) profiles.next();
-            OMElement targetHostsElt = profile.getFirstChildWithName(Q_TARGET_HOSTS);
-            if (targetHostsElt == null || targetHostsElt.getText().trim().isEmpty()) {
+            OMElement targetHostsElement = profile.getFirstChildWithName(Q_TARGET_HOSTS);
+            if (targetHostsElement == null || targetHostsElement.getText().trim().isEmpty()) {
                 log.warn("Skipping ws proxy profile: missing or empty <targetHosts>");
                 continue;
             }
-            OMElement proxyHostElt = profile.getFirstChildWithName(Q_PROXY_HOST);
-            OMElement proxyPortElt = profile.getFirstChildWithName(Q_PROXY_PORT);
-            if (proxyHostElt == null || proxyPortElt == null) {
-                log.warn("Skipping ws proxy profile for [" + targetHostsElt.getText()
+            OMElement proxyHostElement = profile.getFirstChildWithName(Q_PROXY_HOST);
+            OMElement proxyPortElement = profile.getFirstChildWithName(Q_PROXY_PORT);
+            if (proxyHostElement == null || proxyPortElement == null) {
+                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
                         + "]: missing <proxyHost> or <proxyPort>");
                 continue;
             }
-            String proxyHost = proxyHostElt.getText().trim();
+            String proxyHost = proxyHostElement.getText().trim();
+            if (proxyHost.isEmpty()) {
+                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
+                        + "]: empty <proxyHost>");
+                continue;
+            }
             int proxyPort;
+            String proxyPortText = proxyPortElement.getText().trim();
             try {
-                proxyPort = Integer.parseInt(proxyPortElt.getText().trim());
+                proxyPort = Integer.parseInt(proxyPortText);
             } catch (NumberFormatException e) {
-                log.warn("Skipping ws proxy profile for [" + targetHostsElt.getText()
-                        + "]: invalid <proxyPort> value '" + proxyPortElt.getText().trim() + "'");
+                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
+                        + "]: invalid <proxyPort> value '" + proxyPortText + "'");
+                continue;
+            }
+            if (proxyPort < 1 || proxyPort > 65535) {
+                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
+                        + "]: invalid <proxyPort> value '" + proxyPortText + "'");
                 continue;
             }
             String proxyUsername = null;
             String proxyPassword = null;
-            OMElement usernameElt = profile.getFirstChildWithName(Q_PROXY_USERNAME);
-            OMElement passwordElt = profile.getFirstChildWithName(Q_PROXY_PASSWORD);
-            if (usernameElt != null) {
-                proxyUsername = usernameElt.getText().trim();
-                proxyPassword = passwordElt != null
-                        ? MiscellaneousUtil.resolve(passwordElt.getText().trim(), secretResolver)
+            OMElement usernameElement = profile.getFirstChildWithName(Q_PROXY_USERNAME);
+            OMElement passwordElement = profile.getFirstChildWithName(Q_PROXY_PASSWORD);
+            if (usernameElement != null) {
+                proxyUsername = usernameElement.getText().trim();
+                proxyPassword = passwordElement != null
+                        ? MiscellaneousUtil.resolve(passwordElement.getText().trim(), secretResolver)
                         : "";
             }
             Set<String> bypassSet = new HashSet<>();
-            OMElement bypassElt = profile.getFirstChildWithName(Q_BYPASS);
-            if (bypassElt != null && !bypassElt.getText().trim().isEmpty()) {
-                for (String rawEntry : bypassElt.getText().split(",")) {
+            OMElement bypassElement = profile.getFirstChildWithName(Q_BYPASS);
+            if (bypassElement != null && !bypassElement.getText().trim().isEmpty()) {
+                for (String rawEntry : bypassElement.getText().split(",")) {
                     String bypassPattern = rawEntry.trim();
                     try {
                         Pattern.compile(bypassPattern);
                         bypassSet.add(bypassPattern);
                     } catch (PatternSyntaxException e) {
                         log.warn("Skipping invalid bypass regex '" + bypassPattern
-                                + "' in ws proxy profile for [" + targetHostsElt.getText()
+                                + "' in ws proxy profile for [" + targetHostsElement.getText()
                                 + "]: " + e.getMessage());
                     }
                 }
             }
             WsProxyProfileConfig profileConfig =
                     new WsProxyProfileConfig(proxyHost, proxyPort, proxyUsername, proxyPassword, bypassSet);
-            for (String targetHostPattern : targetHostsElt.getText().split(",")) {
+            for (String targetHostPattern : targetHostsElement.getText().split(",")) {
                 targetHostPattern = targetHostPattern.trim();
                 if (!"*".equals(targetHostPattern)) {
                     try {

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -102,6 +102,8 @@ public class WebsocketConnectionFactory {
             }
         }
 
+        // Build the proxy registry only when proxy profiles are configured.
+        // A null registry causes resolveProxyHandler to return null immediately (direct connection).
         Parameter profilesParam = transportOut.getParameter(WebsocketConstants.PROXY_PROFILES);
         if (profilesParam != null) {
             this.proxyRegistry = new WsProxyProfileRegistry(profilesParam.getParameterElement());
@@ -306,6 +308,11 @@ public class WebsocketConnectionFactory {
                                         + ", ThreadID: " + Thread.currentThread().getId());
                             }
                             ChannelPipeline p = ch.pipeline();
+                            // Proxy handler must be the first handler in the pipeline so it
+                            // intercepts the TCP connect and sends the HTTP CONNECT request before
+                            // the SSL or HTTP codec layers are involved. HttpProxyHandler removes
+                            // itself from the pipeline once the CONNECT tunnel is established;
+                            // subsequent WS frames flow through the tunnel without proxy overhead.
                             HttpProxyHandler proxyHandler = resolveProxyHandler(host, resolver);
                             if (proxyHandler != null) {
                                 p.addLast(proxyHandler);

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConnectionFactory.java
@@ -78,6 +78,10 @@ public class WebsocketConnectionFactory {
     private static final QName Q_PROXY_PASS     = new QName("proxyPassword");
     private static final QName Q_BYPASS         = new QName("bypass");
 
+    /**
+     * Holds the resolved proxy settings for a single ws.proxyProfiles profile entry.
+     * Instances are immutable after construction and shared across threads via the profile maps.
+     */
     private static class WsProxyProfileConfig {
         final String proxyHost;
         final int proxyPort;
@@ -148,6 +152,20 @@ public class WebsocketConnectionFactory {
         loadProxyConfig(transportOut);
     }
 
+    /**
+     * Reads proxy configuration from the transport sender descriptor at startup.
+     * <p>
+     * If a {@code ws.proxyProfiles} parameter is present, each {@code <profile>} child is
+     * parsed into a {@link WsProxyProfileConfig} and stored in {@link #proxyProfileMap} keyed
+     * by each comma-separated targetHost pattern. When at least one profile is loaded the method
+     * returns immediately — flat proxy parameters are ignored entirely.
+     * <p>
+     * If no profiles are defined (or the parameter is absent), the flat parameters
+     * {@code ws.proxy.host}, {@code ws.proxy.port}, {@code ws.proxy.username}, and
+     * {@code ws.proxy.password} are read instead.
+     *
+     * @param transportOut the transport sender descriptor from axis2.xml
+     */
     private void loadProxyConfig(TransportOutDescription transportOut) {
         Parameter profilesParam = transportOut.getParameter(WebsocketConstants.PROXY_PROFILES);
         if (profilesParam != null) {
@@ -474,6 +492,17 @@ public class WebsocketConnectionFactory {
         return null;
     }
 
+    /**
+     * Returns a configured {@link HttpProxyHandler} for the given backend host, or {@code null}
+     * if no proxy applies.
+     * <p>
+     * When proxy profiles are defined, delegates to {@link #getProfileForHost(String)} to select
+     * the matching profile. When only flat proxy parameters were configured, uses those directly.
+     * Returns {@code null} in both cases when no proxy configuration matches the host.
+     *
+     * @param targetHost the backend WebSocket host being connected to (e.g., {@code backend.example.com})
+     * @return a ready-to-use {@link HttpProxyHandler}, or {@code null} for a direct connection
+     */
     private HttpProxyHandler resolveProxyHandler(String targetHost) {
         if (!proxyProfileMap.isEmpty()) {
             WsProxyProfileConfig profile = getProfileForHost(targetHost);
@@ -489,6 +518,23 @@ public class WebsocketConnectionFactory {
         return null;
     }
 
+    /**
+     * Selects the proxy profile for the given target host using the following precedence:
+     * <ol>
+     *   <li>Returns the cached result from {@link #knownProxyConfigMap} if already resolved.</li>
+     *   <li>Returns {@code null} (direct) if the host is already in {@link #knownDirectHosts}.</li>
+     *   <li>Iterates {@link #proxyProfileMap}: matches specific patterns first (Java regex via
+     *       {@link String#matches}), then falls back to the {@code "*"} default profile if present.</li>
+     * </ol>
+     * The bypass check is delegated to {@link #resolveWithBypass(String, String)}, which also
+     * populates the caches so subsequent lookups for the same host return immediately.
+     * <p>
+     * Note: {@code targetHosts} patterns use Java regex syntax, not glob. The wildcard default
+     * profile must be configured as {@code <targetHosts>*</targetHosts>} (literal asterisk).
+     *
+     * @param targetHost the backend WebSocket host to match against configured profiles
+     * @return the matching {@link WsProxyProfileConfig}, or {@code null} if the host should connect directly
+     */
     private WsProxyProfileConfig getProfileForHost(String targetHost) {
         if (knownProxyConfigMap.containsKey(targetHost)) {
             return knownProxyConfigMap.get(targetHost);
@@ -512,6 +558,19 @@ public class WebsocketConnectionFactory {
         return null;
     }
 
+    /**
+     * Checks the bypass list of the matched profile and caches the outcome.
+     * <p>
+     * If any bypass pattern in the profile matches {@code targetHost} (Java regex full-string
+     * match), the host is added to {@link #knownDirectHosts} and {@code null} is returned,
+     * causing the caller to make a direct connection. Otherwise the profile is cached in
+     * {@link #knownProxyConfigMap} and returned so the host is proxied on this and all
+     * subsequent connections.
+     *
+     * @param targetHost the backend WebSocket host that matched the profile keyed by {@code key}
+     * @param key        the key in {@link #proxyProfileMap} whose profile was matched ({@code "*"} for the default)
+     * @return the matched {@link WsProxyProfileConfig} to proxy through, or {@code null} to connect directly
+     */
     private WsProxyProfileConfig resolveWithBypass(String targetHost, String key) {
         WsProxyProfileConfig profile = proxyProfileMap.get(key);
         for (String bypass : profile.bypass) {
@@ -528,6 +587,16 @@ public class WebsocketConnectionFactory {
         return profile;
     }
 
+    /**
+     * Constructs a Netty {@link HttpProxyHandler} for the given proxy coordinates.
+     * Uses the authenticated constructor when credentials are provided, anonymous otherwise.
+     *
+     * @param host     proxy server hostname or IP
+     * @param port     proxy server port
+     * @param username proxy username, or {@code null} for anonymous access
+     * @param password proxy password; ignored when {@code username} is {@code null}
+     * @return a configured {@link HttpProxyHandler} ready to be added to the Netty pipeline
+     */
     private HttpProxyHandler buildProxyHandler(String host, int port,
                                                String username, String password) {
         InetSocketAddress proxyAddress = new InetSocketAddress(host, port);

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -86,4 +86,9 @@ public class WebsocketConstants {
 
     public static final String TARGET_ENDPOINT_ADDRESS = "ENDPOINT_ADDRESS";
     public static final String WSO2_PROPERTIES = "WSO2_PROPERTIES";
+
+    public static final String PROXY_HOST = "ws.proxy.host";
+    public static final String PROXY_PORT = "ws.proxy.port";
+    public static final String PROXY_USERNAME = "ws.proxy.username";
+    public static final String PROXY_PASSWORD = "ws.proxy.password";
 }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -91,4 +91,5 @@ public class WebsocketConstants {
     public static final String PROXY_PORT = "ws.proxy.port";
     public static final String PROXY_USERNAME = "ws.proxy.username";
     public static final String PROXY_PASSWORD = "ws.proxy.password";
+    public static final String PROXY_PROFILES = "ws.proxyProfiles";
 }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketConstants.java
@@ -87,9 +87,5 @@ public class WebsocketConstants {
     public static final String TARGET_ENDPOINT_ADDRESS = "ENDPOINT_ADDRESS";
     public static final String WSO2_PROPERTIES = "WSO2_PROPERTIES";
 
-    public static final String PROXY_HOST = "ws.proxy.host";
-    public static final String PROXY_PORT = "ws.proxy.port";
-    public static final String PROXY_USERNAME = "ws.proxy.username";
-    public static final String PROXY_PASSWORD = "ws.proxy.password";
     public static final String PROXY_PROFILES = "ws.proxyProfiles";
 }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
@@ -76,9 +76,7 @@ public class WebsocketTransportSender extends AbstractTransportSender {
             log.debug("Initializing WS Connection Factory.");
         }
         super.init(cfgCtx, transportOut);
-        SecretResolver secretResolver = cfgCtx.getAxisConfiguration() != null
-                ? cfgCtx.getAxisConfiguration().getSecretResolver() : null;
-        connectionFactory = new WebsocketConnectionFactory(transportOut, secretResolver);
+        connectionFactory = new WebsocketConnectionFactory(transportOut);
     }
 
     public void sendMessage(MessageContext msgCtx, String targetEPR, OutTransportInfo trpOut)

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WebsocketTransportSender.java
@@ -76,7 +76,9 @@ public class WebsocketTransportSender extends AbstractTransportSender {
             log.debug("Initializing WS Connection Factory.");
         }
         super.init(cfgCtx, transportOut);
-        connectionFactory = new WebsocketConnectionFactory(transportOut);
+        SecretResolver secretResolver = cfgCtx.getAxisConfiguration() != null
+                ? cfgCtx.getAxisConfiguration().getSecretResolver() : null;
+        connectionFactory = new WebsocketConnectionFactory(transportOut, secretResolver);
     }
 
     public void sendMessage(MessageContext msgCtx, String targetEPR, OutTransportInfo trpOut)

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WsProxyProfileRegistry.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WsProxyProfileRegistry.java
@@ -68,6 +68,13 @@ class WsProxyProfileRegistry {
         final String proxyPassword;
         final Set<String> bypass;
 
+        /**
+         * @param proxyHost     proxy server hostname or IP
+         * @param proxyPort     proxy server port (1–65535)
+         * @param proxyUsername proxy username, or {@code null} for anonymous access
+         * @param proxyPassword proxy password; ignored when {@code proxyUsername} is {@code null}
+         * @param bypass        set of regex patterns for hosts that bypass this proxy
+         */
         WsProxyProfileConfig(String proxyHost, int proxyPort,
                              String proxyUsername, String proxyPassword,
                              Set<String> bypass) {
@@ -112,6 +119,16 @@ class WsProxyProfileRegistry {
         return null;
     }
 
+    /**
+     * Parses all {@code <profile>} children of {@code profilesElement} and populates
+     * {@link #proxyProfileMap}. Each target-host pattern from {@code <targetHosts>} becomes
+     * a key mapping to its resolved {@link WsProxyProfileConfig}. Proxy passwords referencing
+     * SecureVault aliases are resolved via {@code secretResolver}. Invalid or incomplete
+     * profiles are skipped with a warning log.
+     *
+     * @param profilesElement the {@code ws.proxyProfiles} parameter element from axis2.xml
+     * @param secretResolver  resolver for SecureVault aliases in proxy passwords; may be {@code null}
+     */
     private void parseProfiles(OMElement profilesElement, SecretResolver secretResolver) {
         Iterator<?> profiles = profilesElement.getChildrenWithName(Q_PROFILE);
         while (profiles.hasNext()) {

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WsProxyProfileRegistry.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WsProxyProfileRegistry.java
@@ -95,26 +95,27 @@ class WsProxyProfileRegistry {
     /**
      * Parses all {@code <profile>} children of {@code profilesElement} into
      * {@link #proxyProfileMap}. Invalid or incomplete profiles are skipped with a warning.
+     * Proxy passwords are stored as raw text and resolved via SecureVault at connection time.
      *
      * @param profilesElement the {@code ws.proxyProfiles} parameter element from axis2.xml
-     * @param secretResolver  resolver for SecureVault aliases in proxy passwords; may be {@code null}
      */
-    WsProxyProfileRegistry(OMElement profilesElement, SecretResolver secretResolver) {
-        parseProfiles(profilesElement, secretResolver);
+    WsProxyProfileRegistry(OMElement profilesElement) {
+        parseProfiles(profilesElement);
     }
 
     /**
      * Returns a configured {@link HttpProxyHandler} for the given backend host, or {@code null}
-     * for a direct connection.
+     * for a direct connection. The proxy password is resolved at call time via {@code resolver}.
      *
      * @param targetHost the backend WebSocket host (e.g., {@code backend.example.com})
+     * @param resolver   SecureVault resolver used to decrypt proxy passwords; may be {@code null}
      * @return a ready-to-use {@link HttpProxyHandler}, or {@code null} for a direct connection
      */
-    HttpProxyHandler resolveProxyHandler(String targetHost) {
+    HttpProxyHandler resolveProxyHandler(String targetHost, SecretResolver resolver) {
         WsProxyProfileConfig matchedProfile = getProfileForHost(targetHost);
         if (matchedProfile != null) {
             return buildProxyHandler(matchedProfile.proxyHost, matchedProfile.proxyPort,
-                    matchedProfile.proxyUsername, matchedProfile.proxyPassword);
+                    matchedProfile.proxyUsername, matchedProfile.proxyPassword, resolver);
         }
         return null;
     }
@@ -122,14 +123,13 @@ class WsProxyProfileRegistry {
     /**
      * Parses all {@code <profile>} children of {@code profilesElement} and populates
      * {@link #proxyProfileMap}. Each target-host pattern from {@code <targetHosts>} becomes
-     * a key mapping to its resolved {@link WsProxyProfileConfig}. Proxy passwords referencing
-     * SecureVault aliases are resolved via {@code secretResolver}. Invalid or incomplete
+     * a key mapping to its resolved {@link WsProxyProfileConfig}. Proxy passwords are stored
+     * as raw text and resolved via SecureVault at connection time. Invalid or incomplete
      * profiles are skipped with a warning log.
      *
      * @param profilesElement the {@code ws.proxyProfiles} parameter element from axis2.xml
-     * @param secretResolver  resolver for SecureVault aliases in proxy passwords; may be {@code null}
      */
-    private void parseProfiles(OMElement profilesElement, SecretResolver secretResolver) {
+    private void parseProfiles(OMElement profilesElement) {
         Iterator<?> profiles = profilesElement.getChildrenWithName(Q_PROFILE);
         while (profiles.hasNext()) {
             OMElement profile = (OMElement) profiles.next();
@@ -172,7 +172,7 @@ class WsProxyProfileRegistry {
             if (usernameElement != null) {
                 proxyUsername = usernameElement.getText().trim();
                 proxyPassword = passwordElement != null
-                        ? MiscellaneousUtil.resolve(passwordElement.getText().trim(), secretResolver)
+                        ? passwordElement.getText().trim()
                         : "";
             }
             Set<String> bypassSet = new HashSet<>();
@@ -286,17 +286,22 @@ class WsProxyProfileRegistry {
     /**
      * Constructs a Netty {@link HttpProxyHandler} for the given proxy coordinates.
      * Uses the authenticated constructor when credentials are provided, anonymous otherwise.
+     * The raw proxy password is resolved via {@code resolver} before use.
      *
-     * @param host     proxy server hostname or IP
-     * @param port     proxy server port
-     * @param username proxy username, or {@code null} for anonymous access
-     * @param password proxy password; ignored when {@code username} is {@code null}
+     * @param host        proxy server hostname or IP
+     * @param port        proxy server port
+     * @param username    proxy username, or {@code null} for anonymous access
+     * @param rawPassword raw proxy password (may be a SecureVault {@code $secret{alias}});
+     *                    ignored when {@code username} is {@code null}
+     * @param resolver    SecureVault resolver used to decrypt the proxy password; may be {@code null}
      * @return a configured {@link HttpProxyHandler} ready to be added to the Netty pipeline
      */
     private HttpProxyHandler buildProxyHandler(String host, int port,
-                                               String username, String password) {
+                                               String username, String rawPassword,
+                                               SecretResolver resolver) {
         InetSocketAddress proxyAddress = new InetSocketAddress(host, port);
         if (username != null && !username.isEmpty()) {
+            String password = MiscellaneousUtil.resolve(rawPassword, resolver);
             return new HttpProxyHandler(proxyAddress, username, password);
         }
         return new HttpProxyHandler(proxyAddress);

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WsProxyProfileRegistry.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WsProxyProfileRegistry.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.websocket.transport;
+
+import io.netty.handler.proxy.HttpProxyHandler;
+import org.apache.axiom.om.OMElement;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.securevault.SecretResolver;
+import org.wso2.securevault.commons.MiscellaneousUtil;
+
+import javax.xml.namespace.QName;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Parses and resolves {@code ws.proxyProfiles} configuration for the WebSocket transport sender.
+ * <p>
+ * At construction time all {@code <profile>} entries inside the {@code ws.proxyProfiles} parameter
+ * element are parsed and validated. Invalid entries are skipped with a warning. Per-connection,
+ * {@link #resolveProxyHandler(String)} matches the target host against the loaded profiles and
+ * returns a ready-to-use Netty {@link HttpProxyHandler}, or {@code null} for a direct connection.
+ */
+class WsProxyProfileRegistry {
+
+    private static final Log log = LogFactory.getLog(WsProxyProfileRegistry.class);
+
+    private static final QName Q_PROFILE       = new QName("profile");
+    private static final QName Q_TARGET_HOSTS  = new QName("targetHosts");
+    private static final QName Q_PROXY_HOST    = new QName("proxyHost");
+    private static final QName Q_PROXY_PORT    = new QName("proxyPort");
+    private static final QName Q_PROXY_USERNAME = new QName("proxyUserName");
+    private static final QName Q_PROXY_PASSWORD = new QName("proxyPassword");
+    private static final QName Q_BYPASS        = new QName("bypass");
+
+    /**
+     * Holds the resolved proxy settings for a single profile entry.
+     * Immutable after construction and shared across threads via the profile maps.
+     */
+    static class WsProxyProfileConfig {
+        final String proxyHost;
+        final int proxyPort;
+        final String proxyUsername;
+        final String proxyPassword;
+        final Set<String> bypass;
+
+        WsProxyProfileConfig(String proxyHost, int proxyPort,
+                             String proxyUsername, String proxyPassword,
+                             Set<String> bypass) {
+            this.proxyHost     = proxyHost;
+            this.proxyPort     = proxyPort;
+            this.proxyUsername = proxyUsername;
+            this.proxyPassword = proxyPassword;
+            this.bypass        = bypass;
+        }
+    }
+
+    private final Map<String, WsProxyProfileConfig> proxyProfileMap = new LinkedHashMap<>();
+    private final Set<String> knownDirectHosts =
+            Collections.synchronizedSet(new HashSet<>());
+    private final Map<String, WsProxyProfileConfig> knownProxyConfigMap =
+            new ConcurrentHashMap<>();
+
+    /**
+     * Parses all {@code <profile>} children of {@code profilesElement} into
+     * {@link #proxyProfileMap}. Invalid or incomplete profiles are skipped with a warning.
+     *
+     * @param profilesElement the {@code ws.proxyProfiles} parameter element from axis2.xml
+     * @param secretResolver  resolver for SecureVault aliases in proxy passwords; may be {@code null}
+     */
+    WsProxyProfileRegistry(OMElement profilesElement, SecretResolver secretResolver) {
+        parseProfiles(profilesElement, secretResolver);
+    }
+
+    /**
+     * Returns a configured {@link HttpProxyHandler} for the given backend host, or {@code null}
+     * for a direct connection.
+     *
+     * @param targetHost the backend WebSocket host (e.g., {@code backend.example.com})
+     * @return a ready-to-use {@link HttpProxyHandler}, or {@code null} for a direct connection
+     */
+    HttpProxyHandler resolveProxyHandler(String targetHost) {
+        WsProxyProfileConfig matchedProfile = getProfileForHost(targetHost);
+        if (matchedProfile != null) {
+            return buildProxyHandler(matchedProfile.proxyHost, matchedProfile.proxyPort,
+                    matchedProfile.proxyUsername, matchedProfile.proxyPassword);
+        }
+        return null;
+    }
+
+    private void parseProfiles(OMElement profilesElement, SecretResolver secretResolver) {
+        Iterator<?> profiles = profilesElement.getChildrenWithName(Q_PROFILE);
+        while (profiles.hasNext()) {
+            OMElement profile = (OMElement) profiles.next();
+            OMElement targetHostsElement = profile.getFirstChildWithName(Q_TARGET_HOSTS);
+            if (targetHostsElement == null || targetHostsElement.getText().trim().isEmpty()) {
+                log.warn("Skipping ws proxy profile: missing or empty <targetHosts>");
+                continue;
+            }
+            OMElement proxyHostElement = profile.getFirstChildWithName(Q_PROXY_HOST);
+            OMElement proxyPortElement = profile.getFirstChildWithName(Q_PROXY_PORT);
+            if (proxyHostElement == null || proxyPortElement == null) {
+                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
+                        + "]: missing <proxyHost> or <proxyPort>");
+                continue;
+            }
+            String proxyHost = proxyHostElement.getText().trim();
+            if (proxyHost.isEmpty()) {
+                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
+                        + "]: empty <proxyHost>");
+                continue;
+            }
+            int proxyPort;
+            String proxyPortText = proxyPortElement.getText().trim();
+            try {
+                proxyPort = Integer.parseInt(proxyPortText);
+            } catch (NumberFormatException e) {
+                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
+                        + "]: invalid <proxyPort> value '" + proxyPortText + "'");
+                continue;
+            }
+            if (proxyPort < 1 || proxyPort > 65535) {
+                log.warn("Skipping ws proxy profile for [" + targetHostsElement.getText()
+                        + "]: invalid <proxyPort> value '" + proxyPortText + "'");
+                continue;
+            }
+            String proxyUsername = null;
+            String proxyPassword = null;
+            OMElement usernameElement = profile.getFirstChildWithName(Q_PROXY_USERNAME);
+            OMElement passwordElement = profile.getFirstChildWithName(Q_PROXY_PASSWORD);
+            if (usernameElement != null) {
+                proxyUsername = usernameElement.getText().trim();
+                proxyPassword = passwordElement != null
+                        ? MiscellaneousUtil.resolve(passwordElement.getText().trim(), secretResolver)
+                        : "";
+            }
+            Set<String> bypassSet = new HashSet<>();
+            OMElement bypassElement = profile.getFirstChildWithName(Q_BYPASS);
+            if (bypassElement != null && !bypassElement.getText().trim().isEmpty()) {
+                for (String rawEntry : bypassElement.getText().split(",")) {
+                    String bypassPattern = rawEntry.trim();
+                    try {
+                        Pattern.compile(bypassPattern);
+                        bypassSet.add(bypassPattern);
+                    } catch (PatternSyntaxException e) {
+                        log.warn("Skipping invalid bypass regex '" + bypassPattern
+                                + "' in ws proxy profile for [" + targetHostsElement.getText()
+                                + "]: " + e.getMessage());
+                    }
+                }
+            }
+            WsProxyProfileConfig profileConfig =
+                    new WsProxyProfileConfig(proxyHost, proxyPort, proxyUsername, proxyPassword, bypassSet);
+            for (String targetHostPattern : targetHostsElement.getText().split(",")) {
+                targetHostPattern = targetHostPattern.trim();
+                if (!"*".equals(targetHostPattern)) {
+                    try {
+                        Pattern.compile(targetHostPattern);
+                    } catch (PatternSyntaxException e) {
+                        log.warn("Skipping invalid targetHost regex '" + targetHostPattern
+                                + "' in ws proxy profile: " + e.getMessage());
+                        continue;
+                    }
+                }
+                if (!proxyProfileMap.containsKey(targetHostPattern)) {
+                    proxyProfileMap.put(targetHostPattern, profileConfig);
+                } else {
+                    log.warn("Duplicate ws proxy profile for targetHost [" + targetHostPattern
+                            + "] — ignoring");
+                }
+            }
+        }
+        if (!proxyProfileMap.isEmpty()) {
+            log.info("ws proxy profiles loaded for " + proxyProfileMap.size() + " targetHost(s)");
+        }
+    }
+
+    /**
+     * Selects the proxy profile for the given target host using the following precedence:
+     * <ol>
+     *   <li>Returns the cached result from {@link #knownProxyConfigMap} if already resolved.</li>
+     *   <li>Returns {@code null} (direct) if the host is already in {@link #knownDirectHosts}.</li>
+     *   <li>Iterates {@link #proxyProfileMap}: matches specific patterns first (Java regex via
+     *       {@link String#matches}), then falls back to the {@code "*"} default profile if present.</li>
+     * </ol>
+     * The bypass check is delegated to {@link #resolveWithBypass(String, String)}, which also
+     * populates the caches so subsequent lookups for the same host return immediately.
+     * <p>
+     * Note: {@code targetHosts} patterns use Java regex syntax, not glob. The wildcard default
+     * profile must be configured as {@code <targetHosts>*</targetHosts>} (literal asterisk).
+     *
+     * @param targetHost the backend WebSocket host to match against configured profiles
+     * @return the matching {@link WsProxyProfileConfig}, or {@code null} if the host should connect directly
+     */
+    private WsProxyProfileConfig getProfileForHost(String targetHost) {
+        if (knownProxyConfigMap.containsKey(targetHost)) {
+            return knownProxyConfigMap.get(targetHost);
+        }
+        if (knownDirectHosts.contains(targetHost)) {
+            return null;
+        }
+        boolean hasCatchAllProfile = false;
+        for (String profileKey : proxyProfileMap.keySet()) {
+            if ("*".equals(profileKey)) {
+                hasCatchAllProfile = true;
+                continue;
+            }
+            if (targetHost.matches(profileKey)) {
+                return resolveWithBypass(targetHost, profileKey);
+            }
+        }
+        if (hasCatchAllProfile) {
+            return resolveWithBypass(targetHost, "*");
+        }
+        return null;
+    }
+
+    /**
+     * Checks the bypass list of the matched profile and caches the outcome.
+     * <p>
+     * If any bypass pattern matches {@code targetHost}, the host is added to
+     * {@link #knownDirectHosts} and {@code null} is returned for a direct connection.
+     * Otherwise the profile is cached in {@link #knownProxyConfigMap} and returned.
+     *
+     * @param targetHost the backend WebSocket host that matched the profile keyed by {@code profileKey}
+     * @param profileKey the key in {@link #proxyProfileMap} whose profile was matched ({@code "*"} for the default)
+     * @return the matched {@link WsProxyProfileConfig} to proxy through, or {@code null} to connect directly
+     */
+    private WsProxyProfileConfig resolveWithBypass(String targetHost, String profileKey) {
+        WsProxyProfileConfig matchedProfile = proxyProfileMap.get(profileKey);
+        for (String bypassPattern : matchedProfile.bypass) {
+            if (targetHost.matches(bypassPattern)) {
+                knownDirectHosts.add(targetHost);
+                if (log.isDebugEnabled()) {
+                    log.debug("ws proxy bypass matched: host=" + targetHost
+                            + " bypass=" + bypassPattern);
+                }
+                return null;
+            }
+        }
+        knownProxyConfigMap.put(targetHost, matchedProfile);
+        return matchedProfile;
+    }
+
+    /**
+     * Constructs a Netty {@link HttpProxyHandler} for the given proxy coordinates.
+     * Uses the authenticated constructor when credentials are provided, anonymous otherwise.
+     *
+     * @param host     proxy server hostname or IP
+     * @param port     proxy server port
+     * @param username proxy username, or {@code null} for anonymous access
+     * @param password proxy password; ignored when {@code username} is {@code null}
+     * @return a configured {@link HttpProxyHandler} ready to be added to the Netty pipeline
+     */
+    private HttpProxyHandler buildProxyHandler(String host, int port,
+                                               String username, String password) {
+        InetSocketAddress proxyAddress = new InetSocketAddress(host, port);
+        if (username != null && !username.isEmpty()) {
+            return new HttpProxyHandler(proxyAddress, username, password);
+        }
+        return new HttpProxyHandler(proxyAddress);
+    }
+}

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WsProxyProfileRegistry.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/main/java/org/wso2/carbon/websocket/transport/WsProxyProfileRegistry.java
@@ -86,7 +86,11 @@ class WsProxyProfileRegistry {
         }
     }
 
+    // LinkedHashMap preserves insertion order so specific targetHost patterns are evaluated
+    // before the catch-all "*" entry during host matching in getProfileForHost.
     private final Map<String, WsProxyProfileConfig> proxyProfileMap = new LinkedHashMap<>();
+    // Per-hostname result caches populated on first lookup. Bounded by the number of
+    // distinct backend hostnames (infrastructure-level), not by request volume.
     private final Set<String> knownDirectHosts =
             Collections.synchronizedSet(new HashSet<>());
     private final Map<String, WsProxyProfileConfig> knownProxyConfigMap =
@@ -171,6 +175,9 @@ class WsProxyProfileRegistry {
             OMElement passwordElement = profile.getFirstChildWithName(Q_PROXY_PASSWORD);
             if (usernameElement != null) {
                 proxyUsername = usernameElement.getText().trim();
+                // Store the raw password without resolving. The SecretResolver may not be
+                // fully initialized during transport startup; resolution happens at connection
+                // time in buildProxyHandler via MiscellaneousUtil.resolve.
                 proxyPassword = passwordElement != null
                         ? passwordElement.getText().trim()
                         : "";
@@ -181,6 +188,8 @@ class WsProxyProfileRegistry {
                 for (String rawEntry : bypassElement.getText().split(",")) {
                     String bypassPattern = rawEntry.trim();
                     try {
+                        // Validate the regex at parse time so configuration errors are caught
+                        // on startup rather than silently ignored at request time.
                         Pattern.compile(bypassPattern);
                         bypassSet.add(bypassPattern);
                     } catch (PatternSyntaxException e) {
@@ -194,6 +203,8 @@ class WsProxyProfileRegistry {
                     new WsProxyProfileConfig(proxyHost, proxyPort, proxyUsername, proxyPassword, bypassSet);
             for (String targetHostPattern : targetHostsElement.getText().split(",")) {
                 targetHostPattern = targetHostPattern.trim();
+                // "*" is a literal catch-all sentinel, not a regex. It is stored as-is and
+                // matched explicitly at the end of getProfileForHost after all specific patterns fail.
                 if (!"*".equals(targetHostPattern)) {
                     try {
                         Pattern.compile(targetHostPattern);
@@ -234,6 +245,7 @@ class WsProxyProfileRegistry {
      * @return the matching {@link WsProxyProfileConfig}, or {@code null} if the host should connect directly
      */
     private WsProxyProfileConfig getProfileForHost(String targetHost) {
+        // Fast path: return the cached result for hosts already seen.
         if (knownProxyConfigMap.containsKey(targetHost)) {
             return knownProxyConfigMap.get(targetHost);
         }
@@ -242,10 +254,13 @@ class WsProxyProfileRegistry {
         }
         boolean hasCatchAllProfile = false;
         for (String profileKey : proxyProfileMap.keySet()) {
+            // Defer the catch-all "*" so that specific patterns are evaluated first,
+            // ensuring a more-specific profile takes precedence over the default.
             if ("*".equals(profileKey)) {
                 hasCatchAllProfile = true;
                 continue;
             }
+            // String.matches() anchors both ends implicitly, matching the full hostname.
             if (targetHost.matches(profileKey)) {
                 return resolveWithBypass(targetHost, profileKey);
             }
@@ -279,6 +294,7 @@ class WsProxyProfileRegistry {
                 return null;
             }
         }
+        // Cache the proxied result so subsequent lookups for this host return immediately.
         knownProxyConfigMap.put(targetHost, matchedProfile);
         return matchedProfile;
     }
@@ -301,6 +317,7 @@ class WsProxyProfileRegistry {
                                                SecretResolver resolver) {
         InetSocketAddress proxyAddress = new InetSocketAddress(host, port);
         if (username != null && !username.isEmpty()) {
+            // Resolve at connection time; handles both plain-text and $secret{alias} tokens.
             String password = MiscellaneousUtil.resolve(rawPassword, resolver);
             return new HttpProxyHandler(proxyAddress, username, password);
         }

--- a/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/test/java/org/wso2/carbon/websocket/transport/WsProxyProfileRegistryTest.java
+++ b/components/carbon-transports/websocket/org.wso2.carbon.websocket.transport/src/test/java/org/wso2/carbon/websocket/transport/WsProxyProfileRegistryTest.java
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.websocket.transport;
+
+import io.netty.handler.proxy.HttpProxyHandler;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for {@link WsProxyProfileRegistry}.
+ *
+ * Each test builds an {@code OMElement} from an inline XML string using
+ * {@link AXIOMUtil#stringToOM(String)} and passes it directly to
+ * {@code WsProxyProfileRegistry}. No Netty infrastructure is started — the
+ * returned {@link HttpProxyHandler} instances are inspected through their
+ * public accessors only.
+ */
+public class WsProxyProfileRegistryTest {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static WsProxyProfileRegistry buildRegistry(String xml) throws Exception {
+        OMElement element = AXIOMUtil.stringToOM(xml);
+        return new WsProxyProfileRegistry(element, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static InetSocketAddress proxyAddress(HttpProxyHandler handler) {
+        return handler.proxyAddress();
+    }
+
+    // -----------------------------------------------------------------------
+    // Basic resolution
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testEmptyProfiles_returnsNull() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry("<ws.proxyProfiles/>");
+        assertNull(reg.resolveProxyHandler("any.host.com"));
+    }
+
+    @Test
+    public void testAnonymousProfile_matchingHost_proxied() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        HttpProxyHandler handler = reg.resolveProxyHandler("backend.example.com");
+        assertNotNull(handler);
+        assertEquals("proxy.corp.com", proxyAddress(handler).getHostString());
+        assertEquals(3128, proxyAddress(handler).getPort());
+        assertEquals("none", handler.authScheme());
+    }
+
+    @Test
+    public void testAuthenticatedProfile_credentialsForwarded() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "    <proxyUserName>proxyuser</proxyUserName>" +
+                "    <proxyPassword>proxypass</proxyPassword>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        HttpProxyHandler handler = reg.resolveProxyHandler("backend.example.com");
+        assertNotNull(handler);
+        assertEquals("proxy.corp.com", proxyAddress(handler).getHostString());
+        assertEquals(3128, proxyAddress(handler).getPort());
+        assertEquals("basic", handler.authScheme());
+        assertEquals("proxyuser", handler.username());
+        assertEquals("proxypass", handler.password());
+    }
+
+    @Test
+    public void testNonMatchingHost_directConnection() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("other.host.com"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Catch-all and profile precedence
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCatchAllProfile_matchesAnyHost() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>*</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNotNull(reg.resolveProxyHandler("any.random.host.com"));
+        assertNotNull(reg.resolveProxyHandler("another.host"));
+    }
+
+    @Test
+    public void testSpecificPatternBeats_catchAll() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>*</targetHosts>" +
+                "    <proxyHost>default.proxy</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "  <profile>" +
+                "    <targetHosts>special\\.host\\.com</targetHosts>" +
+                "    <proxyHost>special.proxy</proxyHost>" +
+                "    <proxyPort>8080</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        HttpProxyHandler specialHandler = reg.resolveProxyHandler("special.host.com");
+        assertNotNull(specialHandler);
+        assertEquals("special.proxy", proxyAddress(specialHandler).getHostString());
+        assertEquals(8080, proxyAddress(specialHandler).getPort());
+
+        HttpProxyHandler defaultHandler = reg.resolveProxyHandler("other.host.com");
+        assertNotNull(defaultHandler);
+        assertEquals("default.proxy", proxyAddress(defaultHandler).getHostString());
+    }
+
+    @Test
+    public void testDeclarationOrderDeterminesFirstMatch() throws Exception {
+        // Both patterns match internal.corp.com; first declared wins.
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>.*\\.corp\\.com</targetHosts>" +
+                "    <proxyHost>first.proxy</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "  <profile>" +
+                "    <targetHosts>internal\\.corp\\.com</targetHosts>" +
+                "    <proxyHost>second.proxy</proxyHost>" +
+                "    <proxyPort>8080</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        HttpProxyHandler handler = reg.resolveProxyHandler("internal.corp.com");
+        assertNotNull(handler);
+        assertEquals("first.proxy", proxyAddress(handler).getHostString());
+    }
+
+    @Test
+    public void testMultipleTargetHostsInSingleProfile_eachResolved() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>host1\\.com, host2\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNotNull(reg.resolveProxyHandler("host1.com"));
+        assertNotNull(reg.resolveProxyHandler("host2.com"));
+        assertNull(reg.resolveProxyHandler("host3.com"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Bypass
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testBypassHost_directConnection() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>.*\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "    <bypass>direct\\.example\\.com</bypass>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("direct.example.com"));
+        assertNotNull(reg.resolveProxyHandler("proxied.example.com"));
+    }
+
+    @Test
+    public void testBypassUnderCatchAll_directConnection() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>*</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "    <bypass>local\\.internal</bypass>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("local.internal"));
+        assertNotNull(reg.resolveProxyHandler("external.host.com"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Caching
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testProxiedHost_secondCallReturnsSameProxyConfig() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        HttpProxyHandler first = reg.resolveProxyHandler("backend.example.com");
+        HttpProxyHandler second = reg.resolveProxyHandler("backend.example.com");
+        assertNotNull(first);
+        assertNotNull(second);
+        assertEquals(proxyAddress(first).getHostString(), proxyAddress(second).getHostString());
+        assertEquals(proxyAddress(first).getPort(), proxyAddress(second).getPort());
+    }
+
+    @Test
+    public void testBypassedHost_secondCallAlsoReturnsDirect() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>*</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "    <bypass>direct\\.example\\.com</bypass>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("direct.example.com"));
+        assertNull(reg.resolveProxyHandler("direct.example.com")); // served from cache
+    }
+
+    // -----------------------------------------------------------------------
+    // Profile validation — missing / empty required fields
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testMissingTargetHosts_profileSkipped() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("any.host.com"));
+    }
+
+    @Test
+    public void testWhitespaceOnlyTargetHosts_profileSkipped() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>   </targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("any.host.com"));
+    }
+
+    @Test
+    public void testMissingProxyHost_profileSkipped() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("backend.example.com"));
+    }
+
+    @Test
+    public void testMissingProxyPort_profileSkipped() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("backend.example.com"));
+    }
+
+    @Test
+    public void testWhitespaceOnlyProxyHost_profileSkipped() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>   </proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("backend.example.com"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Profile validation — port range checks
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testNonNumericPort_profileSkipped() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>notaport</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("backend.example.com"));
+    }
+
+    @Test
+    public void testPortZero_profileSkipped() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>0</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("backend.example.com"));
+    }
+
+    @Test
+    public void testNegativePort_profileSkipped() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>-1</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("backend.example.com"));
+    }
+
+    @Test
+    public void testPortAboveRange_profileSkipped() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>65536</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("backend.example.com"));
+    }
+
+    @Test
+    public void testBoundaryPorts_valid() throws Exception {
+        WsProxyProfileRegistry reg1 = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>host1\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>1</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNotNull(reg1.resolveProxyHandler("host1.com"));
+        assertEquals(1, proxyAddress(reg1.resolveProxyHandler("host1.com")).getPort());
+
+        WsProxyProfileRegistry reg2 = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>host2\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>65535</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNotNull(reg2.resolveProxyHandler("host2.com"));
+        assertEquals(65535, proxyAddress(reg2.resolveProxyHandler("host2.com")).getPort());
+    }
+
+    // -----------------------------------------------------------------------
+    // Profile validation — regex errors
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testInvalidTargetHostRegex_validPatternsStillLoaded() throws Exception {
+        // The profile has two comma-separated targetHosts; only the invalid one is dropped.
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>valid\\.host\\.com, [invalid</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNotNull(reg.resolveProxyHandler("valid.host.com"));
+    }
+
+    @Test
+    public void testInvalidBypassRegex_validBypassStillApplied() throws Exception {
+        // One bypass entry is invalid; the remaining valid entry still bypasses.
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>.*\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "    <bypass>[invalid,direct\\.example\\.com</bypass>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        assertNull(reg.resolveProxyHandler("direct.example.com"));
+        assertNotNull(reg.resolveProxyHandler("other.example.com"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Duplicate target hosts
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testDuplicateTargetHost_firstProfileWins() throws Exception {
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>first.proxy</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "  </profile>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>second.proxy</proxyHost>" +
+                "    <proxyPort>9999</proxyPort>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        HttpProxyHandler handler = reg.resolveProxyHandler("backend.example.com");
+        assertNotNull(handler);
+        assertEquals("first.proxy", proxyAddress(handler).getHostString());
+    }
+
+    // -----------------------------------------------------------------------
+    // Credentials edge cases
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testUsernameWithoutPassword_emptyPasswordUsed() throws Exception {
+        // Code sets password to "" when <proxyUserName> is present but <proxyPassword> is absent.
+        WsProxyProfileRegistry reg = buildRegistry(
+                "<ws.proxyProfiles>" +
+                "  <profile>" +
+                "    <targetHosts>backend\\.example\\.com</targetHosts>" +
+                "    <proxyHost>proxy.corp.com</proxyHost>" +
+                "    <proxyPort>3128</proxyPort>" +
+                "    <proxyUserName>user</proxyUserName>" +
+                "  </profile>" +
+                "</ws.proxyProfiles>");
+        HttpProxyHandler handler = reg.resolveProxyHandler("backend.example.com");
+        assertNotNull(handler);
+        assertEquals("basic", handler.authScheme());
+        assertEquals("user", handler.username());
+        assertEquals("", handler.password());
+    }
+}


### PR DESCRIPTION
### Purpose
- Add proxy profile support to the WebSocket transport sender (WebsocketTransportSender) in carbon-mediation, backed by Netty's HttpProxyHandler.
- Public Issue: https://github.com/wso2/api-manager/issues/5115

### Configuration
```
[[transport.ws.proxy_profile]]
target_hosts  = ["external\\.backend\\.com"]
proxy_host    = "proxy.corp.com"
proxy_port    = 3128
proxy_username = "proxyuser"
proxy_password = "$secret{proxy_password}"
bypass_hosts   = ["internal\\.backend\\.com"]

[[transport.wss.proxy_profile]]
target_hosts = [".*"]
proxy_host   = "proxy.corp.com"
proxy_port   = 3128

# catch-all default profile
[[transport.ws.proxy_profile]]
target_hosts = ["*"]
proxy_host   = "proxy.corp.com"
proxy_port   = 3128
```

### Implementation changes:

- WsProxyProfileRegistry (new class) — parses the ws.proxyProfiles parameter at startup into an in-memory profile map; resolves the matching profile per connection using Java regex against the target host; caches results per host; handles per-profile bypass lists
- WebsocketConnectionFactory — new overloaded constructor (TransportOutDescription, SecretResolver) accepts an initialized SecretResolver for proxy password resolution; delegates proxy matching to WsProxyProfileRegistry; adds HttpProxyHandler to the Netty pipeline before SslHandler so the CONNECT tunnel is established before the TLS handshake for WSS
- WebsocketTransportSender — init() obtains the globally initialized SecretResolver from AxisConfiguration and forwards it to the factory constructor to enable SecureVault alias resolution for proxy passwords
- WebsocketConstants — PROXY_PROFILES constant for the ws.proxyProfiles parameter name
- axis2.xml.j2 — template blocks to render [[transport.ws.proxy_profile]] and [[transport.wss.proxy_profile]] TOML entries into the ws.proxyProfiles XML parameter for the ws and wss transport senders respectively

### Key behaviours:

- Target host patterns use Java regex; * (literal asterisk) is the catch-all default profile, evaluated last after all specific patterns
- Per-profile bypass_hosts patterns for hosts that must connect directly, bypassing the proxy
- Matching results are cached so regex evaluation runs only once per unique target host for the lifetime of the transport sender
- HttpProxyHandler is added before SslHandler in the Netty pipeline — ensures the CONNECT tunnel is established before the TLS handshake for WSS backends
- Proxy passwords support SecureVault aliases ($secret{alias}) via MiscellaneousUtil.resolve()
- Invalid port values or malformed regex patterns in a profile log a warning and skip that profile at startup; remaining profiles and the transport sender are unaffected