### PR TITLE
Bump synapse version to 4.1.0-wso2v59

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2545,7 +2545,7 @@
         <carbon.rule.version>4.5.10</carbon.rule.version>
         <carbon.rule.imp.pkg.version>[4.5.0, 4.6.0)</carbon.rule.imp.pkg.version>
         <!-- Synapse Version -->
-        <synapse.version>4.1.0-wso2v57</synapse.version>
+        <synapse.version>4.1.0-wso2v59</synapse.version>
         <carbon.identity.entitlement.proxy.version>5.4.9</carbon.identity.entitlement.proxy.version>
         <carbon.identity.entitlement.proxy.imp.pkg.version>[5.2.0, 6.0.0)
         </carbon.identity.entitlement.proxy.imp.pkg.version>


### PR DESCRIPTION
### Description
This pull request updates the Synapse dependency version in the project's Maven configuration to ensure compatibility with newer features or fixes.

Dependency update:

* Updated the `synapse.version` property in `pom.xml` from `4.1.0-wso2v47` to `4.1.0-wso2v59`, which may include important bug fixes or improvements.

### Related PRs
- https://github.com/wso2/wso2-synapse/pull/2575