### PR TITLE
Fix FileInputStream resource leaks in RabbitMQ and MQTT SSL configurations

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/mqtt/MqttConnectionFactory.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/mqtt/MqttConnectionFactory.java
@@ -356,14 +356,18 @@ public class MqttConnectionFactory {
 
         char[] keyPassphrase = keyStorePassword.toCharArray();
         KeyStore keyStore = KeyStore.getInstance(keyStoreType);
-        keyStore.load(new FileInputStream(keyStoreLocation), keyPassphrase);
+        try (FileInputStream keyStoreStream = new FileInputStream(keyStoreLocation)) {
+            keyStore.load(keyStoreStream, keyPassphrase);
+        }
 
         KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         keyManagerFactory.init(keyStore, keyPassphrase);
 
         char[] trustPassphrase = trustStorePassword.toCharArray();
         KeyStore trustStore = KeyStore.getInstance(trustStoreType);
-        trustStore.load(new FileInputStream(trustStoreLocation), trustPassphrase);
+        try (FileInputStream trustStoreStream = new FileInputStream(trustStoreLocation)) {
+            trustStore.load(trustStoreStream, trustPassphrase);
+        }
 
         TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         trustManagerFactory.init(trustStore);

--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQConnectionFactory.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQConnectionFactory.java
@@ -178,14 +178,18 @@ public class RabbitMQConnectionFactory {
                 } else {
                     char[] keyPassphrase = keyStorePassword.toCharArray();
                     KeyStore ks = KeyStore.getInstance(keyStoreType);
-                    ks.load(new FileInputStream(keyStoreLocation), keyPassphrase);
+                    try (FileInputStream keyStoreStream = new FileInputStream(keyStoreLocation)) {
+                        ks.load(keyStoreStream, keyPassphrase);
+                    }
 
                     KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
                     kmf.init(ks, keyPassphrase);
 
                     char[] trustPassphrase = trustStorePassword.toCharArray();
                     KeyStore tks = KeyStore.getInstance(trustStoreType);
-                    tks.load(new FileInputStream(trustStoreLocation), trustPassphrase);
+                    try (FileInputStream trustStoreStream = new FileInputStream(trustStoreLocation)) {
+                        tks.load(trustStoreStream, trustPassphrase);
+                    }
 
                     TrustManagerFactory tmf = TrustManagerFactory
                             .getInstance(KeyManagerFactory.getDefaultAlgorithm());


### PR DESCRIPTION
## Purpose
Fix file descriptor/resource leaks caused by unclosed `FileInputStream` objects inside RabbitMQ and MQTT inbound endpoint configurations.

## Goals
Ensure all file input streams opened for loading SSL KeyStore and TrustStore files are properly closed after usage.

## Approach
Refactored the SSL KeyStore and TrustStore loading logic in `RabbitMQConnectionFactory.java` and `MqttConnectionFactory.java` to use the standard try-with-resources statement. This is consistent with the resource handling patterns already used in other parts of this module (e.g., `SSLHandlerFactory.java`).

## User stories
N/A

## Release note
Fixed a file descriptor resource leak in RabbitMQ and MQTT inbound endpoint SSL configurations.

## Documentation
N/A (No documentation impact as this is an internal resource management bug fix).

## Automation tests
- Unit tests run locally. No changes in public method signatures or behaviors.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
