### PR TITLE
Fix potential NullPointerException in JMSReplySender.sendBack()

### DIFF
--- a/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSReplySender.java
+++ b/components/inbound-endpoints/org.wso2.carbon.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSReplySender.java
@@ -90,15 +90,19 @@ public class JMSReplySender implements InboundResponseSender {
             log.error("Error sending JMS response", e);
         } finally {
             try {
-                producer.close();
+                if (producer != null) {
+                    producer.close();
+                }
             } catch (Exception e) {
                 log.debug("ERROR: Unable to close the producer");
             }
             try {
-                session.close();
+                if (session != null) {
+                    session.close();
+                }
             } catch (Exception e) {
                 log.debug("ERROR: Unable to close the session");
-            }            
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
Fix a potential `NullPointerException` in `JMSReplySender.sendBack()` when JMS connection or session creation fails before `producer` and `session` are initialized.

## Goals
Ensure the `finally` block in `sendBack()` does not throw a `NullPointerException` that masks the original JMS error.

## Approach
Added null checks for `producer` and `session` before calling `.close()` in the `finally` block of `JMSReplySender.sendBack()`.

Both `producer` and `session` are initialized to `null` at the start of the method. If an exception is thrown during `getConnection()`, `getSession()`, or `createProducer()`, these variables remain `null`. The `finally` block then calls `.close()` on a `null` reference, causing a `NullPointerException` that hides the original error.

## Release note
Fixed a potential NullPointerException in JMS inbound endpoint reply sender when connection setup fails.

## Documentation
N/A — No public API or configuration change.

## Automation tests
 - Unit tests
   No new tests required. Existing `JMSReplySenderTest` tests continue to pass. No change in method signatures or behavior.
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
